### PR TITLE
Slow odgi: `flatten`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test/basic/*.out
 
 test/subset-paths/*.out
 
+test/temp.*
 test/depth/*.out
 test/depth/basic/*.out
 test/depth/subset-paths/*.out

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-slow-flip: og
 
 test-slow-flatten: og
 	-turnt --save --env flatten_oracle test/*.og
-	turnt -v --diff --env flatten_test test/*.gfa
+	turnt --diff --env flatten_test test/*.gfa
 
 clean:
 	rm -rf $(TEST_FILES:%=%.*)

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ test-slow-flatten: og
 	-turnt --save --env flatten_oracle test/*.og
 	turnt --env flatten_test test/*.gfa
 
+test-slow-inject: og
+	-turnt -v --env inject_setup test/*.gfa
+	# -turnt --save --env inject_oracle test/*.og
+	# turnt --env inject_test test/*.gfa
+
+
 clean:
 	rm -rf $(TEST_FILES:%=%.*)
 	rm -rf $(TEST_FILES:%=test/%.*)

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ test-slow-flip: og
 	-turnt --save --env flip_oracle test/*.og
 	turnt --diff --env flip_test test/*.gfa
 
+test-slow-flatten: og
+	-turnt --save --env flatten_oracle test/*.og
+# turnt --diff --env flatten_test test/*.gfa
+
 clean:
 	rm -rf $(TEST_FILES:%=%.*)
 	rm -rf $(TEST_FILES:%=test/%.*)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-slow-flip: og
 
 test-slow-flatten: og
 	-turnt --save --env flatten_oracle test/*.og
-# turnt --diff --env flatten_test test/*.gfa
+	turnt -v --diff --env flatten_test test/*.gfa
 
 clean:
 	rm -rf $(TEST_FILES:%=%.*)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-depth: og
 	-turnt --save --env baseline $(DEPTH_OG_FILES)
 	turnt $(DEPTH_OG_FILES)
 
-test-slow-odgi: og test-slow-chop test-slow-crush test-slow-degree test-slow-depth test-slow-emit
+test-slow-odgi: og test-slow-chop test-slow-crush test-slow-degree test-slow-depth test-slow-emit test-slow-flatten
 # to add: test-slow-flip
 
 test-slow-chop: og
@@ -48,7 +48,7 @@ test-slow-flip: og
 
 test-slow-flatten: og
 	-turnt --save --env flatten_oracle test/*.og
-	turnt --diff --env flatten_test test/*.gfa
+	turnt --env flatten_test test/*.gfa
 
 clean:
 	rm -rf $(TEST_FILES:%=%.*)

--- a/slow_odgi/flatten.py
+++ b/slow_odgi/flatten.py
@@ -29,7 +29,7 @@ def insert_newlines(string, every=80):
     return '\n'.join(string[i:i+every] for i in range(0, len(string), every))
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1][-4:] == ".gfa":
+    if len(sys.argv) > 1 and sys.argv[1].endswith(".gfa"):
         infile = open(sys.argv[1], 'r')
         graph = mygfa.Graph.parse(infile)
         odginame = sys.argv[1][:-4] + ".og"

--- a/slow_odgi/flatten.py
+++ b/slow_odgi/flatten.py
@@ -16,7 +16,7 @@ def fasta(graph):
         length = len(segment.seq)
         legend[segment.name] = (ptr, ptr + length)
         ptr += length
-    return(ans, legend)
+    return ans, legend
 
 def print_bed(graph, legend):
     print("\t".join(["#name", "start", "end", "path.name", "strand", "step.rank"]))

--- a/slow_odgi/flatten.py
+++ b/slow_odgi/flatten.py
@@ -1,0 +1,17 @@
+import sys
+import mygfa
+
+def fasta(graph):
+    fasta = ""
+    for segment in graph.segments.values():
+        fasta += segment.seq
+    print(fasta)
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1][-4:] == ".gfa":
+        infile = open(sys.argv[1], 'r')
+        graph = mygfa.Graph.parse(infile)
+        print(f">{sys.argv[1][5:-4]}.og")
+        # TODO: this is a bit hardocded for files living in test/file.gfa
+        # Would be nice to neaten this up and make it less brittle.
+        fasta(graph)

--- a/slow_odgi/flatten.py
+++ b/slow_odgi/flatten.py
@@ -2,24 +2,31 @@ import sys
 import mygfa
 
 def fasta(graph):
-    fasta = ""
+    """ The main deliverable is the FASTA:
+    Simply, for all segments, the seqs glued together. Traverse segments in order.
+    However, it pays to do some bookkeeping now.
+    legend[segname] stores the [start, end) of the spot in the FASTA that
+    segname's seq is featured.
+    """
+    ans = ""
+    legend = {}
+    ptr = 0
     for segment in graph.segments.values():
-        fasta += segment.seq
-    return(fasta)
+        ans += segment.seq
+        length = len(segment.seq)
+        legend[segment.name] = (ptr, ptr + length)
+        ptr += length
+    return(ans, legend)
 
-def bed(graph):
+def print_bed(graph, legend):
     print("\t".join(["#name", "start", "end", "path.name", "strand", "step.rank"]))
     for path in graph.paths.values():
-        i = 0
-        f = fasta(graph)
-        ptr = 0
-        for (segname, orientation) in path.segments:
-            seq = graph.segments[segname].seq
-            start = f[ptr:].find(seq)
-            end = start + len(seq)
-            print ("\t".join([odginame, str(start+ptr), str(end+ptr), path.name, "+", str(i)]))
-            i += 1
-            ptr += end
+        for i, (segname, o) in enumerate(path.segments):
+            start, end = legend[segname]
+            print ("\t".join([odginame, str(start), str(end), path.name, "+" if o else "-", str(i)]))
+
+def insert_newlines(string, every=80):
+    return '\n'.join(string[i:i+every] for i in range(0, len(string), every))
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1][-4:] == ".gfa":
@@ -29,5 +36,7 @@ if __name__ == "__main__":
         print(f">{odginame}")
         # TODO: this is a bit hardocded for files living in test/file.gfa
         # Would be nice to neaten this up and make it less brittle.
-        print(fasta(graph))
-        bed(graph)
+
+        fasta, legend = fasta(graph)
+        print(insert_newlines(fasta))
+        print_bed(graph, legend)

--- a/slow_odgi/flatten.py
+++ b/slow_odgi/flatten.py
@@ -5,13 +5,29 @@ def fasta(graph):
     fasta = ""
     for segment in graph.segments.values():
         fasta += segment.seq
-    print(fasta)
+    return(fasta)
+
+def bed(graph):
+    print("\t".join(["#name", "start", "end", "path.name", "strand", "step.rank"]))
+    for path in graph.paths.values():
+        i = 0
+        f = fasta(graph)
+        ptr = 0
+        for (segname, orientation) in path.segments:
+            seq = graph.segments[segname].seq
+            start = f[ptr:].find(seq)
+            end = start + len(seq)
+            print ("\t".join([odginame, str(start+ptr), str(end+ptr), path.name, "+", str(i)]))
+            i += 1
+            ptr += end
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1][-4:] == ".gfa":
         infile = open(sys.argv[1], 'r')
         graph = mygfa.Graph.parse(infile)
-        print(f">{sys.argv[1][5:-4]}.og")
+        odginame = sys.argv[1][:-4] + ".og"
+        print(f">{odginame}")
         # TODO: this is a bit hardocded for files living in test/file.gfa
         # Would be nice to neaten this up and make it less brittle.
-        fasta(graph)
+        print(fasta(graph))
+        bed(graph)

--- a/slow_odgi/inject_setup.py
+++ b/slow_odgi/inject_setup.py
@@ -1,0 +1,20 @@
+import sys
+import mygfa
+import random
+
+def print_bed(graph, outfile):
+  for path in graph.paths.values():
+    length = mygfa.Path.seqlen(path)
+    for i in range(random.randint(0,5)):
+      r1 = random.randint(0, length)
+      r2 = random.randint(0, length)
+      lo = min(r1, r2)
+      hi = max(r1, r2)
+      print ("\t".join([path.name, str(lo), str(hi), path.name+"_"+str(i)]), \
+        file=outfile)
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+      graph = mygfa.Graph.parse(open("../test/"+sys.argv[1],'r'))
+      outfile = open("../test/"+sys.argv[1][:-4]+".bed", 'w')
+      print_bed(graph, outfile)

--- a/slow_odgi/mygfa.py
+++ b/slow_odgi/mygfa.py
@@ -120,6 +120,12 @@ class Path:
             overlaps_lst,
         )
 
+    def seqlen(self) -> int:
+        length = 0
+        for (seg,_) in self.segments:
+            length += len(seg)
+        return length
+
     def __str__(self):
         return '\t'.join([
             "P",

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -53,3 +53,7 @@ command = "odgi flatten -i {filename} -f temp.fasta -b temp.bed; cat temp.fasta;
 [envs.flatten_test]
 binary = true
 command = "python3 ../slow_odgi/flatten.py {filename}"
+
+[envs.inject_setup]
+binary = true
+command = "python3 ../slow_odgi/inject_setup.py {filename}"

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -45,3 +45,11 @@ command = "odgi flip -i {filename} --out=temp.og; odgi view -g -i temp.og"
 [envs.flip_test]
 binary = true
 command = "python3 ../slow_odgi/flip.py < {filename}"
+
+[envs.flatten_oracle]
+binary = true
+command = "odgi flatten -i {filename} -f temp.fasta -b temp.bed; cat temp.fasta; cat temp.bed"
+
+[envs.flatten_test]
+binary = true
+command = "python3 ../slow_odgi/flatten.py < {filename}"

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -52,4 +52,4 @@ command = "odgi flatten -i {filename} -f temp.fasta -b temp.bed; cat temp.fasta;
 
 [envs.flatten_test]
 binary = true
-command = "python3 ../slow_odgi/flatten.py < {filename}"
+command = "python3 ../slow_odgi/flatten.py {filename}"


### PR DESCRIPTION
This PR adds support for `odgi flatten`. IMO it only really makes sense to run this command with _both_ its flags supplied, though it is happy to run with either. Running
`odgi flatten -i graph.og -f graph.fasta -b graph.bed`
produces:
- in graph.fasta, a simple concatenation of the sequences of the graph's segments. Our visitation (and odgi's) is in the same order that the segments appeared in the original graph.gfa
- in graph.bed, a "key" by which to retrieve path information from the .fasta string. 

It may be clear to see why these really go hand in hand: the former has no path information, and the latter has no sequence information.

It's a simple enough algorithm, and all tests pass with the current suite of graphs.