### PR TITLE
Slow odgi: `overlap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 test/*.og
 test/*.gfa
 test/*.out
+test/*.paths
 
 test/basic/*.og
 test/basic/*.out

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test-slow-flip: og
 	turnt --diff --env flip_test test/*.gfa
 
 test-slow-overlap: og
-	-turnt --save --env overlap_setup test/*.gfa
+	-turnt --env overlap_setup test/*.gfa
 	-turnt --save --env overlap_oracle test/*.og
 	turnt --diff --env overlap_test test/*.gfa
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-slow-inject: og
 test-slow-overlap: og
 	-turnt --save --env overlap_setup test/*.gfa
 	-turnt --save --env overlap_oracle test/*.og
-	turnt --diff --env overlap_test test/*.gfa
+	turnt -v --diff --env overlap_test test/*.gfa
 
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ test-slow-flip: og
 	-turnt --save --env flip_oracle test/*.og
 	turnt --diff --env flip_test test/*.gfa
 
+test-slow-overlap: og
+	-turnt --env overlap_setup test/*.gfa
+	-turnt -v --save --env overlap_oracle test/*.og
+	# turnt --diff --env overlap_test test/*.gfa
+
+
 clean:
 	rm -rf $(TEST_FILES:%=%.*)
 	rm -rf $(TEST_FILES:%=test/%.*)
@@ -53,6 +59,7 @@ clean:
 	rm -rf test/basic/*.og
 
 	rm -rf test/temp.*
+	rm -rf test/*.paths
 	rm -rf test/depth/*.out
 	rm -rf test/depth/basic/*.out
 	rm -rf test/depth/subset-paths/*.out

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-slow-inject: og
 
 
 test-slow-overlap: og
-	-turnt --env overlap_setup test/*.gfa
+	-turnt --save --env overlap_setup test/*.gfa
 	-turnt --save --env overlap_oracle test/*.og
 	turnt --diff --env overlap_test test/*.gfa
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-depth: og
 	-turnt --save --env baseline $(DEPTH_OG_FILES)
 	turnt $(DEPTH_OG_FILES)
 
-test-slow-odgi: og test-slow-chop test-slow-crush test-slow-degree test-slow-depth test-slow-emit test-slow-overlap test-slow-flatten
+test-slow-odgi: og test-slow-chop test-slow-crush test-slow-degree test-slow-depth test-slow-emit test-slow-flatten test-slow-overlap
 
 test-slow-chop: og
 	-turnt --save --env chop_oracle test/*.og
@@ -53,7 +53,6 @@ test-slow-inject: og
 	-turnt -v --env inject_setup test/*.gfa
 	# -turnt --save --env inject_oracle test/*.og
 	# turnt --env inject_test test/*.gfa
-
 
 test-slow-overlap: og
 	-turnt --save --env overlap_setup test/*.gfa

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-depth: og
 	-turnt --save --env baseline $(DEPTH_OG_FILES)
 	turnt $(DEPTH_OG_FILES)
 
-test-slow-odgi: og test-slow-chop test-slow-crush test-slow-degree test-slow-depth test-slow-emit
+test-slow-odgi: og test-slow-chop test-slow-crush test-slow-degree test-slow-depth test-slow-emit test-slow-overlap
 # to add: test-slow-flip
 
 test-slow-chop: og
@@ -47,9 +47,9 @@ test-slow-flip: og
 	turnt --diff --env flip_test test/*.gfa
 
 test-slow-overlap: og
-	-turnt --env overlap_setup test/*.gfa
-	-turnt -v --save --env overlap_oracle test/*.og
-	# turnt --diff --env overlap_test test/*.gfa
+	-turnt --save --env overlap_setup test/*.gfa
+	-turnt --save --env overlap_oracle test/*.og
+	turnt --diff --env overlap_test test/*.gfa
 
 
 clean:

--- a/slow_odgi/list_paths.py
+++ b/slow_odgi/list_paths.py
@@ -1,0 +1,12 @@
+import sys
+import mygfa
+
+def print_paths(graph):
+  for name in graph.paths.keys():
+    print (name)
+
+if __name__ == "__main__":
+    name = sys.stdin
+    graph = mygfa.Graph.parse(sys.stdin)
+    print_paths(graph)
+

--- a/slow_odgi/overlap.py
+++ b/slow_odgi/overlap.py
@@ -1,28 +1,19 @@
 import sys
 import mygfa
 
-
-
 def getpaths(infile):
-    paths = []
-    for line in mygfa.nonblanks(infile):
-        paths.append(line)
-    return paths
+    return list(mygfa.nonblanks(infile))
 
 def touches(path1, path2, graph):
     if path1 == path2:
         return False
-    for seg_o1 in graph.paths[path1].segments: # (segment, orientation) tuple
-        for seg_o2 in graph.paths[path2].segments:
-            if seg_o1 == seg_o2:
-                return True
-    return False
+    segs1 = set(graph.paths[path1].segments)
+    segs2 = set(graph.paths[path2].segments)
+    return bool(segs1 & segs2)
 
 def pathseqlen(path, graph):
-    length = 0
-    for seg, _ in graph.paths[path].segments:
-        length += len (graph.segments[seg].seq)
-    return length
+    return sum(len(graph.segments[seg].seq) for (seg, _) in \
+        graph.paths[path].segments)
 
 def print_overlaps(graph, inputpaths):
     print("\t".join(["#path", "start", "end", "path.touched"]))
@@ -30,7 +21,8 @@ def print_overlaps(graph, inputpaths):
         assert (ip in graph.paths)
         for pathname in graph.paths.keys():
             if touches(ip, pathname, graph):
-                print("\t".join([ip, "0", str(pathseqlen(ip, graph)), pathname]))
+                print("\t".join([ip, "0", str(pathseqlen(ip, graph)), \
+                    pathname]))
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1][-6:] == ".paths":

--- a/slow_odgi/overlap.py
+++ b/slow_odgi/overlap.py
@@ -25,7 +25,7 @@ def pathseqlen(path, graph):
     return length
 
 def print_overlaps(graph, inputpaths):
-    print("\t".join(["#path","path_touched"]))
+    print("\t".join(["#path", "start", "end", "path.touched"]))
     for ip in inputpaths:
         assert (ip in graph.paths)
         for pathname in graph.paths.keys():

--- a/slow_odgi/overlap.py
+++ b/slow_odgi/overlap.py
@@ -1,0 +1,39 @@
+import sys
+import mygfa
+
+
+
+def getpaths(infile):
+    paths = []
+    for line in mygfa.nonblanks(infile):
+        paths.append(line)
+    return paths
+
+def touches(path1, path2, graph):
+    if path1 == path2:
+        return False
+    for seg_o1 in graph.paths[path1].segments: # (segment, orientation) tuple
+        for seg_o2 in graph.paths[path2].segments:
+            if seg_o1 == seg_o2:
+                return True
+    return False
+
+def pathseqlen(path, graph):
+    length = 0
+    for seg, _ in graph.paths[path].segments:
+        length += len (graph.segments[seg].seq)
+    return length
+
+def print_overlaps(graph, inputpaths):
+    print("\t".join(["#path","path_touched"]))
+    for ip in inputpaths:
+        assert (ip in graph.paths)
+        for pathname in graph.paths.keys():
+            if touches(ip, pathname, graph):
+                print("\t".join([ip, "0", str(pathseqlen(ip, graph)), pathname]))
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1][-6:] == ".paths":
+        inputpaths = getpaths(open(sys.argv[1], 'r'))
+        graph = mygfa.Graph.parse(sys.stdin)
+        print_overlaps(graph, inputpaths)

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -45,3 +45,15 @@ command = "odgi flip -i {filename} --out=temp.og; odgi view -g -i temp.og"
 [envs.flip_test]
 binary = true
 command = "python3 ../slow_odgi/flip.py < {filename}"
+
+[envs.overlap_setup]
+binary = true
+command = "fn={filename}; pathsname=$(echo $fn | cut -f 1 -d '.').paths; python3 ../slow_odgi/list_paths.py < {filename} > $pathsname"
+
+[envs.overlap_oracle]
+binary = true
+command = "fn={filename}; pathsname=$(echo $fn | cut -f 1 -d '.').paths; odgi overlap -i {filename} -R $pathsname"
+
+[envs.overlap_test]
+binary = true
+command = "fn={filename}; pathsname=$(echo $fn | cut -f 1 -d '.').paths; python3 ../slow_odgi/overlap.py $pathsname < {filename}"

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -53,11 +53,11 @@ output.paths = "-"
 
 [envs.overlap_oracle]
 binary = true
-command = "fn={filename}; pathsname=$(echo $fn | cut -f 1 -d '.').paths; odgi overlap -i {filename} -R $pathsname"
+command = "odgi overlap -i {filename} -R {base}.paths"
 
 [envs.overlap_test]
 binary = true
-command = "fn={filename}; pathsname=$(echo $fn | cut -f 1 -d '.').paths; python3 ../slow_odgi/overlap.py $pathsname < {filename}"
+command = "python3 ../slow_odgi/overlap.py {base}.paths < {filename}"
 
 [envs.flatten_oracle]
 binary = true

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -48,7 +48,8 @@ command = "python3 ../slow_odgi/flip.py < {filename}"
 
 [envs.overlap_setup]
 binary = true
-command = "fn={filename}; pathsname=$(echo $fn | cut -f 1 -d '.').paths; python3 ../slow_odgi/list_paths.py < {filename} > $pathsname"
+command = "python3 ../slow_odgi/list_paths.py < {filename}"
+output.paths = "-"
 
 [envs.overlap_oracle]
 binary = true


### PR DESCRIPTION
This PR adds support for `odgi overlap`.

The command is straightforward and we diff out cleanly agains the present suite of test graphs. 

One weird thing: the ODGI output is
| #path  | | | path_touched |
| -------------------- | ---------| ----------| ----------------------- |
| name of query path | number1 | number2 |  name of touched path  |
| name of query path | number1 | number2 |  name of touched path  |

but the middle two columns are not labeled, and exploring the [relevant source code](https://github.com/pangenome/odgi/blob/bfae0b3c70a0f044d7ce8510b7a45f59d5138626/src/subcommand/overlap_main.cpp#L167-L168) does not tell me very much. Hilariously, I found, just "by eye", that the second column is always 0 and the third is always the length of the sequence charted by the query path.

I think there is a bug in the odgi code. They want something else, and are trying to compute it, but are inadvertently computing the length of the query path instead. I'll explore further and report back here.

There are some computations in this overlap.py that I'd like to lift into preprocess.py. Also, there is a somewhat ugly bit of .sh hacking in my .turnt file. Thoughts about cleaning that up appreciated!