### PR TITLE
Simplify sorted output of links

### DIFF
--- a/slow_odgi/mygfa.py
+++ b/slow_odgi/mygfa.py
@@ -61,7 +61,7 @@ class Alignment:
         )
 
 
-@dataclass
+@dataclass(eq=True, order=True)
 class Link:
     """A GFA link is an edge connecting two sequences."""
     from_: str  # The name of a segment.
@@ -80,9 +80,6 @@ class Link:
             parse_orient(to_orient),
             Alignment.parse(overlap),
         )
-
-    def cmp(link):
-        return (link.from_, link.to, link.from_orient, link.to_orient)
 
     def __str__(self):
         return '\t'.join([
@@ -175,7 +172,7 @@ class Graph:
         for path in self.paths.values():
             print(str(path), file=outfile)
         if showlinks:
-            for link in sorted(self.links, key=Link.cmp):
+            for link in sorted(self.links):
                 print(str(link), file=outfile)
 
 


### PR DESCRIPTION
Just a little thing: as mentioned in https://github.com/cucapra/pollen/pull/27/files#r1158837575, we can avoid defining our own ordering method and just use the one [provided by `dataclass`](https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass).

The sort order is very slightly different now, since it's the order given by the fields in the `dataclass` definition: that's "from, from-orient, to, to-orient" as opposed to "from, to, from-orient, to-orient." I didn't test this exhaustively, but it matched on a couple of small inputs. It would be great to make sure this doesn't cause mismatches with odgi that I missed before we merge. If it does, we can reorder the fields in the `Link` definition to match, but we will also need to change other code that is currently relying on the order (namely, the code that constructs `Link` objects).