### PR TITLE
Use @dataclass magic to hash SegO

### DIFF
--- a/slow_odgi/mygfa.py
+++ b/slow_odgi/mygfa.py
@@ -91,9 +91,10 @@ class Link:
             str(self.overlap),
         ])
 
-@dataclass
+
+@dataclass(eq=True, frozen=True)
 class SegO:
-    """A segment's name and its orientation"""
+    """A specific orientation for a segment, referenced by name."""
     name: str
     orientation: bool
 
@@ -102,16 +103,10 @@ class SegO:
         return SegO(s[:-1], parse_orient(s[-1]))
 
     def rev(self) -> "SegO":
-        return SegO (self.name, not self.orientation)
+        return SegO(self.name, not self.orientation)
 
     def __str__(self):
         return self.name + ("+" if self.orientation else "-")
-
-    def __key(self):
-        return (self.name, self.orientation)
-
-    def __hash__(self):
-        return hash(self.__key())
 
 
 @dataclass


### PR DESCRIPTION
This is a minuscule follow-up to #29, which introduced the `mygfa.SegO` class. As in #35, I noticed a place where we were doing things manually that [the `dataclasses` library](https://docs.python.org/3/library/dataclasses.html) can do for us. Namely, based on a couple of rules, it can generate `__hash__` for us; all you need to do is make the type immutable (`frozen`) and equatable (`eq`). Both make sense for this type, so I've done that.

I also made the docstring slightly more accurate: it's not that the segment *has an orientation*; it's that we're referring to one of its two orientations.

It also occurs to me that we could use `SegO` to define `Link`:
https://github.com/cucapra/pollen/blob/fce54a3bfa62364612190594ad732e18ef4eb5ea/slow_odgi/mygfa.py#L67-L70

Instead of having two fields (segment orientation) for both "from" and "to", we could just have a "from" `SegO` and a "to" `SegO`.