### PR TITLE
A little file manipulation to avoid clobbering gfa files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,10 @@ test-slow-paths: og
 
 test-slow-validate: fetch
 	-turnt --save --env validate_setup test/*.gfa
-	-turnt --save --env validate_oracle test/*.gfa
-	turnt -v --env validate_test test/*.gfa
-	rm test/*.gfa; rm test/*.og
+	for fn in `ls test/*.temp`; do `mv $$fn $${fn%.*}_temp.gfa`; done
+	-turnt --save --env validate_oracle test/*_temp.gfa
+	turnt -v --env validate_test test/*_temp.gfa
+	rm test/*_temp.gfa
 
 clean:
 	rm -rf $(TEST_FILES:%=%.*)
@@ -79,7 +80,7 @@ clean:
 
 	rm -rf test/basic/*.og
 
-	rm -rf test/temp.*
+	rm -rf test/*temp.*
 	rm -rf test/*.paths
 	rm -rf test/depth/*.out
 	rm -rf test/depth/basic/*.out

--- a/slow_odgi/inject_setup.py
+++ b/slow_odgi/inject_setup.py
@@ -3,6 +3,7 @@ import mygfa
 import random
 
 def print_bed(graph, outfile):
+  random.seed(4)
   for path in graph.paths.values():
     length = mygfa.Path.seqlen(path)
     for i in range(random.randint(0,5)):

--- a/slow_odgi/perturb.py
+++ b/slow_odgi/perturb.py
@@ -3,6 +3,7 @@ import mygfa
 import random
 
 def drop_some_lines(graph):
+    random.seed(4)
     links = list(sorted(graph.links))
     links[:] = random.sample(links, int(0.1 * len(links)))
     return mygfa.Graph(graph.headers, graph.segments, links, graph.paths)

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -90,7 +90,7 @@ command = "python3 ../slow_odgi/paths.py < {filename}"
 [envs.validate_setup]
 binary = true
 command = "python3 ../slow_odgi/perturb.py < {filename}"
-output.gfa = "-"
+output.temp = "-"
 
 [envs.validate_oracle]
 binary = true


### PR DESCRIPTION
This PR changes the workflow of `slow odgi validate` a little, as suggested in https://github.com/cucapra/pollen/pull/29#discussion_r1160304303, to avoid the clobbering of hard-won GFA files.

```
test-slow-validate: fetch
	-turnt --save --env validate_setup test/*.gfa
	for fn in `ls test/*.temp`; do `mv $$fn $${fn%.*}_temp.gfa`; done
	-turnt --save --env validate_oracle test/*_temp.gfa
	turnt -v --env validate_test test/*_temp.gfa
	rm test/*_temp.gfa
```

Here, `-turnt --save --env validate_setup test/*.gfa` takes graph.gfa, runs a script that kills off some links, and saves the output as graph.temp while leaving graph.gfa around for the future. The rest is straightforward.