### PR TITLE
use separate turnt outputs to reduce clobbering. closes #34

### DIFF
--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -1,58 +1,72 @@
 [envs.chop_oracle]
 binary = true
 command = "odgi chop -i {filename} -c 3 -o - | odgi view -g -i - | python3 ../slow_odgi/mygfa.py --nl"
+output.chop = "-"
 
 [envs.chop_test]
 binary = true
 command = "python3 ../slow_odgi/chop.py < {filename}"
+output.chop = "-"
 
 [envs.crush_oracle]
 binary = true
 command = "odgi crush -i {filename} -o - | odgi view -g -i - | python3 ../slow_odgi/mygfa.py"
+output.crush = "-"
 
 [envs.crush_test]
 binary = true
 command = "python3 ../slow_odgi/crush_n.py < {filename}"
+output.crush = "-"
 
 [envs.degree_oracle]
 binary = true
 command = "odgi degree -d --input={filename}"
+output.degree = "-"
 
 [envs.degree_test]
 binary = true
 command = "python3 ../slow_odgi/node_degree.py < {filename}"
+output.degree = "-"
 
 [envs.depth_oracle]
 binary = true
 command = "odgi depth -d --input={filename}"
+output.depth = "-"
 
 [envs.depth_test]
 binary = true
 command = "python3 ../slow_odgi/node_depth.py < {filename}"
+output.depth = "-"
 
 [envs.emit_oracle]
 binary = true
 command = "odgi view -g -i {filename} | python3 ../slow_odgi/mygfa.py"
+output.emit = "-"
 
 [envs.emit_test]
 binary = true
 command = "python3 ../slow_odgi/mygfa.py < {filename}"
+output.emit = "-"
 
 [envs.flatten_oracle]
 binary = true
 command = "odgi flatten -i {filename} -f temp.fasta -b temp.bed; cat temp.fasta; cat temp.bed"
+output.flatten = "-"
 
 [envs.flatten_test]
 binary = true
 command = "python3 ../slow_odgi/flatten.py {filename}"
+output.flatten = "-"
 
 [envs.flip_oracle]
 binary = true
 command = "odgi flip -i {filename} -o - | odgi view -g -i - | python3 ../slow_odgi/mygfa.py"
+output.flip = "-"
 
 [envs.flip_test]
 binary = true
 command = "python3 ../slow_odgi/flip.py < {filename}"
+output.flip = "-"
 
 [envs.inject_setup]
 binary = true
@@ -61,10 +75,12 @@ command = "python3 ../slow_odgi/inject_setup.py {filename}"
 [envs.matrix_oracle]
 binary = true
 command = "odgi matrix -i {filename} | sort"
+output.matrix = "-"
 
 [envs.matrix_test]
 binary = true
 command = "python3 ../slow_odgi/matrix.py < {filename} | sort"
+output.matrix = "-"
 
 [envs.overlap_setup]
 binary = true
@@ -74,18 +90,22 @@ output.paths = "-"
 [envs.overlap_oracle]
 binary = true
 command = "odgi overlap -i {filename} -R {base}.paths"
+output.overlap = "-"
 
 [envs.overlap_test]
 binary = true
 command = "python3 ../slow_odgi/overlap.py {base}.paths < {filename}"
+output.overlap = "-"
 
 [envs.paths_oracle]
 binary = true
 command = "odgi paths -i {filename} -L"
+output.paths = "-"
 
 [envs.paths_test]
 binary = true
 command = "python3 ../slow_odgi/paths.py < {filename}"
+output.paths = "-"
 
 [envs.validate_setup]
 binary = true
@@ -95,7 +115,9 @@ output.gfa = "-"
 [envs.validate_oracle]
 binary = true
 command = "odgi build -g {filename} -o - | odgi validate -i - 2>temp.txt; cat temp.txt"
+output.validate = "-"
 
 [envs.validate_test]
 binary = true
 command = "python3 ../slow_odgi/validate.py < {filename}"
+output.validate = "-"


### PR DESCRIPTION
A simple PR that helps tidy up our testing a fair bit! As #34 advises, I use turnt's `output.extension` feature to make bespoke .expect files for each algorithm. A much less stressful testing experience!