### PR TITLE
Use turnt return_code for cleanup

### DIFF
--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -114,7 +114,8 @@ output.temp = "-"
 
 [envs.validate_oracle]
 binary = true
-command = "odgi build -g {filename} -o - | odgi validate -i - 2>temp.txt; cat temp.txt"
+command = "odgi build -g {filename} -o - | odgi validate -i - 2>&1"
+return_code = 1
 output.validate = "-"
 
 [envs.validate_test]


### PR DESCRIPTION
A tiny bit of cleanup in `validate`. The command produces its interesting output in `stderr`, so, in my Turnt command, I was trying to use `2>&1` to pipe the stderr into stdout and then let Turnt carry that on to the output file.

Turns out I missed a detail: I needed to tell Turnt to expect a non-zero return code. This also closes https://github.com/cucapra/turnt/issues/25; sorry to have made a false accusation! 