### PR TITLE
Fix overlap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST_FILES := t k note5 overlap q.chop LPA DRB1-3123 chr6.C4
+TEST_FILES := t k note5 # overlap q.chop LPA DRB1-3123 chr6.C4
 BASIC_TESTS := ex1 ex2
 OG_FILES := $(BASIC_TESTS:%=test/basic/%.og) $(TEST_FILES:%=test/%.og)
 DEPTH_OG_FILES := $(OG_FILES:test/%.og=test/depth/%.og)
@@ -67,6 +67,11 @@ slow-odgi-all-tests:
 	-turnt --env overlap_test test/*.gfa
 	-turnt --env paths_test test/*.gfa
 	-turnt --env validate_test test/*.gfa
+
+curr: og
+	-turnt --save --env overlap_setup test/*.gfa
+	-turnt --save --env overlap_oracle test/*.og
+	-turnt --env overlap_test test/*.gfa
 
 
 # The basic test suite above, plus a few handmade tests for good measure.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST_FILES := t k note5 # overlap q.chop LPA DRB1-3123 chr6.C4
+TEST_FILES := t k note5 overlap q.chop LPA DRB1-3123 chr6.C4
 BASIC_TESTS := ex1 ex2
 OG_FILES := $(BASIC_TESTS:%=test/basic/%.og) $(TEST_FILES:%=test/%.og)
 DEPTH_OG_FILES := $(OG_FILES:test/%.og=test/depth/%.og)
@@ -67,11 +67,6 @@ slow-odgi-all-tests:
 	-turnt --env overlap_test test/*.gfa
 	-turnt --env paths_test test/*.gfa
 	-turnt --env validate_test test/*.gfa
-
-curr: og
-	-turnt --save --env overlap_setup test/*.gfa
-	-turnt --save --env overlap_oracle test/*.og
-	-turnt --env overlap_test test/*.gfa
 
 
 # The basic test suite above, plus a few handmade tests for good measure.

--- a/slow_odgi/slow_odgi/overlap.py
+++ b/slow_odgi/slow_odgi/overlap.py
@@ -15,11 +15,14 @@ def touches(path1, path2, graph):
 
 def overlap(graph, inputpaths):
     """Which paths touch these input paths?"""
-    print("\t".join(["#path", "start", "end", "path.touched"]))
+    header_printed = False
     for ip in inputpaths:
         assert ip in graph.paths
         for path in graph.paths.keys():
             if touches(ip, path, graph):
+                if not header_printed:
+                    print("\t".join(["#path", "start", "end", "path.touched"]))
+                    header_printed = True
                 print(
                     "\t".join([ip, "0", str(len(preprocess.pathseq(graph)[ip])), path])
                 )

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -35,7 +35,7 @@ output.depthpaths = "-"
 
 [envs.depth_oracle]
 binary = true
-command = "odgi depth -d -i {filename} -R {base}.depthpaths"
+command = "odgi depth -d -i {filename} -s {base}.depthpaths"
 output.depth = "-"
 
 [envs.depth_test]

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -35,7 +35,7 @@ output.depthpaths = "-"
 
 [envs.depth_oracle]
 binary = true
-command = "odgi depth -d -i {filename} -s {base}.depthpaths"
+command = "odgi depth -d -i {filename} -R {base}.depthpaths"
 output.depth = "-"
 
 [envs.depth_test]
@@ -110,7 +110,7 @@ output.norm = "-"
 
 [envs.overlap_setup]
 binary = true
-command = "python -m slow_odgi.paths {filename} 0"
+command = "python -m slow_odgi.paths {filename} 50"
 output.overlappaths = "-"
 
 [envs.overlap_oracle]


### PR DESCRIPTION
Using a selection of paths, as I did in #76, revealed that `slow_odgi overlap` was disagreeing with `odgi overlap` when there was no output. This is a quick fix for that.