### PR TITLE
Minimize imports in slow-odgi

### DIFF
--- a/slow_odgi/slow_odgi/chop.py
+++ b/slow_odgi/slow_odgi/chop.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Dict, Tuple
 from . import mygfa
 

--- a/slow_odgi/slow_odgi/crush.py
+++ b/slow_odgi/slow_odgi/crush.py
@@ -1,4 +1,3 @@
-import sys
 from . import mygfa
 
 

--- a/slow_odgi/slow_odgi/degree.py
+++ b/slow_odgi/slow_odgi/degree.py
@@ -1,4 +1,3 @@
-import sys
 from . import mygfa, preprocess
 
 

--- a/slow_odgi/slow_odgi/flatten.py
+++ b/slow_odgi/slow_odgi/flatten.py
@@ -1,7 +1,3 @@
-import sys
-from . import mygfa
-
-
 def get_fasta_legend(graph):
     """The main deliverable is the FASTA:
     Simply traverse the segments in order and glue their seqs together.
@@ -49,10 +45,8 @@ def insert_newlines(string, every=80):
 def flatten(graph, name):
     """Print out the FASTA and BED."""
     print(f">{name}")
+    # TODO: this is a bit harcoded for files living in test/file.gfa
+    # Would be nice to neaten this up and make it less brittle.
     fasta, legend = get_fasta_legend(graph)
     print(insert_newlines(fasta))
     print_bed(graph, legend, name)
-
-    #
-    # TODO: this is a bit harcoded for files living in test/file.gfa
-    # Would be nice to neaten this up and make it less brittle.

--- a/slow_odgi/slow_odgi/flip.py
+++ b/slow_odgi/slow_odgi/flip.py
@@ -1,4 +1,3 @@
-import sys
 from typing import List
 from . import mygfa
 

--- a/slow_odgi/slow_odgi/inject.py
+++ b/slow_odgi/slow_odgi/inject.py
@@ -1,5 +1,3 @@
-import sys
-from typing import List
 from . import mygfa, chop
 
 

--- a/slow_odgi/slow_odgi/matrix.py
+++ b/slow_odgi/slow_odgi/matrix.py
@@ -1,5 +1,4 @@
-import sys
-from . import mygfa, preprocess
+from . import preprocess
 
 
 def matrix(graph):

--- a/slow_odgi/slow_odgi/mkjson.py
+++ b/slow_odgi/slow_odgi/mkjson.py
@@ -1,4 +1,3 @@
-import sys
 import json
 import dataclasses
 from json import JSONEncoder

--- a/slow_odgi/slow_odgi/mygfa.py
+++ b/slow_odgi/slow_odgi/mygfa.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import dataclass
-from typing import List, Tuple, Optional, Dict, TextIO, Iterator, NamedTuple
+from typing import List, Tuple, Optional, Dict, TextIO, Iterator
 from enum import Enum
 import re
 

--- a/slow_odgi/slow_odgi/overlap.py
+++ b/slow_odgi/slow_odgi/overlap.py
@@ -1,5 +1,4 @@
-import sys
-from . import mygfa, preprocess
+from . import preprocess
 
 
 def touches(path1, path2, graph):

--- a/slow_odgi/slow_odgi/validate.py
+++ b/slow_odgi/slow_odgi/validate.py
@@ -1,5 +1,4 @@
-import sys
-from . import mygfa, preprocess
+from . import preprocess
 
 
 def validate(graph):


### PR DESCRIPTION
The briefest of things: moving to the CLI interface and doing graph-parsing centrally allows me to cut down on my imports.