### PR TITLE
Cigar overlaps in paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,32 +30,38 @@ test-mkjson: og
 #################
 
 # Sets up all the odgi-oracles and then tests slow-odgi against them.
-test-slow-odgi: slow-odgi-all-oracles slow-odgi-all-tests
+test-slow-odgi: slow-odgi-setup slow-odgi-oracles slow-odgi-tests
 
 # Collects all the setup/oracle stages of slow-odgi into once place.
+slow-odgi-setup: og
+	-turnt --save --env depth_setup test/*.gfa
+	-turnt --save --env inject_setup test/*.gfa
+	-turnt --save --env overlap_setup test/*.gfa
+
+# Collects all the oracle stages of slow-odgi into once place.
 # This can be run once, noisily, and then slow-odgi-all-tests can be run
 # quietly against the expect-files created here.
-slow-odgi-all-oracles: og
+# Note that, in reality, this depends on the setup stage above.
+# Run this by itself ONLY if you know that the setup stages don't need to be
+# run afresh.
+slow-odgi-oracles: og
 	-turnt --save --env chop_oracle test/*.og
 	-turnt --save --env crush_oracle test/*.og
 	-turnt --save --env degree_oracle test/*.og
-	-turnt --save --env depth_setup test/*.gfa
 	-turnt --save --env depth_oracle test/*.og
 	-turnt --save --env flip_oracle test/*.og
 	-turnt --save --env flatten_oracle test/*.og
-	-turnt --save --env inject_setup test/*.gfa
 	-turnt --save --env inject_oracle test/*.og
 	-turnt --save --env matrix_oracle test/*.og
-	-turnt --save --env overlap_setup test/*.gfa
 	-turnt --save --env overlap_oracle test/*.og
 	-turnt --save --env paths_oracle test/*.og
-	-turnt --save --env validate_oracle test/*.gfa
+	-turnt --save --env validate_oracle test/*.og
 
-# In reality slow-odgi-all-tests needs slow-odgi-all-oracles as a dependency.
+# In reality slow-odgi-tests depends on slow-odgi-oracles above.
 # Running the below by itself is faster and less noisy,
 # but do so ONLY if you know that the graphs and the odgi commands have not
-# changed, in which case slow-odgi-all-oracles would have had no effect anyway.
-slow-odgi-all-tests:
+# changed, in which case slow-odgi-oracles would have had no effect anyway.
+slow-odgi-tests:
 	turnt --env chop_test test/*.gfa
 	-turnt --env crush_test test/*.gfa
 	-turnt --env degree_test test/*.gfa
@@ -71,7 +77,7 @@ slow-odgi-all-tests:
 
 # The basic test suite above, plus a few handmade tests for good measure.
 # Those are described below.
-test-slow-odgi-careful: test-slow-odgi test-slow-validate-careful test-slow-crush-careful test-slow-flip-careful
+test-slow-odgi-careful: slow-odgi-validate-careful slow-odgi-crush-careful slow-odgi-flip-careful
 
 # The fetch-ed graphs are valid, so `validate` succeeds quietly against them.
 # To actually see `validate` in action, we need to walk over the graphs and
@@ -79,22 +85,25 @@ test-slow-odgi-careful: test-slow-odgi test-slow-validate-careful test-slow-crus
 # This is what `validate_setup` does, creating graphname.temp files.
 # It is too annoying to run this every time (it pollutes the .gfa namespace
 # of the test directory), so we provide this as a separate "careful" test.
-test-slow-validate-careful: fetch
+slow-odgi-validate-careful: fetch
 	-turnt --save --env validate_setup test/*.gfa
 	for fn in `ls test/*.temp`; do `mv $$fn $${fn%.*}_temp.gfa`; done
-	-turnt --save --env validate_oracle_err test/*_temp.gfa
+	-turnt --save --env validate_oracle_careful test/*_temp.gfa
 	turnt --env validate_test test/*_temp.gfa
 	rm test/*_temp.gfa
 
 # Handmade files to test crush and flip more comprehensively.
-test-slow-crush-careful: fetch
+slow-odgi-crush-careful: fetch
 	-turnt --save --env crush_oracle test/handmade/crush*.gfa
 	-turnt --env crush_test test/handmade/crush*.gfa
 
-test-slow-flip-careful: fetch
+slow-odgi-flip-careful: fetch
 	-turnt --save --env flip_oracle test/handmade/flip*.gfa
 	-turnt --env flip_test test/handmade/flip*.gfa
 
+
+# All the slow-odgi tests, basic + careful.
+test-slow-odgi-all: test-slow-odgi test-slow-odgi-careful
 
 clean:
 	rm -rf $(TEST_FILES:%=%.*)f

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ slow-odgi-all-oracles: og
 	-turnt --save --env overlap_setup test/*.gfa
 	-turnt --save --env overlap_oracle test/*.og
 	-turnt --save --env paths_oracle test/*.og
-	-turnt --save --env validate_oracle test/*.og
+	-turnt --save --env validate_oracle test/*.gfa
 
 # In reality slow-odgi-all-tests needs slow-odgi-all-oracles as a dependency.
 # Running the below by itself is faster and less noisy,

--- a/slow_odgi/slow_odgi/chop.py
+++ b/slow_odgi/slow_odgi/chop.py
@@ -53,8 +53,8 @@ def chop_paths(graph, legend):
             a, b = legend[seg.name]
             segments = [mygfa.Handle(str(s), o) for s in range(a, b)]
             new_p_segs += segments if o else list(reversed(segments))
-        new_paths[path.name] = mygfa.Path(path.name, new_p_segs, path.overlaps)
-        # For now we handle overlaps very sloppily.
+        new_paths[path.name] = mygfa.Path(path.name, new_p_segs, None)
+        # odgi drops overlaps, so we do too.
     return new_paths
 
 

--- a/slow_odgi/slow_odgi/crush.py
+++ b/slow_odgi/slow_odgi/crush.py
@@ -1,4 +1,4 @@
-from . import mygfa
+from . import mygfa, preprocess
 
 
 def crush_seg(seg):
@@ -20,4 +20,10 @@ def crush_seg(seg):
 def crush(graph):
     """Crush all the segments of the graph."""
     crushed_segs = {name: crush_seg(seg) for name, seg in graph.segments.items()}
-    return mygfa.Graph(graph.headers, crushed_segs, graph.links, graph.paths)
+    return mygfa.Graph(
+        graph.headers,
+        crushed_segs,
+        graph.links,
+        preprocess.drop_all_overlaps(graph.paths),
+        # odgi drops overlaps, so we do too.
+    )

--- a/slow_odgi/slow_odgi/flip.py
+++ b/slow_odgi/slow_odgi/flip.py
@@ -23,9 +23,10 @@ def flip_path(path, graph):
         path_segs = []
         for seg in reversed(path.segments):
             path_segs.append(mygfa.Handle(seg.name, not seg.orientation))
-        return mygfa.Path(f"{path.name}_inv", path_segs, path.overlaps), True
+        return mygfa.Path(f"{path.name}_inv", path_segs, None), True
     else:
-        return path, False
+        return path.drop_overlaps(), False
+        # odgi drops overlaps, so we do too.
 
 
 def dedup(list: List[mygfa.Link]) -> List[mygfa.Link]:

--- a/slow_odgi/slow_odgi/mygfa.py
+++ b/slow_odgi/slow_odgi/mygfa.py
@@ -171,9 +171,17 @@ class Path:
             overlaps_lst,
         )
 
+    def drop_overlaps(self) -> "Path":
+        return Path(self.name, self.segments, None)
+
     def __str__(self):
         return "\t".join(
-            ["P", self.name, ",".join(str(seg) for seg in self.segments), "*"]
+            [
+                "P",
+                self.name,
+                ",".join(str(seg) for seg in self.segments),
+                ",".join(str(a) for a in self.overlaps) if self.overlaps else "*",
+            ]
         )
 
 

--- a/slow_odgi/slow_odgi/preprocess.py
+++ b/slow_odgi/slow_odgi/preprocess.py
@@ -57,3 +57,7 @@ def get_maxes(graph):
     max_steps = max([len(steps) for steps in node_steps(graph).values()])
     max_paths = len(graph.paths)
     return max_nodes, max_steps, max_paths
+
+
+def drop_all_overlaps(paths):
+    return {name: path.drop_overlaps() for name, path in paths.items()}

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -140,10 +140,10 @@ output.temp = "-"
 
 [envs.validate_oracle]
 binary = true
-command = "odgi build -g {filename} -o - | odgi validate -i - 2>&1"
+command = "odgi validate -i {filename} 2>&1"
 output.validate = "-"
 
-[envs.validate_oracle_err]
+[envs.validate_oracle_careful]
 binary = true
 command = "odgi build -g {filename} -o - | odgi validate -i - 2>&1"
 return_code = 1


### PR DESCRIPTION
At some point I removed our CIGAR-string parsing just started putting `*`. The CIGAR string is optional, and a None is rendered as a `*` in GFA files, so this was relatively okay. However, I worried that there may be cases where odgi was doing something careful with CIGAR strings and we were not.

This PR brings CIGAR-string overlaps back into play. In the algorithms slow-odgi covers thus far, odgi never does anything clever with these strings. It carries them around when the path is unchanged, and drops them on the ground when the paths have changed. We now mimic this behavior in slow-odgi.