### PR TITLE
Expose slow_odgi's normalization in a new subcommand

### DIFF
--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -31,8 +31,7 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     chop_parser = subparsers.add_parser(
-        "chop",
-        help="Shortens segments' sequences to a given maximum length.",
+        "chop", help="Shortens segments' sequences to a given maximum length.",
     )
     chop_parser.add_argument(
         "-n",
@@ -43,8 +42,7 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "crush",
-        help="Replaces consecutive instances of `N` with a single `N`.",
+        "crush", help="Replaces consecutive instances of `N` with a single `N`.",
     )
 
     _ = subparsers.add_parser(
@@ -62,13 +60,11 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "flatten",
-        help="Converts the graph into FASTA + BED representation.",
+        "flatten", help="Converts the graph into FASTA + BED representation.",
     )
 
     _ = subparsers.add_parser(
-        "flip",
-        help="Flips any paths that step more backward than forward.",
+        "flip", help="Flips any paths that step more backward than forward.",
     )
 
     inject_parser = subparsers.add_parser(
@@ -97,18 +93,14 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     subparsers.add_parser("paths", help="Lists the paths in the graph.")
 
     subparsers.add_parser(
-        "validate",
-        help="Checks whether the links of the graph support its paths.",
+        "validate", help="Checks whether the links of the graph support its paths.",
     )
 
     norm_parser = subparsers.add_parser(
-        "norm",
-        help="Print a graph unmodified, normalizing its representation.",
+        "norm", help="Print a graph unmodified, normalizing its representation.",
     )
     norm_parser.add_argument(
-        "--nl",
-        action="store_true",
-        help="Don't include links.",
+        "--nl", action="store_true", help="Don't include links.",
     )
 
     # Add the graph argument to all subparsers.
@@ -171,9 +163,7 @@ def dispatch(args: argparse.Namespace) -> None:
     ans = name_to_func[args.command](graph)
     if args.command in makes_new_graph:
         ans.emit(
-            sys.stdout,
-            args.command not in show_no_links and
-            not vars(args).get('nl')
+            sys.stdout, args.command not in show_no_links and not vars(args).get("nl")
         )
         if args.command in constructive_changes:
             assert proofs.logically_le(graph, ans)

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -172,7 +172,7 @@ def dispatch(args: argparse.Namespace) -> None:
     if args.command in makes_new_graph:
         ans.emit(
             sys.stdout,
-            args.command not in show_no_links or
+            args.command not in show_no_links and
             not vars(args).get('nl')
         )
         if args.command in constructive_changes:

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+import io
 from typing import Dict, Tuple, List
 from collections.abc import Callable
 from mygfa import mygfa
@@ -164,9 +165,8 @@ def dispatch(args: argparse.Namespace) -> None:
     if args.graph:
         in_file = open(args.graph, "r", encoding="utf-8")
     else:
-        in_file = sys.stdin
+        in_file = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
     graph = mygfa.Graph.parse(in_file)
-
     # Run the appropriate command on the input graph.
     ans = name_to_func[args.command](graph)
     if args.command in makes_new_graph:

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -31,7 +31,8 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     chop_parser = subparsers.add_parser(
-        "chop", help="Shortens segments' sequences to a given maximum length.",
+        "chop",
+        help="Shortens segments' sequences to a given maximum length.",
     )
     chop_parser.add_argument(
         "-n",
@@ -42,7 +43,8 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "crush", help="Replaces consecutive instances of `N` with a single `N`.",
+        "crush",
+        help="Replaces consecutive instances of `N` with a single `N`.",
     )
 
     _ = subparsers.add_parser(
@@ -60,11 +62,13 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "flatten", help="Converts the graph into FASTA + BED representation.",
+        "flatten",
+        help="Converts the graph into FASTA + BED representation.",
     )
 
     _ = subparsers.add_parser(
-        "flip", help="Flips any paths that step more backward than forward.",
+        "flip",
+        help="Flips any paths that step more backward than forward.",
     )
 
     inject_parser = subparsers.add_parser(
@@ -93,14 +97,18 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     subparsers.add_parser("paths", help="Lists the paths in the graph.")
 
     subparsers.add_parser(
-        "validate", help="Checks whether the links of the graph support its paths.",
+        "validate",
+        help="Checks whether the links of the graph support its paths.",
     )
 
     norm_parser = subparsers.add_parser(
-        "norm", help="Print a graph unmodified, normalizing its representation.",
+        "norm",
+        help="Print a graph unmodified, normalizing its representation.",
     )
     norm_parser.add_argument(
-        "--nl", action="store_true", help="Don't include links.",
+        "--nl",
+        action="store_true",
+        help="Don't include links.",
     )
 
     # Add the graph argument to all subparsers.

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -1,6 +1,6 @@
 [envs.chop_oracle]
 binary = true
-command = "odgi chop -i {filename} -c 3 -o - | odgi view -g -i - | python -m slow_odgi.norm --nl"
+command = "odgi chop -i {filename} -c 3 -o - | odgi view -g -i - | slow_odgi norm --nl"
 output.chop = "-"
 
 [envs.chop_test]
@@ -10,7 +10,7 @@ output.chop = "-"
 
 [envs.crush_oracle]
 binary = true
-command = "odgi crush -i {filename} -o - | odgi view -g -i - | python -m slow_odgi.norm"
+command = "odgi crush -i {filename} -o - | odgi view -g -i - | slow_odgi norm"
 output.crush = "-"
 
 [envs.crush_test]
@@ -55,7 +55,7 @@ output.flatten = "-"
 
 [envs.flip_oracle]
 binary = true
-command = "odgi flip -i {filename} -o - | odgi view -g -i - | python -m slow_odgi.norm"
+command = "odgi flip -i {filename} -o - | odgi view -g -i - | slow_odgi norm"
 output.flip = "-"
 
 [envs.flip_test]
@@ -70,7 +70,7 @@ output.bed = "-"
 
 [envs.inject_oracle]
 binary = true
-command = "odgi inject -i {filename} -b {base}.bed -o - | odgi view -g -i - | python -m slow_odgi.norm --nl"
+command = "odgi inject -i {filename} -b {base}.bed -o - | odgi view -g -i - | slow_odgi norm --nl"
 output.inj = "-"
 
 [envs.inject_test]
@@ -90,12 +90,12 @@ output.matrix = "-"
 
 [envs.norm_oracle]
 binary = true
-command = "odgi view -g -i {filename} | python -m slow_odgi.norm"
+command = "odgi view -g -i {filename} | slow_odgi norm"
 output.norm = "-"
 
 [envs.norm_test]
 binary = true
-command = "python -m slow_odgi.norm {filename}"
+command = "slow_odgi norm {filename}"
 output.norm = "-"
 
 [envs.overlap_setup]


### PR DESCRIPTION
This solves a minor Python-related problem I ran into when running the tests on my machine: the `python` that the Turnt commands were using was the wrong one for the `slow_odgi` I had installed. The current Turnt config uses `python -m slow_odgi.<stuff>` in a few places, as opposed to a plain `slow_odgi` command, and the most prominent one is for normalization (`slow_odgi.norm`). This just works around the need for that by making `slow_odgi norm` into a proper subcommand.

To make this work, I also made all `slow_odgi` subcommands accept GFA files on stdin—in addition to the way they previously worked, which was to take a filename argument on the command line. Just leave off the filename to read from stdin instead.

I might try to make the other various `python -m slow_odgi.<stuff>` things into subcommands too at some point.