### PR TITLE
Use `slow_odgi`'s `paths` subcommand consistently

### DIFF
--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -31,8 +31,7 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     chop_parser = subparsers.add_parser(
-        "chop",
-        help="Shortens segments' sequences to a given maximum length.",
+        "chop", help="Shortens segments' sequences to a given maximum length.",
     )
     chop_parser.add_argument(
         "-n",
@@ -43,8 +42,7 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "crush",
-        help="Replaces consecutive instances of `N` with a single `N`.",
+        "crush", help="Replaces consecutive instances of `N` with a single `N`.",
     )
 
     _ = subparsers.add_parser(
@@ -62,13 +60,11 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "flatten",
-        help="Converts the graph into FASTA + BED representation.",
+        "flatten", help="Converts the graph into FASTA + BED representation.",
     )
 
     _ = subparsers.add_parser(
-        "flip",
-        help="Flips any paths that step more backward than forward.",
+        "flip", help="Flips any paths that step more backward than forward.",
     )
 
     inject_parser = subparsers.add_parser(
@@ -97,18 +93,14 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     subparsers.add_parser("paths", help="Lists the paths in the graph.")
 
     subparsers.add_parser(
-        "validate",
-        help="Checks whether the links of the graph support its paths.",
+        "validate", help="Checks whether the links of the graph support its paths.",
     )
 
     norm_parser = subparsers.add_parser(
-        "norm",
-        help="Print a graph unmodified, normalizing its representation.",
+        "norm", help="Print a graph unmodified, normalizing its representation.",
     )
     norm_parser.add_argument(
-        "--nl",
-        action="store_true",
-        help="Don't include links.",
+        "--nl", action="store_true", help="Don't include links.",
     )
 
     # Add the graph argument to all subparsers.
@@ -171,9 +163,7 @@ def dispatch(args: argparse.Namespace) -> None:
     ans = name_to_func[args.command](graph)
     if args.command in makes_new_graph:
         ans.emit(
-            sys.stdout,
-            args.command not in show_no_links and
-            not vars(args).get('nl')
+            sys.stdout, args.command not in show_no_links and not vars(args).get("nl")
         )
         if args.command in constructive_changes:
             assert proofs.logically_le(graph, ans)

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -172,7 +172,7 @@ def dispatch(args: argparse.Namespace) -> None:
     if args.command in makes_new_graph:
         ans.emit(
             sys.stdout,
-            args.command not in show_no_links or
+            args.command not in show_no_links and
             not vars(args).get('nl')
         )
         if args.command in constructive_changes:

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+import io
 from typing import Dict, Tuple, List
 from collections.abc import Callable
 from mygfa import mygfa
@@ -164,9 +165,8 @@ def dispatch(args: argparse.Namespace) -> None:
     if args.graph:
         in_file = open(args.graph, "r", encoding="utf-8")
     else:
-        in_file = sys.stdin
+        in_file = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
     graph = mygfa.Graph.parse(in_file)
-
     # Run the appropriate command on the input graph.
     ans = name_to_func[args.command](graph)
     if args.command in makes_new_graph:

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -31,7 +31,8 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     chop_parser = subparsers.add_parser(
-        "chop", help="Shortens segments' sequences to a given maximum length.",
+        "chop",
+        help="Shortens segments' sequences to a given maximum length.",
     )
     chop_parser.add_argument(
         "-n",
@@ -42,7 +43,8 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "crush", help="Replaces consecutive instances of `N` with a single `N`.",
+        "crush",
+        help="Replaces consecutive instances of `N` with a single `N`.",
     )
 
     _ = subparsers.add_parser(
@@ -60,11 +62,13 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
 
     _ = subparsers.add_parser(
-        "flatten", help="Converts the graph into FASTA + BED representation.",
+        "flatten",
+        help="Converts the graph into FASTA + BED representation.",
     )
 
     _ = subparsers.add_parser(
-        "flip", help="Flips any paths that step more backward than forward.",
+        "flip",
+        help="Flips any paths that step more backward than forward.",
     )
 
     inject_parser = subparsers.add_parser(
@@ -93,14 +97,18 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     subparsers.add_parser("paths", help="Lists the paths in the graph.")
 
     subparsers.add_parser(
-        "validate", help="Checks whether the links of the graph support its paths.",
+        "validate",
+        help="Checks whether the links of the graph support its paths.",
     )
 
     norm_parser = subparsers.add_parser(
-        "norm", help="Print a graph unmodified, normalizing its representation.",
+        "norm",
+        help="Print a graph unmodified, normalizing its representation.",
     )
     norm_parser.add_argument(
-        "--nl", action="store_true", help="Don't include links.",
+        "--nl",
+        action="store_true",
+        help="Don't include links.",
     )
 
     # Add the graph argument to all subparsers.

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -30,7 +30,7 @@ output.degree = "-"
 
 [envs.depth_setup]
 binary = true
-command = "python -m slow_odgi.paths {filename} 50"
+command = "slow_odgi paths {filename} 50"
 output.depthpaths = "-"
 
 [envs.depth_oracle]
@@ -100,7 +100,7 @@ output.norm = "-"
 
 [envs.overlap_setup]
 binary = true
-command = "python -m slow_odgi.paths {filename} 50"
+command = "slow_odgi paths {filename} 50"
 output.overlappaths = "-"
 
 [envs.overlap_oracle]

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -1,6 +1,6 @@
 [envs.chop_oracle]
 binary = true
-command = "odgi chop -i {filename} -c 3 -o - | odgi view -g -i - | python -m slow_odgi.norm --nl"
+command = "odgi chop -i {filename} -c 3 -o - | odgi view -g -i - | slow_odgi norm --nl"
 output.chop = "-"
 
 [envs.chop_test]
@@ -10,7 +10,7 @@ output.chop = "-"
 
 [envs.crush_oracle]
 binary = true
-command = "odgi crush -i {filename} -o - | odgi view -g -i - | python -m slow_odgi.norm"
+command = "odgi crush -i {filename} -o - | odgi view -g -i - | slow_odgi norm"
 output.crush = "-"
 
 [envs.crush_test]
@@ -55,7 +55,7 @@ output.flatten = "-"
 
 [envs.flip_oracle]
 binary = true
-command = "odgi flip -i {filename} -o - | odgi view -g -i - | python -m slow_odgi.norm"
+command = "odgi flip -i {filename} -o - | odgi view -g -i - | slow_odgi norm"
 output.flip = "-"
 
 [envs.flip_test]
@@ -70,7 +70,7 @@ output.bed = "-"
 
 [envs.inject_oracle]
 binary = true
-command = "odgi inject -i {filename} -b {base}.bed -o - | odgi view -g -i - | python -m slow_odgi.norm --nl"
+command = "odgi inject -i {filename} -b {base}.bed -o - | odgi view -g -i - | slow_odgi norm --nl"
 output.inj = "-"
 
 [envs.inject_test]
@@ -90,12 +90,12 @@ output.matrix = "-"
 
 [envs.norm_oracle]
 binary = true
-command = "odgi view -g -i {filename} | python -m slow_odgi.norm"
+command = "odgi view -g -i {filename} | slow_odgi norm"
 output.norm = "-"
 
 [envs.norm_test]
 binary = true
-command = "python -m slow_odgi.norm {filename}"
+command = "slow_odgi norm {filename}"
 output.norm = "-"
 
 [envs.overlap_setup]


### PR DESCRIPTION
Until this PR I was using `python -m slow_odgi.paths` in some cases and the actual subcommand `slow_odgi paths` in some. There was some reasoning behind this, and that is chalked out [here](https://github.com/cucapra/pollen/pull/108#issuecomment-1626525948), but it's time to move on and make these uses of the command consistent.