### PR TITLE
Expose the remaining slow_odgi test utilities as subcommands

### DIFF
--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -94,7 +94,13 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         required=True,
     )
 
-    subparsers.add_parser("paths", help="Lists the paths in the graph.")
+    paths_parser = subparsers.add_parser("paths", help="Lists the paths in the graph.")
+    paths_parser.add_argument(
+        "--drop",
+        type=int,
+        help="Randomly drop a percentage of the paths.",
+        metavar="PCT",
+    )
 
     subparsers.add_parser(
         "validate",
@@ -151,7 +157,7 @@ def dispatch(args: argparse.Namespace) -> None:
         "inject": lambda g: inject.inject(g, parse_bedfile(args.bed)),
         "matrix": matrix.matrix,
         "overlap": lambda g: overlap.overlap(g, parse_paths(args.paths)),
-        "paths": paths.paths,
+        "paths": lambda g: paths.paths(g, args.drop),
         "validate": validate.validate,
         "norm": norm.norm,
     }

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -19,6 +19,8 @@ from . import (
     proofs,
     validate,
     norm,
+    inject_setup,
+    validate_setup,
 )
 
 
@@ -117,6 +119,10 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         help="Don't include links.",
     )
 
+    # "Hidden" commands for testing only
+    subparsers.add_parser("inject_setup")
+    subparsers.add_parser("validate_setup")
+
     # Add the graph argument to all subparsers.
     # Doing it this way means that the graph argument is sought _after_ the
     # command name.
@@ -160,8 +166,10 @@ def dispatch(args: argparse.Namespace) -> None:
         "paths": lambda g: paths.paths(g, args.drop),
         "validate": validate.validate,
         "norm": norm.norm,
+        "inject_setup": inject_setup.print_bed,
+        "validate_setup": validate_setup.drop_some_links,
     }
-    makes_new_graph = ["chop", "crush", "flip", "inject", "norm"]
+    makes_new_graph = ["chop", "crush", "flip", "inject", "norm", "validate_setup"]
     show_no_links = ["chop", "inject"]
     constructive_changes = ["chop", "inject"]
     # These commands only add to the graph, so we'll assert "logically_le".

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -42,12 +42,12 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         required=True,
     )
 
-    _ = subparsers.add_parser(
+    subparsers.add_parser(
         "crush",
         help="Replaces consecutive instances of `N` with a single `N`.",
     )
 
-    _ = subparsers.add_parser(
+    subparsers.add_parser(
         "degree", help="Generates a table summarizing each segment's degree."
     )
 
@@ -61,12 +61,12 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         required=True,
     )
 
-    _ = subparsers.add_parser(
+    subparsers.add_parser(
         "flatten",
         help="Converts the graph into FASTA + BED representation.",
     )
 
-    _ = subparsers.add_parser(
+    subparsers.add_parser(
         "flip",
         help="Flips any paths that step more backward than forward.",
     )
@@ -81,7 +81,7 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         required=True,
     )
 
-    _ = subparsers.add_parser("matrix", help="Represents the graph as a matrix.")
+    subparsers.add_parser("matrix", help="Represents the graph as a matrix.")
 
     overlap_parser = subparsers.add_parser(
         "overlap",

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -65,7 +65,7 @@ output.flip = "-"
 
 [envs.inject_setup]
 binary = true
-command = "python -m slow_odgi.inject_setup < {filename}"
+command = "slow_odgi inject_setup < {filename}"
 output.bed = "-"
 
 [envs.inject_oracle]
@@ -125,7 +125,7 @@ output.paths = "-"
 
 [envs.validate_setup]
 binary = true
-command = "python -m slow_odgi.validate_setup < {filename}"
+command = "slow_odgi validate_setup < {filename}"
 output.temp = "-"
 
 [envs.validate_oracle]

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -30,7 +30,7 @@ output.degree = "-"
 
 [envs.depth_setup]
 binary = true
-command = "slow_odgi paths {filename} 50"
+command = "slow_odgi paths --drop 50 {filename}"
 output.depthpaths = "-"
 
 [envs.depth_oracle]
@@ -100,7 +100,7 @@ output.norm = "-"
 
 [envs.overlap_setup]
 binary = true
-command = "slow_odgi paths {filename} 50"
+command = "slow_odgi paths --drop 50 {filename}"
 output.overlappaths = "-"
 
 [envs.overlap_oracle]


### PR DESCRIPTION
This is a follow-up to #108 & #109. It takes the remaining places where we were using `python -m slow_odgi.<stuff>` in our testing setup and replaces them with commands we can invoke as `slow_odgi <stuff>`. (As a recap, this makes things work more smoothly on my machine, where the `python` executable is not the right one and it's surprisingly annoying to make it point to the right thing. It will hopefully avoid similar weirdness in other setups.)

It also fixes a minor problem from #109 where the new uses of `slow_odgi paths` required an additional argument for the `paths` command that wasn't present before.

Finally, to satisfy mypy, I split the graph-returning from the non-graph-returning `slow_odgi` functions (so they can have different return types). This way, subcommand functions that don't want to return a graph don't have to.