### PR TITLE
Use Pollen Logo with Transparent Background in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1>
 <p align="center">
-<img src="https://github.com/cucapra/pollen/blob/main/pollen_icon.png">
+<img src="https://github.com/cucapra/pollen/blob/main/pollen_icon_transparent.png">
 </h1>
 
 Pangenome Graph Queries in Calyx


### PR DESCRIPTION
As the title says! I've already added the logo with the transparent background to the main branch so that it's link in `README.md` will not break once this branch is merged, and I think it would be useful to have the logo on file in case we want to use it in future presentations even if we don't want to use it in the `README`. Using the transparent logo in the `README`, however, should be more aesthetically pleasing in browsers that use dark mode.

I also have not deleted the original logo, as I did have to do a big of shenaniganry to completely remove its background and, like copying a key, I think it may be better to work on the original image in the future if we ever want to modify it for some reason, but I'd like to hear y'all's opinion on which icon we should use for the `README` and whether or not we should keep both of them in the repo!