### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ and run `cd pollen_py && flit install -s --user`. You will need [`flit`][flit]. 
 
 #### Calyx
 
-Follow these [instructions](https://docs.calyxir.org/) to install calyx. You must complete the [first](https://docs.calyxir.org/#installing-from-source-to-use-and-extend-calyx) and [third](https://docs.calyxir.org/#installing-the-command-line-driver) sections, installing calyx from source, but feel free to skip the second section. Then, from the root of the calyx repository, install the calyx interpreter by running 
+Follow these [instructions](https://docs.calyxir.org/) to install Calyx. You must complete the [first](https://docs.calyxir.org/#installing-from-source-to-use-and-extend-calyx) and [third](https://docs.calyxir.org/#installing-the-command-line-driver) sections, installing Calyx from source, but feel free to skip the second section. Then, from the root of the Calyx repository, install the Calyx interpreter by running 
 ```
 cargo build -p interp
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ and run `cd pollen_py && flit install -s --user`. You will need [`flit`][flit]. 
 
 #### Calyx
 
-Follow these [instructions](https://docs.calyxir.org/) to install calyx. You must complete the [first](https://docs.calyxir.org/#compiler-installation) and [third](https://docs.calyxir.org/#installing-the-command-line-driver) sections, but feel free to skip the second. Then, from the root of the calyx repository, install the calyx interpreter by running 
+Follow these [instructions](https://docs.calyxir.org/) to install calyx. You must complete the [first](https://docs.calyxir.org/#installing-from-source-to-use-and-extend-calyx) and [third](https://docs.calyxir.org/#installing-the-command-line-driver) sections, installing calyx from source, but feel free to skip the second section. Then, from the root of the calyx repository, install the calyx interpreter by running 
 ```
 cargo build -p interp
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ and run `cd pollen_py && flit install -s --user`. You will need [`flit`][flit]. 
 
 #### Calyx
 
-Follow these [instructions](https://docs.calyxir.org/) to install calyx. You must complete the [first](https://docs.calyxir.org/#compiler-installation) and [third](https://docs.calyxir.org/#installing-the-command-line-driver) sections, but feel free to skip the second. The last step should be running `fud check`, which will report that some tools are unavailable. This is okay for our purposes.
+Follow these [instructions](https://docs.calyxir.org/) to install calyx. You must complete the [first](https://docs.calyxir.org/#compiler-installation) and [third](https://docs.calyxir.org/#installing-the-command-line-driver) sections, but feel free to skip the second. Then, from the root of the calyx repository, install the calyx interpreter by running 
+```
+cargo build -p interp
+```
+
+The last step should be running `fud check`, which will report that some tools are unavailable. This is okay for our purposes.
 
 After completing the above, run
 ```
@@ -135,7 +140,7 @@ exine depth -r depth.data -x depth.futil
 Testing
 -------
 
-To run the core tests, you will need to install [Turnt][]. We rely on version 1.9.0 or later. Then, navigative to the root directory of the pollen repository and run `make test`.
+To run the core tests, you will need to install [Turnt][]. We rely on version 1.11.0 or later. Then, navigative to the root directory of the pollen repository and run `make test`.
 
 Warning: the tests take approximately 2 hours to complete.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The last step should be running `fud check`, which will report that some tools a
 
 After completing the above, run
 ```
-fud config stages.futil.exec <full path to calyx repository>/target/debug/futil
+fud config stages.calyx.exec <full path to calyx repository>/target/debug/calyx
 fud config stages.interpreter.exec <full path to calyx repository>/target/debug/interp
 fud check
 ```


### PR DESCRIPTION
This addresses #114 (it turns out that our calyx installation instructions did need to be updated as a result of calyx renaming `futil` to `calyx` - sorry for the confusion Anshuman!) and the last two comments in #98.

What this PR does:
- Clarify that our installation instructions assume that the user has installed calyx from source
- Add a line about installing the calyx interpreter
- Instruct users to configure `stages.calyx.exec`, rather than `stages.futil.exec`
- Update instructions regarding the version of turnt that we're using

What this PR does NOT do:
- Address the symlinked test files
- Add a more precise invocation of `fud check` to only look at the tools a pollen user would need to get started
- Address how to install and configure calyx via Docker or as a crate

