### PR TITLE
Nix invalid graphs when running `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ clean:
 	rm -rf test/handmade/*.flip
 	rm -rf test/invalid/*.*
 
-
 test/chr8.pan.gfa:
 	curl -Lo ./test/chr8.pan.gfa.gz $(GFA_ZIP_URL)
 	gunzip ./test/chr8.pan.gfa.gz

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ clean:
 	rm -rf test/depth/subset-paths/*.out
 	rm -rf test/handmade/*.crush
 	rm -rf test/handmade/*.flip
+	rm -rf test/invalid/*.*
+
 
 test/chr8.pan.gfa:
 	curl -Lo ./test/chr8.pan.gfa.gz $(GFA_ZIP_URL)


### PR DESCRIPTION
`make clean` had missed a small thing: we gotta clean the graphs under `invalid`, just as we clean the graphs in `handmade`.