### PR TITLE
Small `slow-odgi` testing fixes, hopefully to fix #119

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ TEST_ENVS := chop_test crush_test degree_test depth_test flip_test \
 	 flatten_test inject_test matrix_test overlap_test paths_test validate_test
 slow-odgi-tests:
 	-turnt -j $(TEST_ENVS:%=--env %) test/*.gfa
-	-turnt -j --env validate_test_err test/invalid/*.gfa
+	-turnt -j --env validate_test test/invalid/*.gfa
 	-turnt -j --env crush_test test/handmade/crush*.gfa
 	-turnt -j --env flip_test test/handmade/flip*.gfa
 

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ slow-odgi-oracles: og
 TEST_ENVS := chop_test crush_test degree_test depth_test flip_test \
 	 flatten_test inject_test matrix_test overlap_test paths_test validate_test
 slow-odgi-tests:
-	turnt -j $(TEST_ENVS:%=--env %) test/*.gfa
-	turnt -j --env validate_test_err test/invalid/*.gfa
-	turnt -j --env crush_test test/handmade/crush*.gfa
-	turnt -j --env flip_test test/handmade/flip*.gfa
+	-turnt -j $(TEST_ENVS:%=--env %) test/*.gfa
+	-turnt -j --env validate_test_err test/invalid/*.gfa
+	-turnt -j --env crush_test test/handmade/crush*.gfa
+	-turnt -j --env flip_test test/handmade/flip*.gfa
 
 clean:
 	rm -rf $(TEST_FILES:%=%.*)

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -149,12 +149,6 @@ binary = true
 command = "slow_odgi validate {filename}"
 output.validate = "-"
 
-[envs.validate_test_err]
-binary = true
-command = "slow_odgi validate {filename}"
-output.validate = "-"
-return_code = 1
-
 [envs.pollen_data_gen_depth_oracle]
 binary = true
 command = "exine depth -d {filename} -a {filename}"


### PR DESCRIPTION
This fixes a couple of issues in the `slow-odgi` testing setup pointed out in #119. With this, on my machine, cleaning everything and running it from scratch produces only two failures:

```
not ok 17 - test/note5.gfa flip_test # differing: test/note5.flip
not ok 4 - test/handmade/flip4.gfa flip_test # differing: test/handmade/flip4.flip
```

If this seems to work good for one of @susan-garry & @anshumanmohan, these should at least get us closer to everything working. It would be great to know from @susan-garry whether there are any more failures remaining after this (and if so, which).