### PR TITLE
Pollen supports array access

### DIFF
--- a/pollen/src/ast/mod.rs
+++ b/pollen/src/ast/mod.rs
@@ -75,6 +75,10 @@ pub enum Expr {
         op: UOp,
         expr: Box<Expr>
     },
+    ArrayAccess {
+        expr: Box<Expr>,
+        idx: Box<Expr>
+    },
     Record {
         typ: Typ,
         fields: Vec<RecordField>

--- a/pollen/src/main.rs
+++ b/pollen/src/main.rs
@@ -25,6 +25,7 @@ lazy_static! {
 
         // Precedence is defined lowest to highest
         PrattParser::new()
+            .op(Op::postfix(Rule::array_access))
             .op(Op::infix(Rule::or, Left))
             .op(Op::infix(Rule::and, Left))
             .op(Op::infix(Rule::eq, Left) | Op::infix(Rule::neq, Left))
@@ -625,10 +626,22 @@ fn parse_expr(expression: Pairs<Rule>) -> Expr {
                 expr: Box::new(exp),
             }
         })
-        .map_postfix(|lhs, op| {
-            match op.as_rule() {
-                rule => unreachable!("{:?} not recognized as a postfix", rule),
-            }
+        .map_postfix(|exp, op| {
+            let idx_expr = match op.as_rule() {
+                Rule::array_access => {
+                    let mut inner = op.into_inner();
+                    let Some(expr) = inner.next() else {
+                        unreachable!("array access requires an expression")
+                    };
+                    parse_expr(expr.into_inner())
+                }
+                rule => unreachable!("{:?} not recognized as a postfix", rule)
+            };
+            
+                Expr::ArrayAccess {
+                    expr: Box::new(exp),
+                    idx: Box::new(idx_expr)
+                }
         })
         .map_infix(|lhs, op, rhs| {
             enum OpType {

--- a/pollen/src/pollen.pest
+++ b/pollen/src/pollen.pest
@@ -115,8 +115,8 @@ obj_initialize = { typ ~ "()" }
 call_args = { "(" ~ (expr ~ ("," ~ expr)*)? ~ ")" }
 func_call = { identifier ~ call_args }
 
-term = _{ (literal | obj_initialize | func_call | identifier 
-          | "(" ~ expr ~ ")" | "[" ~ expr ~ "]") }
+term = _{ literal | obj_initialize | func_call | identifier 
+          | "(" ~ expr ~ ")" | "[" ~ expr ~ "]" }
 
 array_access = { "[" ~ expr ~ "]" }
 postfix = _{ array_access }

--- a/pollen/src/pollen.pest
+++ b/pollen/src/pollen.pest
@@ -115,10 +115,13 @@ obj_initialize = { typ ~ "()" }
 call_args = { "(" ~ (expr ~ ("," ~ expr)*)? ~ ")" }
 func_call = { identifier ~ call_args }
 
-term = _{ literal | obj_initialize | func_call | identifier 
-          | "(" ~ expr ~ ")" | "[" ~ expr ~ "]" }
+term = _{ (literal | obj_initialize | func_call | identifier 
+          | "(" ~ expr ~ ")" | "[" ~ expr ~ "]") }
 
-expr = { prefix* ~ term ~ (binop ~ prefix* ~ term ) * }
+array_access = { "[" ~ expr ~ "]" }
+postfix = _{ array_access }
+
+expr = { prefix* ~ term ~ postfix* ~ (binop ~ prefix* ~ term ~ postfix*) * }
 
 
 /* ----- Statements ---- */

--- a/pollen/src/pollen.pest
+++ b/pollen/src/pollen.pest
@@ -120,8 +120,9 @@ term = _{ literal | obj_initialize | func_call | identifier
 
 array_access = { "[" ~ expr ~ "]" }
 postfix = _{ array_access }
+term_ext = _ { prefix* ~ term ~ postfix* }
 
-expr = { prefix* ~ term ~ postfix* ~ (binop ~ prefix* ~ term ~ postfix*) * }
+expr = { term_ext ~ (binop ~ term_ext) * }
 
 
 /* ----- Statements ---- */

--- a/pollen/tests/parse-out/paths.expect
+++ b/pollen/tests/parse-out/paths.expect
@@ -1,0 +1,101 @@
+Prog {
+    imports: [],
+    func_defs: [
+        FuncDef {
+            name: Id(
+                "emit_paths",
+            ),
+            args: [],
+            ret_typ: None,
+            stmts: [
+                ParsetDecl {
+                    id: Id(
+                        "out_paths",
+                    ),
+                    typ: Tuple(
+                        Step,
+                        Step,
+                    ),
+                    graph_id: None,
+                },
+                For {
+                    id: Id(
+                        "path",
+                    ),
+                    iterator: Var(
+                        Id(
+                            "Paths",
+                        ),
+                    ),
+                    body: Block {
+                        stmts: [
+                            EmitTo {
+                                expr: Tuple {
+                                    lhs: ArrayAccess {
+                                        expr: FieldAccess {
+                                            object: Var(
+                                                Id(
+                                                    "path",
+                                                ),
+                                            ),
+                                            field: Var(
+                                                Id(
+                                                    "steps",
+                                                ),
+                                            ),
+                                        },
+                                        idx: Integer(
+                                            0,
+                                        ),
+                                    },
+                                    rhs: ArrayAccess {
+                                        expr: FieldAccess {
+                                            object: Var(
+                                                Id(
+                                                    "path",
+                                                ),
+                                            ),
+                                            field: Var(
+                                                Id(
+                                                    "steps",
+                                                ),
+                                            ),
+                                        },
+                                        idx: BinOpExpr {
+                                            lhs: MethodCall {
+                                                object: FieldAccess {
+                                                    object: Var(
+                                                        Id(
+                                                            "path",
+                                                        ),
+                                                    ),
+                                                    field: Var(
+                                                        Id(
+                                                            "steps",
+                                                        ),
+                                                    ),
+                                                },
+                                                method: Id(
+                                                    "size",
+                                                ),
+                                                args: [],
+                                            },
+                                            op: Sub,
+                                            rhs: Integer(
+                                                1,
+                                            ),
+                                        },
+                                    },
+                                },
+                                set_id: Id(
+                                    "out_paths",
+                                ),
+                            },
+                        ],
+                    },
+                },
+            ],
+            ret: None,
+        },
+    ],
+}

--- a/pollen/tests/paths.pollen
+++ b/pollen/tests/paths.pollen
@@ -9,7 +9,7 @@ def paths() {
   parset out_paths[(Step*Step)];
 
   for path in Paths {
-    emit ( path[0] /* path.steps[0], */
+    emit ( path.steps[0],
           path.steps[path.steps.size() - 1]) 
       to out_paths;
   }

--- a/pollen/tests/paths.pollen
+++ b/pollen/tests/paths.pollen
@@ -1,4 +1,4 @@
-def paths() {
+def emit_paths() {
   // Since Pollen doesn't explicitly have path identifiers, 
   // we print the start and end steps of each path 
   // (akin to `odgi paths --idx = graph.og --list-paths --list-paths-start-end`). 


### PR DESCRIPTION
Pollen can now parse array access statements with arbitrary index expressions, such as path.steps[path.steps.size() - 1]!

This means that paths.pollen parses correctly, so now all of the slow-odgi examples that Priya translated to pollen parse correctly.