### PR TITLE
Slow odgi depth no paths

### DIFF
--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -166,8 +166,9 @@ def dispatch(args: argparse.Namespace) -> None:
     # Other functions, which typically print their own output.
     other_funcs: Dict[str, Callable[[mygfa.Graph], object]] = {
         "degree": degree.degree,
-        "depth": lambda g: depth.depth(g, parse_paths(args.paths)
-                                          if args.paths else None),
+        "depth": lambda g: depth.depth(
+            g, parse_paths(args.paths) if args.paths else None
+        ),
         "flatten": lambda g: flatten.flatten(g, f"{args.graph[:-4]}.og"),
         "matrix": matrix.matrix,
         "overlap": lambda g: overlap.overlap(g, parse_paths(args.paths)),

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -142,12 +142,9 @@ def parse_bedfile(filename: str) -> List[mygfa.Bed]:
     return [mygfa.Bed.parse(line) for line in (mygfa.nonblanks(bedfile))]
 
 
-def parse_paths(filename: Optional[str]) -> List[str]:
+def parse_paths(filename: str) -> List[str]:
     """Parse path names from a file."""
-    if filename:
-        return list(mygfa.nonblanks(open(filename, "r", encoding="utf-8")))
-    else:
-        return None
+    return list(mygfa.nonblanks(open(filename, "r", encoding="utf-8")))
 
 
 def dispatch(args: argparse.Namespace) -> None:
@@ -169,7 +166,8 @@ def dispatch(args: argparse.Namespace) -> None:
     # Other functions, which typically print their own output.
     other_funcs: Dict[str, Callable[[mygfa.Graph], object]] = {
         "degree": degree.degree,
-        "depth": lambda g: depth.depth(g, parse_paths(args.paths)),
+        "depth": lambda g: depth.depth(g, parse_paths(args.paths)
+                                          if args.paths else None),
         "flatten": lambda g: flatten.flatten(g, f"{args.graph[:-4]}.og"),
         "matrix": matrix.matrix,
         "overlap": lambda g: overlap.overlap(g, parse_paths(args.paths)),

--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 import io
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 from collections.abc import Callable
 from mygfa import mygfa
 
@@ -58,9 +58,8 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     )
     depth_parser.add_argument(
         "--paths",
-        nargs="?",
         help="A file describing the paths you wish to query.",
-        required=True,
+        required=False,
     )
 
     subparsers.add_parser(
@@ -143,9 +142,12 @@ def parse_bedfile(filename: str) -> List[mygfa.Bed]:
     return [mygfa.Bed.parse(line) for line in (mygfa.nonblanks(bedfile))]
 
 
-def parse_paths(filename: str) -> List[str]:
+def parse_paths(filename: Optional[str]) -> List[str]:
     """Parse path names from a file."""
-    return list(mygfa.nonblanks(open(filename, "r", encoding="utf-8")))
+    if filename:
+        return list(mygfa.nonblanks(open(filename, "r", encoding="utf-8")))
+    else:
+        return None
 
 
 def dispatch(args: argparse.Namespace) -> None:

--- a/slow_odgi/slow_odgi/depth.py
+++ b/slow_odgi/slow_odgi/depth.py
@@ -8,7 +8,8 @@ def depth(graph: mygfa.Graph, inputpaths: List[str]) -> mygfa.Graph:
     for seg, crossings in preprocess.node_steps(graph).items():
         # Each crossing is a (path name, index on path, direction) tuple.
         # We only want to count crossings that are on input paths.
-        crossings = [c for c in crossings if c[0] in inputpaths]
+        crossings = [c for c in crossings
+                     if inputpaths is None or c[0] in inputpaths]
         # For depth.uniq, we need to know how many unique path-names there are.
         uniq_path_names = set(c[0] for c in crossings)
         print("\t".join([seg, str(len(crossings)), str(len(uniq_path_names))]))

--- a/slow_odgi/slow_odgi/depth.py
+++ b/slow_odgi/slow_odgi/depth.py
@@ -8,8 +8,7 @@ def depth(graph: mygfa.Graph, inputpaths: Optional[List[str]]) -> mygfa.Graph:
     for seg, crossings in preprocess.node_steps(graph).items():
         # Each crossing is a (path name, index on path, direction) tuple.
         # We only want to count crossings that are on input paths.
-        crossings = [c for c in crossings
-                     if inputpaths is None or c[0] in inputpaths]
+        crossings = [c for c in crossings if inputpaths is None or c[0] in inputpaths]
         # For depth.uniq, we need to know how many unique path-names there are.
         uniq_path_names = set(c[0] for c in crossings)
         print("\t".join([seg, str(len(crossings)), str(len(uniq_path_names))]))

--- a/slow_odgi/slow_odgi/depth.py
+++ b/slow_odgi/slow_odgi/depth.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import List, Optional
 from mygfa import mygfa, preprocess
 
 
-def depth(graph: mygfa.Graph, inputpaths: List[str]) -> mygfa.Graph:
+def depth(graph: mygfa.Graph, inputpaths: Optional[List[str]]) -> mygfa.Graph:
     """The depth of a node is the cardinality of node_step for that node."""
     print("\t".join(["#node.id", "depth", "depth.uniq"]))
     for seg, crossings in preprocess.node_steps(graph).items():

--- a/slow_odgi/slow_odgi/overlap.py
+++ b/slow_odgi/slow_odgi/overlap.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from mygfa import mygfa, preprocess
 
 


### PR DESCRIPTION
For no particular reason, I noticed that `slow_odgi depth` was requiring you to specify a subset of the paths. The real `odgi` command doesn't require a `--paths` list, so let's not require one either.