### PR TITLE
polbin: Actually dump FlatGFA binary files

### DIFF
--- a/polbin/Cargo.lock
+++ b/polbin/Cargo.lock
@@ -18,6 +18,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +233,7 @@ dependencies = [
 name = "polbin"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "bstr 1.9.1",
  "gfa",
  "memmap",

--- a/polbin/Cargo.toml
+++ b/polbin/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+argh = "0.1.12"
 bstr = "1.9.1"
 gfa = "0.10.1"
 memmap = "0.7.0"

--- a/polbin/src/file.rs
+++ b/polbin/src/file.rs
@@ -2,12 +2,12 @@ use crate::flatgfa;
 use std::mem::{size_of, size_of_val};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
-const MAGIC_NUMBER: usize = 0x1337_4915;
+const MAGIC_NUMBER: u64 = 0xB101_1054;
 
 #[derive(FromBytes, FromZeroes, AsBytes)]
 #[repr(packed)]
 struct TOC {
-    magic: usize,
+    magic: u64,
     header_len: usize,
     segs_count: usize,
     paths_count: usize,

--- a/polbin/src/file.rs
+++ b/polbin/src/file.rs
@@ -1,9 +1,10 @@
 use crate::flatgfa;
-use zerocopy::{FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 const MAGIC_NUMBER: usize = 0x1337_4915;
 
-#[derive(FromBytes, FromZeroes)]
+#[derive(FromBytes, FromZeroes, AsBytes)]
+#[repr(packed)]
 struct TOC {
     magic: usize,
     header_len: usize,
@@ -25,11 +26,13 @@ fn get_prefix(data: &[u8], len: usize) -> (&[u8], &[u8]) {
     (&data[0..len], &data[len..])
 }
 
+/// Get a FlatGFA backed by the data in a byte buffer.
 pub fn view(data: &[u8]) -> flatgfa::FlatGFA {
     // Table of contents.
     let toc = TOC::ref_from_prefix(data).unwrap();
     let rest = &data[std::mem::size_of::<TOC>()..];
-    assert_eq!(toc.magic, MAGIC_NUMBER);
+    let magic = toc.magic;
+    assert_eq!(magic, MAGIC_NUMBER);
 
     // Get slices for each chunk.
     let (header, rest) = get_prefix(rest, toc.header_len);
@@ -57,4 +60,49 @@ pub fn view(data: &[u8]) -> flatgfa::FlatGFA {
         optional_data: optional_data.into(),
         line_order,
     }
+}
+
+fn write_bump<'a, 'b, T: AsBytes + ?Sized>(buf: &'a mut [u8], data: &'b T) -> Option<&'a mut [u8]> {
+    let len = std::mem::size_of_val(data);
+    data.write_to_prefix(buf)?;
+    Some(&mut buf[len..])
+}
+
+fn write_bytes<'a, 'b>(buf: &'a mut [u8], data: &'b [u8]) -> Option<&'a mut [u8]> {
+    let len = data.len();
+    buf[0..len].copy_from_slice(data);
+    Some(&mut buf[len..])
+}
+
+/// Copy a FlatGFA into a byte buffer.
+pub fn dump(gfa: &flatgfa::FlatGFA, buf: &mut [u8]) {
+    // Table of contents.
+    let toc = TOC {
+        magic: MAGIC_NUMBER,
+        header_len: gfa.header.len(),
+        segs_count: gfa.segs.len(),
+        paths_count: gfa.paths.len(),
+        links_count: gfa.links.len(),
+        steps_count: gfa.steps.len(),
+        seq_data_len: gfa.seq_data.len(),
+        overlaps_count: gfa.overlaps.len(),
+        alignment_count: gfa.alignment.len(),
+        name_data_len: gfa.name_data.len(),
+        optional_data_len: gfa.optional_data.len(),
+        line_order_len: gfa.line_order.len(),
+    };
+    let rest = write_bump(buf, &toc).unwrap();
+
+    // All the slices.
+    let rest = write_bytes(rest, gfa.header).unwrap();
+    let rest = write_bump(rest, gfa.segs).unwrap();
+    let rest = write_bump(rest, gfa.paths).unwrap();
+    let rest = write_bump(rest, gfa.links).unwrap();
+    let rest = write_bump(rest, gfa.steps).unwrap();
+    let rest = write_bytes(rest, gfa.seq_data).unwrap();
+    let rest = write_bump(rest, gfa.overlaps).unwrap();
+    let rest = write_bump(rest, gfa.alignment).unwrap();
+    let rest = write_bytes(rest, gfa.name_data).unwrap();
+    let rest = write_bytes(rest, gfa.optional_data).unwrap();
+    write_bytes(rest, gfa.line_order).unwrap();
 }

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -138,7 +138,7 @@ pub enum Orientation {
 /// So, logically, it consists of a pair of a segment reference (usize) and an
 /// orientation (1 bit). We pack the two values into a single word.
 #[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy)]
-#[repr(transparent)]
+#[repr(packed)]
 pub struct Handle(usize);
 
 impl Handle {
@@ -176,7 +176,7 @@ pub enum AlignOpcode {
 /// Logically, this is a pair of a number and an `AlignOpcode`. We pack the two
 /// into a single u32.
 #[derive(Debug, FromZeroes, FromBytes, AsBytes)]
-#[repr(transparent)]
+#[repr(packed)]
 pub struct AlignOp(u32);
 
 impl AlignOp {

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -1,6 +1,6 @@
 use bstr::{BStr, BString};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use zerocopy::{FromBytes, FromZeroes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// An efficient flattened representation of a GFA file.
 ///
@@ -65,22 +65,23 @@ pub struct FlatGFA<'a> {
 /// useful for creating new ones from scratch.
 #[derive(Default)]
 pub struct FlatGFAStore {
-    header: BString,
-    segs: Vec<Segment>,
-    paths: Vec<Path>,
-    links: Vec<Link>,
-    steps: Vec<Handle>,
-    seq_data: Vec<u8>,
-    overlaps: Vec<Span>,
-    alignment: Vec<AlignOp>,
-    name_data: BString,
-    optional_data: BString,
-    line_order: Vec<u8>,
+    pub header: BString,
+    pub segs: Vec<Segment>,
+    pub paths: Vec<Path>,
+    pub links: Vec<Link>,
+    pub steps: Vec<Handle>,
+    pub seq_data: Vec<u8>,
+    pub overlaps: Vec<Span>,
+    pub alignment: Vec<AlignOp>,
+    pub name_data: BString,
+    pub optional_data: BString,
+    pub line_order: Vec<u8>,
 }
 
 /// GFA graphs consist of "segment" nodes, which are fragments of base-pair sequences
 /// that can be strung together into paths.
-#[derive(Debug, FromZeroes, FromBytes)]
+#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[repr(packed)]
 pub struct Segment {
     /// The segment's name. We assume all names are just plain numbers.
     pub name: usize,
@@ -93,7 +94,8 @@ pub struct Segment {
 }
 
 /// A path is a sequence of oriented references to segments.
-#[derive(Debug, FromZeroes, FromBytes)]
+#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[repr(packed)]
 pub struct Path {
     /// The path's name. This can be an arbitrary string. It is a renge in the
     /// `name_data` pool.
@@ -108,7 +110,8 @@ pub struct Path {
 }
 
 /// An allowed edge between two oriented segments.
-#[derive(Debug, FromBytes, FromZeroes)]
+#[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy)]
+#[repr(packed)]
 pub struct Link {
     /// The source of the edge.
     pub from: Handle,
@@ -134,7 +137,8 @@ pub enum Orientation {
 /// A Handle refers to the forward (+) or backward (-) orientation for a given segment.
 /// So, logically, it consists of a pair of a segment reference (usize) and an
 /// orientation (1 bit). We pack the two values into a single word.
-#[derive(Debug, FromBytes, FromZeroes)]
+#[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy)]
+#[repr(transparent)]
 pub struct Handle(usize);
 
 impl Handle {
@@ -171,7 +175,8 @@ pub enum AlignOpcode {
 ///
 /// Logically, this is a pair of a number and an `AlignOpcode`. We pack the two
 /// into a single u32.
-#[derive(Debug, FromZeroes, FromBytes)]
+#[derive(Debug, FromZeroes, FromBytes, AsBytes)]
+#[repr(transparent)]
 pub struct AlignOp(u32);
 
 impl AlignOp {
@@ -216,7 +221,8 @@ pub enum LineKind {
 ///
 /// TODO: Consider smaller indices for this, and possibly base/offset instead
 /// of start/end.
-#[derive(Debug, FromZeroes, FromBytes)]
+#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[repr(packed)]
 pub struct Span {
     pub start: usize,
     pub end: usize,

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -10,14 +10,14 @@ fn map_file(name: &str) -> Mmap {
     unsafe { Mmap::map(&file) }.unwrap()
 }
 
-fn map_file_mut(name: &str) -> MmapMut {
+fn map_file_mut(name: &str, size: u64) -> MmapMut {
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .open(name)
         .unwrap();
-    file.set_len(8092).unwrap(); // TODO Estimate the size?
+    file.set_len(size).unwrap();
     unsafe { MmapMut::map_mut(&file) }.unwrap()
 }
 
@@ -54,8 +54,9 @@ fn main() {
     // Write the output to a file (binary) or stdout (text).
     match args.output {
         Some(name) => {
-            let mut mmap = map_file_mut(&name);
+            let mut mmap = map_file_mut(&name, file::size(&gfa) as u64);
             file::dump(&gfa, &mut mmap);
+            mmap.flush().unwrap();
         }
         None => print::print(&gfa),
     }

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -2,6 +2,7 @@ mod file;
 mod flatgfa;
 mod parse;
 mod print;
+use argh::FromArgs;
 use memmap::{Mmap, MmapMut};
 
 fn map_file(name: &str) -> Mmap {
@@ -20,20 +21,42 @@ fn map_file_mut(name: &str) -> MmapMut {
     unsafe { MmapMut::map_mut(&file) }.unwrap()
 }
 
-fn main() {
-    // Read either GFA text from stdin or a binary file from the first argument.
-    if let Some(name) = std::env::args().nth(1) {
-        let mmap = map_file(&name);
-        let gfa = file::view(&mmap);
-        print::print(&gfa);
-    } else {
-        let stdin = std::io::stdin();
-        let store = parse::Parser::parse(stdin.lock());
-        let gfa = store.view();
-        print::print(&gfa);
+#[derive(FromArgs)]
+/// Convert between GFA text and FlatGFA binary formats.
+struct PolBin {
+    /// read from a binary FlatGFA file
+    #[argh(option, short = 'i')]
+    input: Option<String>,
 
-        // TODO Just try dumping to a file.
-        let mut mmap = map_file_mut("hello.flatgfa");
-        file::dump(&gfa, &mut mmap);
+    /// write to a binary FlatGFA file
+    #[argh(option, short = 'o')]
+    output: Option<String>,
+}
+
+fn main() {
+    let args: PolBin = argh::from_env();
+
+    // Load the input from a file (binary) or stdin (text).
+    let mmap;
+    let store;
+    let gfa = match args.input {
+        Some(name) => {
+            mmap = map_file(&name);
+            file::view(&mmap)
+        }
+        None => {
+            let stdin = std::io::stdin();
+            store = parse::Parser::parse(stdin.lock());
+            store.view()
+        }
+    };
+
+    // Write the output to a file (binary) or stdout (text).
+    match args.output {
+        Some(name) => {
+            let mut mmap = map_file_mut(&name);
+            file::dump(&gfa, &mut mmap);
+        }
+        None => print::print(&gfa),
     }
 }

--- a/polbin/src/print.rs
+++ b/polbin/src/print.rs
@@ -31,8 +31,9 @@ impl<'a> fmt::Display for flatgfa::Alignment<'a> {
 }
 
 fn print_step(gfa: &flatgfa::FlatGFA, handle: &flatgfa::Handle) {
-    let seg = &gfa.segs[handle.segment()];
-    print!("{}{}", seg.name, handle.orient());
+    let seg = gfa.segs[handle.segment()];
+    let name = seg.name;
+    print!("{}{}", name, handle.orient());
 }
 
 fn print_path(gfa: &flatgfa::FlatGFA, path: &flatgfa::Path) {
@@ -57,18 +58,23 @@ fn print_path(gfa: &flatgfa::FlatGFA, path: &flatgfa::Path) {
 }
 
 fn print_link(gfa: &flatgfa::FlatGFA, link: &flatgfa::Link) {
+    let from = link.from;
+    let from_name = gfa.segs[from.segment()].name;
+    let to = link.to;
+    let to_name = gfa.segs[to.segment()].name;
     println!(
         "L\t{}\t{}\t{}\t{}\t{}",
-        gfa.segs[link.from.segment()].name,
-        link.from.orient(),
-        gfa.segs[link.to.segment()].name,
-        link.to.orient(),
+        from_name,
+        from.orient(),
+        to_name,
+        to.orient(),
         gfa.get_alignment(&link.overlap)
     );
 }
 
 fn print_seg(gfa: &flatgfa::FlatGFA, seg: &flatgfa::Segment) {
-    print!("S\t{}\t{}", seg.name, gfa.get_seq(seg));
+    let name = seg.name;
+    print!("S\t{}\t{}", name, gfa.get_seq(seg));
     if !seg.optional.is_empty() {
         print!("\t{}", gfa.get_optional_data(seg));
     }

--- a/tests/turnt.toml
+++ b/tests/turnt.toml
@@ -159,6 +159,10 @@ binary = true
 command = "pollen_data_gen simple {filename} | jq .depth"
 output.json = "-"
 
-[envs.polbin_roundtrip]
+[envs.polbin_mem]
 command = "../polbin/target/debug/polbin < {filename}"
+output.gfa = "-"
+
+[envs.polbin_file]
+command = "../polbin/target/debug/polbin < {filename} -o {base}.flatgfa ; ../polbin/target/debug/polbin -i {base}.flatgfa"
 output.gfa = "-"


### PR DESCRIPTION
Now the `polbin` binary can both read and write two formats: text GFA files and "FlatGFA" binary files. So these four commands are possible:

```sh
$ polbin < something.gfa  # round trip through in-memory FlatGFA, print GFA to stdout
$ polbin -o cool.flatgfa < something.gfa  # convert GFA to FlatGFA
$ polbin -i cool.flatgfa  # print a FlatGFA file out as plain ol GFA, to stdout
$ polbin -i cool.flatgfa -o ice_cold.flatgfa  # glorified `cp`, no reason to do this
```

I also added test environments to check both kinds of round-tripping (through in-memory FlatGFA and through an on-disk file). It all works!!!!!

```
$ turnt -j -e polbin_mem -e polbin_file *.gfa
1..16
ok 1 - DRB1-3123.gfa polbin_mem
ok 2 - DRB1-3123.gfa polbin_file
ok 3 - LPA.gfa polbin_mem
ok 4 - LPA.gfa polbin_file
ok 5 - chr6.C4.gfa polbin_mem
ok 6 - chr6.C4.gfa polbin_file
ok 7 - k.gfa polbin_mem
ok 8 - k.gfa polbin_file
ok 9 - note5.gfa polbin_mem
ok 10 - note5.gfa polbin_file
ok 11 - overlap.gfa polbin_mem
ok 12 - overlap.gfa polbin_file
ok 13 - q.chop.gfa polbin_mem
ok 14 - q.chop.gfa polbin_file
ok 15 - t.gfa polbin_mem
ok 16 - t.gfa polbin_file
```

Conversion seems to be decently fast on these small examples. For our go-to big example, `chr8.pan.gfa` (4.2 GB), one run of conversion on my rapidly aging Intel iMac took 1m8s for parsing (GFA -> FlatGFA) and 1m44s for pretty-printing (FlatGFA -> GFA). Seems within the ballpark of reasonableness? (Moreover, the GFA seems to have round-tripped successfully. FWIW, just running `diff` to check took 22s.)