### PR TITLE
FlatGFA: Optimize GFA parsing a bit

### DIFF
--- a/polbin/Cargo.toml
+++ b/polbin/Cargo.toml
@@ -10,3 +10,7 @@ gfa = "0.10.1"
 memmap = "0.7.0"
 num_enum = "0.7.2"
 zerocopy = { version = "0.7.32", features = ["derive"] }
+
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -306,7 +306,7 @@ impl FlatGFAStore {
     pub fn add_path(
         &mut self,
         name: Vec<u8>,
-        steps: Vec<Handle>,
+        steps: impl Iterator<Item = Handle>,
         overlaps: Vec<Vec<AlignOp>>,
     ) -> usize {
         let overlaps = pool_extend(

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -139,19 +139,19 @@ pub enum Orientation {
 /// orientation (1 bit). We pack the two values into a single word.
 #[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy)]
 #[repr(packed)]
-pub struct Handle(usize);
+pub struct Handle(u32);
 
 impl Handle {
     /// Create a new handle referring to a segment ID and an orientation.
-    pub fn new(segment: usize, orient: Orientation) -> Self {
-        assert!(segment & (1 << (usize::BITS - 1)) == 0, "index too large");
+    pub fn new(segment: Index, orient: Orientation) -> Self {
+        assert!(segment & (1 << (u32::BITS - 1)) == 0, "index too large");
         let orient_bit: u8 = orient.into();
         assert!(orient_bit & !1 == 0, "invalid orientation");
-        Self(segment << 1 | (orient_bit as usize))
+        Self(segment << 1 | (orient_bit as u32))
     }
 
     /// Get the segment ID. This is an index in the `segs` pool.
-    pub fn segment(&self) -> usize {
+    pub fn segment(&self) -> Index {
         self.0 >> 1
     }
 
@@ -217,6 +217,11 @@ pub enum LineKind {
     Link,
 }
 
+/// An index into a pool.
+///
+/// TODO: Consider using newtypes for each distinct type.
+type Index = u32;
+
 /// A range of indices into a pool.
 ///
 /// TODO: Consider smaller indices for this, and possibly base/offset instead
@@ -224,13 +229,13 @@ pub enum LineKind {
 #[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
 #[repr(packed)]
 pub struct Span {
-    pub start: usize,
-    pub end: usize,
+    pub start: Index,
+    pub end: Index,
 }
 
 impl From<Span> for std::ops::Range<usize> {
     fn from(span: Span) -> std::ops::Range<usize> {
-        span.start..span.end
+        (span.start as usize)..(span.end as usize)
     }
 }
 
@@ -240,7 +245,7 @@ impl Span {
     }
 
     pub fn range(&self) -> std::ops::Range<usize> {
-        self.start..self.end
+        (*self).into()
     }
 }
 
@@ -263,6 +268,11 @@ impl<'a> FlatGFA<'a> {
     /// Get the string name of a path.
     pub fn get_path_name(&self, path: &Path) -> &BStr {
         self.name_data[path.name.range()].as_ref()
+    }
+
+    /// Get a handle's associated segment.
+    pub fn get_handle_seg(&self, handle: Handle) -> &Segment {
+        &self.segs[handle.segment() as usize]
     }
 
     /// Get the optional data for a segment, as a tab-separated string.
@@ -291,7 +301,7 @@ impl FlatGFAStore {
     }
 
     /// Add a new segment to the GFA file.
-    pub fn add_seg(&mut self, name: usize, seq: Vec<u8>, optional: Vec<u8>) -> usize {
+    pub fn add_seg(&mut self, name: usize, seq: Vec<u8>, optional: Vec<u8>) -> Index {
         pool_push(
             &mut self.segs,
             Segment {
@@ -308,7 +318,7 @@ impl FlatGFAStore {
         name: Vec<u8>,
         steps: impl Iterator<Item = Handle>,
         overlaps: impl Iterator<Item = Vec<AlignOp>>,
-    ) -> usize {
+    ) -> Index {
         let overlaps = pool_extend(
             &mut self.overlaps,
             overlaps
@@ -327,7 +337,7 @@ impl FlatGFAStore {
     }
 
     /// Add a link between two (oriented) segments.
-    pub fn add_link(&mut self, from: Handle, to: Handle, overlap: Vec<AlignOp>) -> usize {
+    pub fn add_link(&mut self, from: Handle, to: Handle, overlap: Vec<AlignOp>) -> Index {
         pool_push(
             &mut self.links,
             Link {
@@ -362,8 +372,8 @@ impl FlatGFAStore {
 }
 
 /// Add an item to a "pool" vector and get the new index (ID).
-fn pool_push<T>(vec: &mut Vec<T>, item: T) -> usize {
-    let len = vec.len();
+fn pool_push<T>(vec: &mut Vec<T>, item: T) -> Index {
+    let len: u32 = vec.len().try_into().expect("size too large");
     vec.push(item);
     len
 }
@@ -371,10 +381,10 @@ fn pool_push<T>(vec: &mut Vec<T>, item: T) -> usize {
 /// Add an entire sequence of items to a "pool" vector and return the
 /// range of new indices (IDs).
 fn pool_extend<T>(vec: &mut Vec<T>, iter: impl IntoIterator<Item = T>) -> Span {
-    let old_len = vec.len();
+    let old_len: u32 = vec.len().try_into().expect("old size too large");
     vec.extend(iter);
     Span {
         start: old_len,
-        end: vec.len(),
+        end: vec.len().try_into().expect("new size too large"),
     }
 }

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -307,7 +307,7 @@ impl FlatGFAStore {
         &mut self,
         name: Vec<u8>,
         steps: impl Iterator<Item = Handle>,
-        overlaps: Vec<Vec<AlignOp>>,
+        overlaps: impl Iterator<Item = Vec<AlignOp>>,
     ) -> usize {
         let overlaps = pool_extend(
             &mut self.overlaps,

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -43,7 +43,7 @@ pub struct Parser {
     flat: FlatGFAStore,
 
     // Track the segment IDs by their name, which we need to refer to segments in paths.
-    segs_by_name: HashMap<usize, usize>,
+    segs_by_name: HashMap<usize, u32>,
 
     links: Vec<gfa::gfa::Link<usize, OptFields>>,
     paths: Vec<gfa::gfa::Path<usize, OptFields>>,

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -124,8 +124,7 @@ impl Parser {
                             Orientation::Backward
                         },
                     )
-                })
-                .collect();
+                });
 
             // When the overlaps section is just `*`, the rs-gfa library produces a
             // vector like `[None]`. I'm not sure if we really need to handle `None`

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -130,17 +130,15 @@ impl Parser {
             // vector like `[None]`. I'm not sure if we really need to handle `None`
             // otherwise: all the real data I've seen either has *real* overlaps or
             // is just `*`.
-            let overlaps: Vec<Vec<_>> = if path.overlaps.len() == 1 && path.overlaps[0].is_none() {
+            let overlaps = if path.overlaps.len() == 1 && path.overlaps[0].is_none() {
                 vec![]
             } else {
                 path.overlaps
-                    .iter()
-                    .map(|o| match o {
-                        Some(c) => convert_cigar(c),
-                        None => unimplemented!(),
-                    })
-                    .collect()
             };
+            let overlaps = overlaps.iter().map(|o| match o {
+                Some(c) => convert_cigar(c),
+                None => unimplemented!(),
+            });
 
             self.flat.add_path(path.path_name, steps, overlaps);
         }

--- a/polbin/src/print.rs
+++ b/polbin/src/print.rs
@@ -30,8 +30,8 @@ impl<'a> fmt::Display for flatgfa::Alignment<'a> {
     }
 }
 
-fn print_step(gfa: &flatgfa::FlatGFA, handle: &flatgfa::Handle) {
-    let seg = gfa.segs[handle.segment()];
+fn print_step(gfa: &flatgfa::FlatGFA, handle: flatgfa::Handle) {
+    let seg = gfa.get_handle_seg(handle);
     let name = seg.name;
     print!("{}{}", name, handle.orient());
 }
@@ -39,10 +39,10 @@ fn print_step(gfa: &flatgfa::FlatGFA, handle: &flatgfa::Handle) {
 fn print_path(gfa: &flatgfa::FlatGFA, path: &flatgfa::Path) {
     print!("P\t{}\t", gfa.get_path_name(path));
     let steps = gfa.get_steps(path);
-    print_step(gfa, &steps[0]);
+    print_step(gfa, steps[0]);
     for step in steps[1..].iter() {
         print!(",");
-        print_step(gfa, step);
+        print_step(gfa, *step);
     }
     print!("\t");
     let overlaps = gfa.get_overlaps(path);
@@ -59,9 +59,9 @@ fn print_path(gfa: &flatgfa::FlatGFA, path: &flatgfa::Path) {
 
 fn print_link(gfa: &flatgfa::FlatGFA, link: &flatgfa::Link) {
     let from = link.from;
-    let from_name = gfa.segs[from.segment()].name;
+    let from_name = gfa.get_handle_seg(from).name;
     let to = link.to;
-    let to_name = gfa.segs[to.segment()].name;
+    let to_name = gfa.get_handle_seg(to).name;
     println!(
         "L\t{}\t{}\t{}\t{}\t{}",
         from_name,


### PR DESCRIPTION
A bunch of little optimizations guided by some profiling, all for the parsing part of polbin.

I used two [human pangenome GFAs](https://github.com/human-pangenomics/hpp_pangenome_resources) to measure stuff. Measured on havarti (reporting times to convert GFA -> FlatGFA):

|  | chr22 | chr8 |
|--|-------|------|
| original GFA size | 2.4 GB | 3.9 GB |
| FlatGA size | 1.5 GB | 2.1 GB |
| before time | 28s | 49s |
| after time | 13s | 18s |

So that's a 2.2x and 2.7x speedup for the two input graphs, respectively.

Optimizations included:

* Getting rid of some `collect`s to avoid allocating vectors.
* Replacing `usize` IDs with `u32` IDs.
* The big one: optimizing for the (apparently common) case when segment names are sequential numbers, avoiding a hash table that was previously required to look up IDs by name.

Next steps would be:

* Roll my own (regex-free) GFA parser.
* Avoid the memcpy stage by pre-allocating big slabs of memory and parsing directly into there. Requires estimating the sizes of things, which seems hard?
* Something about how weirdly large the "path steps" parser looms in the time profile??