### PR TITLE
FlatGFA: Hand-rolled GFA parser

### DIFF
--- a/polbin/Cargo.lock
+++ b/polbin/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "anyhow"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
-
-[[package]]
 name = "argh"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,27 +34,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "bstr"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,64 +45,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "gfa"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9632601a032d2ae43f5050b454dd27c2add69b2e52bd46a4888f3aeb6e3629f5"
-dependencies = [
- "anyhow",
- "bstr 0.2.17",
- "bytemuck",
- "fnv",
- "lazy_static",
- "memmap",
- "nom",
- "regex",
-]
 
 [[package]]
 name = "hashbrown"
@@ -154,25 +70,6 @@ checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -195,17 +92,6 @@ checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -234,8 +120,7 @@ name = "polbin"
 version = "0.1.0"
 dependencies = [
  "argh",
- "bstr 1.9.1",
- "gfa",
+ "bstr",
  "memmap",
  "num_enum",
  "zerocopy",
@@ -269,39 +154,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "ryu"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "serde"
@@ -322,12 +178,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -362,12 +212,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/polbin/Cargo.toml
+++ b/polbin/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 argh = "0.1.12"
 bstr = "1.9.1"
-gfa = "0.10.1"
 memmap = "0.7.0"
 num_enum = "0.7.2"
 zerocopy = { version = "0.7.32", features = ["derive"] }

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -301,13 +301,13 @@ impl FlatGFAStore {
     }
 
     /// Add a new segment to the GFA file.
-    pub fn add_seg(&mut self, name: usize, seq: Vec<u8>, optional: Vec<u8>) -> Index {
+    pub fn add_seg(&mut self, name: usize, seq: &[u8], optional: &[u8]) -> Index {
         pool_push(
             &mut self.segs,
             Segment {
                 name,
-                seq: pool_extend(&mut self.seq_data, seq),
-                optional: pool_extend(&mut self.optional_data, optional),
+                seq: pool_extend_from_slice(&mut self.seq_data, seq),
+                optional: pool_extend_from_slice(&mut self.optional_data, optional),
             },
         )
     }
@@ -383,6 +383,16 @@ fn pool_push<T>(vec: &mut Vec<T>, item: T) -> Index {
 fn pool_extend<T>(vec: &mut Vec<T>, iter: impl IntoIterator<Item = T>) -> Span {
     let old_len: u32 = vec.len().try_into().expect("old size too large");
     vec.extend(iter);
+    Span {
+        start: old_len,
+        end: vec.len().try_into().expect("new size too large"),
+    }
+}
+
+/// Like `pool_extend`, but for slices.
+fn pool_extend_from_slice(vec: &mut Vec<u8>, slice: &[u8]) -> Span {
+    let old_len: u32 = vec.len().try_into().expect("old size too large");
+    vec.extend_from_slice(slice);
     Span {
         start: old_len,
         end: vec.len().try_into().expect("new size too large"),

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -315,7 +315,7 @@ impl FlatGFAStore {
     /// Add a new path.
     pub fn add_path(
         &mut self,
-        name: Vec<u8>,
+        name: &[u8],
         steps: impl Iterator<Item = Handle>,
         overlaps: impl Iterator<Item = Vec<AlignOp>>,
     ) -> Index {
@@ -326,10 +326,11 @@ impl FlatGFAStore {
                 .map(|align| pool_extend(&mut self.alignment, align)),
         );
 
+        let name = pool_extend_from_slice(&mut self.name_data, name);
         pool_push(
             &mut self.paths,
             Path {
-                name: pool_extend(&mut self.name_data, name),
+                name,
                 steps: pool_extend(&mut self.steps, steps),
                 overlaps,
             },

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -316,7 +316,7 @@ impl FlatGFAStore {
     pub fn add_path(
         &mut self,
         name: &[u8],
-        steps: impl Iterator<Item = Handle>,
+        steps: Span,
         overlaps: impl Iterator<Item = Vec<AlignOp>>,
     ) -> Index {
         let overlaps = pool_extend(
@@ -331,10 +331,15 @@ impl FlatGFAStore {
             &mut self.paths,
             Path {
                 name,
-                steps: pool_extend(&mut self.steps, steps),
+                steps,
                 overlaps,
             },
         )
+    }
+
+    /// Add a sequence of steps.
+    pub fn add_steps(&mut self, steps: impl Iterator<Item = Handle>) -> Span {
+        pool_extend(&mut self.steps, steps)
     }
 
     /// Add a link between two (oriented) segments.

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -295,7 +295,7 @@ impl<'a> FlatGFA<'a> {
 
 impl FlatGFAStore {
     /// Add a header line for the GFA file. This may only be added once.
-    pub fn add_header(&mut self, version: Vec<u8>) {
+    pub fn add_header(&mut self, version: &[u8]) {
         assert!(self.header.is_empty());
         self.header = version.into();
     }

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -146,11 +146,9 @@ fn parse_num(line: &[u8]) -> Result<(usize, &[u8]), &'static str> {
         return Err("expected number");
     }
 
-    // Convert the digits to a number.
-    // TODO could use `unsafe` here to avoid the cost of `from_utf8`...
+    // Convert the digits to a number. This is safe because we know the bytes are ASCII.
     let s = &line[0..index];
-    let num = std::str::from_utf8(s)
-        .unwrap()
+    let num = unsafe { std::str::from_utf8_unchecked(s) }
         .parse()
         .map_err(|_| "number too large")?;
 

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -210,10 +210,6 @@ fn parse_align(s: &[u8]) -> PartialParseResult<Vec<AlignOp>> {
 }
 
 /// Parse GFA paths' segment lists. These look like `1+,2-,3+`.
-///
-/// The underlying gfa-rs library does not yet parse the actual segments
-/// involved in the path. So we do it ourselves: splitting on commas and
-/// matching the direction.
 pub struct StepsParser<'a> {
     str: &'a [u8],
     index: usize,

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -1,0 +1,19 @@
+type ParseResult<'a> = Result<Line<'a>, &'static str>;
+
+pub enum Line<'a> {
+    Header { data: &'a [u8] },
+}
+
+pub fn parse_line(line: &[u8]) -> ParseResult {
+    if line.len() < 2 || line[1] != b'\t' {
+        return Err("expected marker and tab");
+    }
+    match line[0] {
+        b'H' => parse_header(&line[2..]),
+        _ => Err("unhandled line kind"),
+    }
+}
+
+fn parse_header(line: &[u8]) -> ParseResult {
+    Ok(Line::Header { data: line })
+}

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -1,14 +1,26 @@
+use crate::flatgfa::{AlignOp, Orientation};
+use gfa::cigar;
+
 type ParseResult<'a> = Result<Line<'a>, &'static str>;
 
+pub struct Segment<'a> {
+    pub name: usize,
+    pub seq: &'a [u8],
+    pub data: &'a [u8],
+}
+
+pub struct Link {
+    pub from_seg: usize,
+    pub from_orient: Orientation,
+    pub to_seg: usize,
+    pub to_orient: Orientation,
+    pub overlap: Vec<AlignOp>,
+}
+
 pub enum Line<'a> {
-    Header {
-        data: &'a [u8],
-    },
-    Segment {
-        name: usize,
-        seq: &'a [u8],
-        data: &'a [u8],
-    },
+    Header(&'a [u8]),
+    Segment(Segment<'a>),
+    Link(Link),
 }
 
 pub fn parse_line(line: &[u8]) -> ParseResult {
@@ -19,12 +31,13 @@ pub fn parse_line(line: &[u8]) -> ParseResult {
     match line[0] {
         b'H' => parse_header(rest),
         b'S' => parse_seg(rest),
+        b'L' => parse_link(rest),
         _ => Err("unhandled line kind"),
     }
 }
 
 fn parse_header(line: &[u8]) -> ParseResult {
-    Ok(Line::Header { data: line })
+    Ok(Line::Header(line))
 }
 
 fn parse_seg(line: &[u8]) -> ParseResult {
@@ -36,7 +49,29 @@ fn parse_seg(line: &[u8]) -> ParseResult {
     } else {
         parse_byte(rest, b'\t')?
     };
-    Ok(Line::Segment { name, seq, data })
+    Ok(Line::Segment(Segment { name, seq, data }))
+}
+
+fn parse_link(line: &[u8]) -> ParseResult {
+    let (from_seg, rest) = parse_num(line)?;
+    let rest = parse_byte(rest, b'\t')?;
+    let (from_orient, rest) = parse_orient(rest)?;
+    let rest = parse_byte(rest, b'\t')?;
+    let (to_seg, rest) = parse_num(rest)?;
+    let rest = parse_byte(rest, b'\t')?;
+    let (to_orient, rest) = parse_orient(rest)?;
+    let rest = parse_byte(rest, b'\t')?;
+    let (overlap, rest) = parse_field(rest)?;
+    if !rest.is_empty() {
+        return Err("expected end of line");
+    }
+    Ok(Line::Link(Link {
+        from_seg,
+        from_orient,
+        to_seg,
+        to_orient,
+        overlap: parse_cigar(overlap),
+    }))
 }
 
 fn parse_field(line: &[u8]) -> Result<(&[u8], &[u8]), &'static str> {
@@ -70,4 +105,42 @@ fn parse_num(line: &[u8]) -> Result<(usize, &[u8]), &'static str> {
         .map_err(|_| "number too large")?;
 
     Ok((num, &line[index..]))
+}
+
+fn parse_orient(line: &[u8]) -> Result<(Orientation, &[u8]), &'static str> {
+    if line.is_empty() {
+        return Err("expected orientation");
+    }
+    let orient = match line[0] {
+        b'+' => Orientation::Forward,
+        b'-' => Orientation::Backward,
+        _ => return Err("expected orient"),
+    };
+    Ok((orient, &line[1..]))
+}
+
+fn convert_align_op(c: &cigar::CIGARPair) -> AlignOp {
+    AlignOp::new(
+        match c.op() {
+            cigar::CIGAROp::M => crate::flatgfa::AlignOpcode::Match,
+            cigar::CIGAROp::N => crate::flatgfa::AlignOpcode::Gap,
+            cigar::CIGAROp::D => crate::flatgfa::AlignOpcode::Deletion,
+            cigar::CIGAROp::I => crate::flatgfa::AlignOpcode::Insertion,
+            _ => unimplemented!(),
+        },
+        c.len(),
+    )
+}
+
+/// Parse a CIGAR string.
+///
+/// TODO: This both relies on the `gfa-rs` crate and collects results into a
+/// `Vec` instead of streaming. Both could be fixed.
+fn parse_cigar(s: &[u8]) -> Vec<AlignOp> {
+    let cigar = cigar::CIGAR::from_bytestring(s).unwrap();
+    convert_cigar(&cigar)
+}
+
+pub fn convert_cigar(c: &cigar::CIGAR) -> Vec<AlignOp> {
+    c.0.iter().map(convert_align_op).collect()
 }

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -1,19 +1,73 @@
 type ParseResult<'a> = Result<Line<'a>, &'static str>;
 
 pub enum Line<'a> {
-    Header { data: &'a [u8] },
+    Header {
+        data: &'a [u8],
+    },
+    Segment {
+        name: usize,
+        seq: &'a [u8],
+        data: &'a [u8],
+    },
 }
 
 pub fn parse_line(line: &[u8]) -> ParseResult {
     if line.len() < 2 || line[1] != b'\t' {
         return Err("expected marker and tab");
     }
+    let rest = &line[2..];
     match line[0] {
-        b'H' => parse_header(&line[2..]),
+        b'H' => parse_header(rest),
+        b'S' => parse_seg(rest),
         _ => Err("unhandled line kind"),
     }
 }
 
 fn parse_header(line: &[u8]) -> ParseResult {
     Ok(Line::Header { data: line })
+}
+
+fn parse_seg(line: &[u8]) -> ParseResult {
+    let (name, rest) = parse_num(line)?;
+    let rest = parse_byte(rest, b'\t')?;
+    let (seq, rest) = parse_field(rest)?;
+    let data = if rest.is_empty() {
+        &[]
+    } else {
+        parse_byte(rest, b'\t')?
+    };
+    Ok(Line::Segment { name, seq, data })
+}
+
+fn parse_field(line: &[u8]) -> Result<(&[u8], &[u8]), &'static str> {
+    let end = line.iter().position(|&b| b == b'\t').unwrap_or(line.len());
+    Ok((&line[..end], &line[end..]))
+}
+
+fn parse_byte(s: &[u8], byte: u8) -> Result<&[u8], &'static str> {
+    if s.is_empty() || s[0] != byte {
+        return Err("expected byte");
+    }
+    Ok(&s[1..])
+}
+
+fn parse_num(line: &[u8]) -> Result<(usize, &[u8]), &'static str> {
+    // Scan for digits.
+    let mut index = 0;
+    while index < line.len() && line[index].is_ascii_digit() {
+        index += 1;
+    }
+    if index == 0 {
+        return Err("expected number");
+    }
+
+    // Convert the digits to a number.
+    // TODO could use `unsafe` here to avoid the cost of `from_utf8`...
+    let s = &line[0..index];
+    let num = std::str::from_utf8(s)
+        .unwrap()
+        .parse()
+        .map_err(|_| "number too large")?;
+
+    Ok((num, &line[index..]))
 }

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -1,5 +1,6 @@
 mod file;
 mod flatgfa;
+mod gfaline;
 mod parse;
 mod print;
 use argh::FromArgs;

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -91,13 +91,8 @@ impl Parser {
     /// resolve their segment name references.
     fn parse_line(&mut self, line: Line<usize, OptFields>, deferred: &mut Deferred) {
         match line {
-            Line::Header(_) => {
-                panic!("headers handled by hand-rolled parser");
-            }
-            Line::Segment(s) => {
-                self.flat.record_line(LineKind::Segment);
-                let seg_id = self.flat.add_seg(s.name, s.sequence, s.optional.0);
-                self.seg_ids.insert(s.name, seg_id);
+            Line::Header(_) | Line::Segment(_) => {
+                panic!("handled by hand-rolled parser");
             }
             Line::Link(l) => {
                 self.flat.record_line(LineKind::Link);
@@ -117,6 +112,11 @@ impl Parser {
             gfaline::Line::Header { data } => {
                 self.flat.record_line(LineKind::Header);
                 self.flat.add_header(data);
+            }
+            gfaline::Line::Segment { name, seq, data } => {
+                self.flat.record_line(LineKind::Segment);
+                let seg_id = self.flat.add_seg(name, seq, data);
+                self.seg_ids.insert(name, seg_id);
             }
         }
     }

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -14,7 +14,7 @@ pub struct Parser {
 /// Holds data structures that we haven't added to the flat representation yet.
 struct Deferred {
     links: Vec<gfaline::Link>,
-    paths: Vec<String>,
+    paths: Vec<Vec<u8>>,
 }
 
 impl Parser {
@@ -25,7 +25,7 @@ impl Parser {
             links: Vec::new(),
             paths: Vec::new(),
         };
-        for line in stream.lines() {
+        for line in stream.split(b'\n') {
             let line = line.unwrap();
             parser.parse_line(line, &mut deferred);
         }
@@ -37,9 +37,9 @@ impl Parser {
     /// We add *segments* to the flat representation immediately. We buffer *links* and *paths*
     /// in our internal vectors, because we must see all the segments first before we can
     /// resolve their segment name references.
-    fn parse_line(&mut self, line: String, deferred: &mut Deferred) {
+    fn parse_line(&mut self, line: Vec<u8>, deferred: &mut Deferred) {
         // Avoid parsing paths entirely for now; just preserve the entire line for later.
-        if line.as_bytes()[0] == b'P' {
+        if line[0] == b'P' {
             self.flat.record_line(LineKind::Path);
             deferred.paths.push(line);
             return;
@@ -72,9 +72,8 @@ impl Parser {
         self.flat.add_link(from, to, link.overlap);
     }
 
-    fn add_path(&mut self, line: String) {
+    fn add_path(&mut self, line: Vec<u8>) {
         // This must be a path line.
-        let line = &line.as_bytes();
         assert_eq!(&line[..2], b"P\t");
         let line = &line[2..];
 

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -1,42 +1,6 @@
 use crate::flatgfa::{AlignOp, FlatGFAStore, Handle, LineKind, Orientation};
 use crate::gfaline;
-use gfa;
 use std::collections::HashMap;
-
-/// A newtype to preserve optional fields without parsing them.
-///
-/// The underlying gfa-rs library lets you specify a type to hold optional
-/// fields. We just store a plain (byte) string.
-#[derive(Clone, Default, Debug)]
-struct OptFields(Vec<u8>);
-
-impl gfa::optfields::OptFields for OptFields {
-    fn get_field(&self, _: &[u8]) -> Option<&gfa::optfields::OptField> {
-        None
-    }
-
-    fn fields(&self) -> &[gfa::optfields::OptField] {
-        &[]
-    }
-
-    fn parse<T>(input: T) -> Self
-    where
-        T: IntoIterator,
-        T::Item: AsRef<[u8]>,
-    {
-        let mut out: Vec<u8> = vec![];
-        let mut first = true;
-        for i in input {
-            if first {
-                first = false;
-            } else {
-                out.push(b'\t');
-            }
-            out.extend(i.as_ref());
-        }
-        Self(out)
-    }
-}
 
 #[derive(Default)]
 pub struct Parser {

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -115,7 +115,7 @@ impl Parser {
     }
 
     fn add_path(&mut self, path: DeferredPath) {
-        let steps = StepsParser::new(&path.steps).map(|(name, dir)| {
+        let steps = gfaline::StepsParser::new(&path.steps).map(|(name, dir)| {
             Handle::new(
                 self.seg_ids.get(name),
                 if dir {
@@ -172,76 +172,4 @@ impl NameMap {
             self.others[&name]
         }
     }
-}
-
-/// Parse GFA paths' segment lists. These look like `1+,2-,3+`.
-///
-/// The underlying gfa-rs library does not yet parse the actual segments
-/// involved in the path. So we do it ourselves: splitting on commas and
-/// matching the direction.
-struct StepsParser<'a> {
-    str: &'a [u8],
-    index: usize,
-    state: StepsParseState,
-    seg: usize,
-}
-
-/// The parser state: we're either looking for a segment name (or a +/- terminator),
-/// or we're expecting a comma (or end of string).
-enum StepsParseState {
-    Seg,
-    Comma,
-}
-
-impl<'a> StepsParser<'a> {
-    pub fn new(str: &'a [u8]) -> Self {
-        StepsParser {
-            str,
-            index: 0,
-            state: StepsParseState::Seg,
-            seg: 0,
-        }
-    }
-}
-
-impl<'a> Iterator for StepsParser<'a> {
-    type Item = (usize, bool);
-    fn next(&mut self) -> Option<(usize, bool)> {
-        while self.index < self.str.len() {
-            // Consume one byte.
-            let byte = self.str[self.index];
-            self.index += 1;
-
-            match self.state {
-                StepsParseState::Seg => {
-                    if byte == b'+' || byte == b'-' {
-                        self.state = StepsParseState::Comma;
-                        return Some((self.seg, byte == b'+'));
-                    } else if byte.is_ascii_digit() {
-                        self.seg *= 10;
-                        self.seg += (byte - b'0') as usize;
-                    } else {
-                        panic!("unexpected character in path: {}", byte as char);
-                    }
-                }
-                StepsParseState::Comma => {
-                    if byte == b',' {
-                        self.state = StepsParseState::Seg;
-                        self.seg = 0;
-                    } else {
-                        panic!("unexpected character in path: {}", byte as char);
-                    }
-                }
-            }
-        }
-
-        None
-    }
-}
-
-#[test]
-fn test_parse_path() {
-    let str = b"1+,23-,4+";
-    let path: Vec<_> = StepsParser::new(str).collect();
-    assert_eq!(path, vec![(1, true), (23, false), (4, true)]);
 }

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -128,18 +128,16 @@ impl Parser {
     }
 
     fn add_path(&mut self, path: gfa::gfa::Path<usize, OptFields>) {
-        let steps = StepsParser::new(&path.segment_names)
-            .into_iter()
-            .map(|(name, dir)| {
-                Handle::new(
-                    self.seg_ids.get(name),
-                    if dir {
-                        Orientation::Forward
-                    } else {
-                        Orientation::Backward
-                    },
-                )
-            });
+        let steps = StepsParser::new(&path.segment_names).map(|(name, dir)| {
+            Handle::new(
+                self.seg_ids.get(name),
+                if dir {
+                    Orientation::Forward
+                } else {
+                    Orientation::Backward
+                },
+            )
+        });
 
         // When the overlaps section is just `*`, the rs-gfa library produces a
         // vector like `[None]`. I'm not sure if we really need to handle `None`

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -33,8 +33,7 @@ impl Parser {
         };
         for line in stream.lines() {
             let line = line.unwrap();
-            let gfa_line = gfaline::parse_line(line.as_ref()).unwrap();
-            parser.add_line(gfa_line, &mut deferred);
+            parser.parse_line(line, &mut deferred);
         }
         parser.finish(deferred)
     }
@@ -44,8 +43,9 @@ impl Parser {
     /// We add *segments* to the flat representation immediately. We buffer *links* and *paths*
     /// in our internal vectors, because we must see all the segments first before we can
     /// resolve their segment name references.
-    fn add_line(&mut self, line: gfaline::Line, deferred: &mut Deferred) {
-        match line {
+    fn parse_line(&mut self, line: String, deferred: &mut Deferred) {
+        let gfa_line = gfaline::parse_line(line.as_ref()).unwrap();
+        match gfa_line {
             gfaline::Line::Header(data) => {
                 self.flat.record_line(LineKind::Header);
                 self.flat.add_header(data);

--- a/polbin/src/print.rs
+++ b/polbin/src/print.rs
@@ -91,7 +91,7 @@ pub fn print(gfa: &flatgfa::FlatGFA) {
             flatgfa::LineKind::Header => {
                 let version = gfa.header;
                 assert!(!version.is_empty());
-                println!("H\tVN:Z:{}", version);
+                println!("H\t{}", version);
             }
             flatgfa::LineKind::Segment => {
                 print_seg(gfa, seg_iter.next().expect("too few segments"));


### PR DESCRIPTION
The next bottleneck in GFA parsing was the external [rs-gfa](https://github.com/chfi/rs-gfa) library. I replaced this with a hand-rolled one.

Using the same measurement setup as #153:

|  | chr22 | chr8 |
|--|-------|------|
| originally | 28s | 49s |
| after #153 | 13s | 18s |
| after this PR | 7s | 12s |

So that's another 1.9x and 1.5x speedup over the last set of optimizations, for a total of 4x speedup over the first version.

It's clear that the bottleneck now is in the `memcpy`ing to the destination files, which is also avoidable (with some compromises).