### PR TITLE
FlatGFA: Set up for in-place mutation

### DIFF
--- a/polbin/Cargo.lock
+++ b/polbin/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "bstr",
  "memmap",
  "num_enum",
+ "tinyvec",
  "zerocopy",
 ]
 
@@ -189,6 +190,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 
 [[package]]
 name = "toml_datetime"

--- a/polbin/Cargo.toml
+++ b/polbin/Cargo.toml
@@ -8,6 +8,7 @@ argh = "0.1.12"
 bstr = "1.9.1"
 memmap = "0.7.0"
 num_enum = "0.7.2"
+tinyvec = "1.6.0"
 zerocopy = { version = "0.7.32", features = ["derive"] }
 
 [profile.profiling]

--- a/polbin/src/file.rs
+++ b/polbin/src/file.rs
@@ -72,7 +72,7 @@ pub fn view(data: &[u8]) -> flatgfa::FlatGFA {
     let (line_order, _) = slice_prefix(rest, toc.line_order);
 
     flatgfa::FlatGFA {
-        header: header.into(),
+        header,
         segs,
         paths,
         links,
@@ -80,8 +80,8 @@ pub fn view(data: &[u8]) -> flatgfa::FlatGFA {
         seq_data,
         overlaps,
         alignment,
-        name_data: name_data.into(),
-        optional_data: optional_data.into(),
+        name_data,
+        optional_data,
         line_order,
     }
 }

--- a/polbin/src/file.rs
+++ b/polbin/src/file.rs
@@ -4,6 +4,7 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 const MAGIC_NUMBER: u64 = 0xB101_1054;
 
+/// A table of contents for the FlatGFA file.
 #[derive(FromBytes, FromZeroes, AsBytes)]
 #[repr(packed)]
 struct Toc {
@@ -21,10 +22,14 @@ struct Toc {
     line_order: Size,
 }
 
+/// A table-of-contents entry for a pool in the FlatGFA file.
 #[derive(FromBytes, FromZeroes, AsBytes, Clone, Copy)]
 #[repr(packed)]
 struct Size {
+    /// The number of actual elements in the pool.
     len: usize,
+
+    // The allocated space for the pool. `capacity - len` slots are "empty."
     capacity: usize,
 }
 

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -1,3 +1,4 @@
+use crate::pool::{Index, Pool, Span};
 use bstr::{BStr, BString};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
@@ -217,38 +218,6 @@ pub enum LineKind {
     Link,
 }
 
-/// An index into a pool.
-///
-/// TODO: Consider using newtypes for each distinct type.
-type Index = u32;
-
-/// A range of indices into a pool.
-///
-/// TODO: Consider smaller indices for this, and possibly base/offset instead
-/// of start/end.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
-#[repr(packed)]
-pub struct Span {
-    pub start: Index,
-    pub end: Index,
-}
-
-impl From<Span> for std::ops::Range<usize> {
-    fn from(span: Span) -> std::ops::Range<usize> {
-        (span.start as usize)..(span.end as usize)
-    }
-}
-
-impl Span {
-    pub fn is_empty(&self) -> bool {
-        self.start == self.end
-    }
-
-    pub fn range(&self) -> std::ops::Range<usize> {
-        (*self).into()
-    }
-}
-
 impl<'a> FlatGFA<'a> {
     /// Get the base-pair sequence for a segment.
     pub fn get_seq(&self, seg: &Segment) -> &BStr {
@@ -363,57 +332,5 @@ impl FlatGFAStore {
             optional_data: self.optional_data.as_ref(),
             line_order: &self.line_order,
         }
-    }
-}
-
-trait Pool<T: Clone> {
-    /// Add an item to the pool and get the new index (ID).
-    fn add(&mut self, item: T) -> Index;
-
-    /// Add an entire sequence of items to a "pool" vector and return the
-    /// range of new indices (IDs).
-    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span;
-
-    /// Like `add_iter`, but for slices.
-    fn add_slice(&mut self, slice: &[T]) -> Span;
-
-    /// Get a single element from the pool by its ID.
-    fn get(&self, index: Index) -> &T;
-
-    /// Get a range of elements from the pool using their IDs.
-    fn get_span(&self, span: Span) -> &[T];
-}
-
-impl<T: Clone> Pool<T> for Vec<T> {
-    fn add(&mut self, item: T) -> Index {
-        let len: u32 = self.len().try_into().expect("size too large");
-        self.push(item);
-        len
-    }
-
-    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span {
-        let old_len: u32 = self.len().try_into().expect("old size too large");
-        self.extend(iter);
-        Span {
-            start: old_len,
-            end: self.len().try_into().expect("new size too large"),
-        }
-    }
-
-    fn add_slice(&mut self, slice: &[T]) -> Span {
-        let old_len: u32 = self.len().try_into().expect("old size too large");
-        self.extend_from_slice(slice);
-        Span {
-            start: old_len,
-            end: self.len().try_into().expect("new size too large"),
-        }
-    }
-
-    fn get(&self, index: Index) -> &T {
-        &self[index as usize]
-    }
-
-    fn get_span(&self, span: Span) -> &[T] {
-        &self[span.range()]
     }
 }

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -246,12 +246,6 @@ pub trait PoolFamily {
     type Pool<T: Clone>: crate::pool::Pool<T>;
 }
 
-#[derive(Default)]
-pub struct VecPoolFamily;
-impl PoolFamily for VecPoolFamily {
-    type Pool<T: Clone> = Vec<T>;
-}
-
 /// The data storage pools for a `FlatGFA`.
 #[derive(Default)]
 pub struct Store<P: PoolFamily> {
@@ -339,6 +333,12 @@ impl<P: PoolFamily> Store<P> {
             line_order: self.line_order.all(),
         }
     }
+}
+
+#[derive(Default)]
+pub struct VecPoolFamily;
+impl PoolFamily for VecPoolFamily {
+    type Pool<T: Clone> = Vec<T>;
 }
 
 /// A mutable, in-memory data store for `FlatGFA`.

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -2,6 +2,7 @@ mod file;
 mod flatgfa;
 mod gfaline;
 mod parse;
+mod pool;
 mod print;
 use argh::FromArgs;
 use memmap::{Mmap, MmapMut};

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -12,7 +12,7 @@ fn map_file(name: &str) -> Mmap {
     unsafe { Mmap::map(&file) }.unwrap()
 }
 
-fn map_file_mut(name: &str, size: u64) -> MmapMut {
+fn map_new_file(name: &str, size: u64) -> MmapMut {
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -20,6 +20,15 @@ fn map_file_mut(name: &str, size: u64) -> MmapMut {
         .open(name)
         .unwrap();
     file.set_len(size).unwrap();
+    unsafe { MmapMut::map_mut(&file) }.unwrap()
+}
+
+fn map_file_mut(name: &str) -> MmapMut {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(name)
+        .unwrap();
     unsafe { MmapMut::map_mut(&file) }.unwrap()
 }
 
@@ -33,6 +42,10 @@ struct PolBin {
     /// write to a binary FlatGFA file
     #[argh(option, short = 'o')]
     output: Option<String>,
+
+    /// mutate the input file in place
+    #[argh(switch, short = 'm')]
+    mutate: bool,
 }
 
 fn main() {
@@ -40,11 +53,19 @@ fn main() {
 
     // Load the input from a file (binary) or stdin (text).
     let mmap;
+    let mut mmap_mut;
     let store;
+    let slice_store;
     let gfa = match args.input {
         Some(name) => {
-            mmap = map_file(&name);
-            file::view(&mmap)
+            if args.mutate {
+                mmap_mut = map_file_mut(&name);
+                slice_store = file::view_store(&mut mmap_mut);
+                slice_store.view()
+            } else {
+                mmap = map_file(&name);
+                file::view(&mmap)
+            }
         }
         None => {
             let stdin = std::io::stdin();
@@ -56,7 +77,7 @@ fn main() {
     // Write the output to a file (binary) or stdout (text).
     match args.output {
         Some(name) => {
-            let mut mmap = map_file_mut(&name, file::size(&gfa) as u64);
+            let mut mmap = map_new_file(&name, file::size(&gfa) as u64);
             file::dump(&gfa, &mut mmap);
             mmap.flush().unwrap();
         }

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -1,11 +1,11 @@
-use crate::flatgfa::{FlatGFAStore, Handle, LineKind, Orientation};
+use crate::flatgfa::{self, Handle, LineKind, Orientation};
 use crate::gfaline;
 use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct Parser {
     /// The flat representation we're building.
-    flat: FlatGFAStore,
+    flat: flatgfa::HeapStore,
 
     /// All segment IDs, indexed by their names, which we need to refer to segments in paths.
     seg_ids: NameMap,
@@ -19,7 +19,7 @@ struct Deferred {
 
 impl Parser {
     /// Parse a GFA text file.
-    pub fn parse<R: std::io::BufRead>(stream: R) -> FlatGFAStore {
+    pub fn parse<R: std::io::BufRead>(stream: R) -> flatgfa::HeapStore {
         let mut parser = Self::default();
         let mut deferred = Deferred {
             links: Vec::new(),
@@ -105,7 +105,7 @@ impl Parser {
     ///
     /// We "unwind" the buffers of links and paths, now that we have all
     /// the segments.
-    fn finish(mut self, deferred: Deferred) -> FlatGFAStore {
+    fn finish(mut self, deferred: Deferred) -> flatgfa::HeapStore {
         for link in deferred.links {
             self.add_link(link);
         }

--- a/polbin/src/pool.rs
+++ b/polbin/src/pool.rs
@@ -1,0 +1,85 @@
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+/// An index into a pool.
+///
+/// TODO: Consider using newtypes for each distinct type.
+pub type Index = u32;
+
+/// A range of indices into a pool.
+///
+/// TODO: Consider smaller indices for this, and possibly base/offset instead
+/// of start/end.
+#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[repr(packed)]
+pub struct Span {
+    pub start: Index,
+    pub end: Index,
+}
+
+impl From<Span> for std::ops::Range<usize> {
+    fn from(span: Span) -> std::ops::Range<usize> {
+        (span.start as usize)..(span.end as usize)
+    }
+}
+
+impl Span {
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
+    pub fn range(&self) -> std::ops::Range<usize> {
+        (*self).into()
+    }
+}
+
+pub trait Pool<T: Clone> {
+    /// Add an item to the pool and get the new index (ID).
+    fn add(&mut self, item: T) -> Index;
+
+    /// Add an entire sequence of items to a "pool" vector and return the
+    /// range of new indices (IDs).
+    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span;
+
+    /// Like `add_iter`, but for slices.
+    fn add_slice(&mut self, slice: &[T]) -> Span;
+
+    /// Get a single element from the pool by its ID.
+    fn get(&self, index: Index) -> &T;
+
+    /// Get a range of elements from the pool using their IDs.
+    fn get_span(&self, span: Span) -> &[T];
+}
+
+impl<T: Clone> Pool<T> for Vec<T> {
+    fn add(&mut self, item: T) -> Index {
+        let len: u32 = self.len().try_into().expect("size too large");
+        self.push(item);
+        len
+    }
+
+    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span {
+        let old_len: u32 = self.len().try_into().expect("old size too large");
+        self.extend(iter);
+        Span {
+            start: old_len,
+            end: self.len().try_into().expect("new size too large"),
+        }
+    }
+
+    fn add_slice(&mut self, slice: &[T]) -> Span {
+        let old_len: u32 = self.len().try_into().expect("old size too large");
+        self.extend_from_slice(slice);
+        Span {
+            start: old_len,
+            end: self.len().try_into().expect("new size too large"),
+        }
+    }
+
+    fn get(&self, index: Index) -> &T {
+        &self[index as usize]
+    }
+
+    fn get_span(&self, span: Span) -> &[T] {
+        &self[span.range()]
+    }
+}

--- a/polbin/src/pool.rs
+++ b/polbin/src/pool.rs
@@ -48,6 +48,12 @@ pub trait Pool<T: Clone> {
 
     /// Get a range of elements from the pool using their IDs.
     fn get_span(&self, span: Span) -> &[T];
+
+    /// Get the number of items in the pool.
+    fn count(&self) -> usize;
+
+    /// Get all items in the pool.
+    fn all(&self) -> &[T];
 }
 
 impl<T: Clone> Pool<T> for Vec<T> {
@@ -81,5 +87,13 @@ impl<T: Clone> Pool<T> for Vec<T> {
 
     fn get_span(&self, span: Span) -> &[T] {
         &self[span.range()]
+    }
+
+    fn count(&self) -> usize {
+        self.len()
+    }
+
+    fn all(&self) -> &[T] {
+        self
     }
 }

--- a/polbin/src/print.rs
+++ b/polbin/src/print.rs
@@ -91,7 +91,7 @@ pub fn print(gfa: &flatgfa::FlatGFA) {
             flatgfa::LineKind::Header => {
                 let version = gfa.header;
                 assert!(!version.is_empty());
-                println!("H\t{}", version);
+                println!("H\t{}", bstr::BStr::new(version));
             }
             flatgfa::LineKind::Segment => {
                 print_seg(gfa, seg_iter.next().expect("too few segments"));

--- a/tests/turnt.toml
+++ b/tests/turnt.toml
@@ -166,3 +166,7 @@ output.gfa = "-"
 [envs.polbin_file]
 command = "../polbin/target/debug/polbin < {filename} -o {base}.flatgfa ; ../polbin/target/debug/polbin -i {base}.flatgfa"
 output.gfa = "-"
+
+[envs.polbin_file_inplace]
+command = "../polbin/target/debug/polbin < {filename} -o {base}.flatgfa ; ../polbin/target/debug/polbin -m -i {base}.flatgfa"
+output.gfa = "-"


### PR DESCRIPTION
There is no actual externally useful change here, but this changes the file format to allow for "gaps," i.e., to have more space for elements in the GFA representation than we have actual values. This way, we can feasibly mutate graphs in place (adding and removing elements), up to the limit of the pre-allocated regions.

To make this work, I used the [tinyvec](https://github.com/Lokathor/tinyvec) crate's `SliceVec` type, which works like `Vec` but is backed by a fixed-size slice (which may, in our case, come from an mmap'd file). Some [type and lifetime trickery](https://rustyyato.github.io/type/system,type/families/2021/02/22/Type-Families-1_5.html) was required to make our backing stores polymorphic over whether they use `SliceVec` or `Vec`, but now they are. (The new `Pool` abstraction covers both cases.)

So far, this is hooked up for reading only. Next, I will add pre-allocated file *emission*, which will require guessing the necessary sizes.