### PR TITLE
FlatGFA: Pre-allocated writes

### DIFF
--- a/polbin/src/file.rs
+++ b/polbin/src/file.rs
@@ -54,7 +54,7 @@ impl Size {
 
 impl Toc {
     /// Get the total size in bytes of the file described.
-    fn size(&self) -> usize {
+    pub fn size(&self) -> usize {
         size_of::<Self>()
             + self.header.bytes::<u8>()
             + self.segs.bytes::<flatgfa::Segment>()
@@ -88,7 +88,7 @@ impl Toc {
     }
 
     /// Guess a reasonable set of capacities for a fresh file.
-    fn guess(factor: usize) -> Self {
+    pub fn guess(factor: usize) -> Self {
         Self {
             magic: MAGIC_NUMBER,
             header: Size::empty(128),

--- a/polbin/src/file.rs
+++ b/polbin/src/file.rs
@@ -116,16 +116,16 @@ impl Toc {
         Self {
             magic: MAGIC_NUMBER,
             header: Size::empty(128),
-            segs: Size::empty(512 * factor),
-            paths: Size::empty(16 * factor),
-            links: Size::empty(1024 * factor),
-            steps: Size::empty(512 * factor),
-            seq_data: Size::empty(4096 * factor),
-            overlaps: Size::empty(512 * factor),
-            alignment: Size::empty(1024 * factor),
+            segs: Size::empty(32 * factor * factor),
+            paths: Size::empty(factor),
+            links: Size::empty(32 * factor * factor),
+            steps: Size::empty(1024 * factor * factor),
+            seq_data: Size::empty(512 * factor * factor),
+            overlaps: Size::empty(256 * factor),
+            alignment: Size::empty(64 * factor * factor),
             name_data: Size::empty(64 * factor),
-            optional_data: Size::empty(64 * factor),
-            line_order: Size::empty(2048 * factor),
+            optional_data: Size::empty(512 * factor * factor),
+            line_order: Size::empty(64 * factor * factor),
         }
     }
 }

--- a/polbin/src/file.rs
+++ b/polbin/src/file.rs
@@ -46,6 +46,10 @@ impl Size {
     fn bytes<T>(&self) -> usize {
         self.capacity * size_of::<T>()
     }
+
+    fn empty(capacity: usize) -> Self {
+        Size { len: 0, capacity }
+    }
 }
 
 impl Toc {
@@ -67,7 +71,7 @@ impl Toc {
 
     /// Get a table of contents that fits a FlatGFA with no spare space.
     fn full(gfa: &flatgfa::FlatGFA) -> Self {
-        Toc {
+        Self {
             magic: MAGIC_NUMBER,
             header: Size::of_slice(gfa.header),
             segs: Size::of_slice(gfa.segs),
@@ -80,6 +84,24 @@ impl Toc {
             name_data: Size::of_slice(gfa.name_data),
             optional_data: Size::of_slice(gfa.optional_data),
             line_order: Size::of_slice(gfa.line_order),
+        }
+    }
+
+    /// Guess a reasonable set of capacities for a fresh file.
+    fn guess(factor: usize) -> Self {
+        Self {
+            magic: MAGIC_NUMBER,
+            header: Size::empty(128),
+            segs: Size::empty(512 * factor),
+            paths: Size::empty(16 * factor),
+            links: Size::empty(1024 * factor),
+            steps: Size::empty(512 * factor),
+            seq_data: Size::empty(4096 * factor),
+            overlaps: Size::empty(512 * factor),
+            alignment: Size::empty(1024 * factor),
+            name_data: Size::empty(64 * factor),
+            optional_data: Size::empty(64 * factor),
+            line_order: Size::empty(2048 * factor),
         }
     }
 }

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
         }
         None => {
             let stdin = std::io::stdin();
-            let parser = parse::Parser::new(flatgfa::HeapStore::default());
+            let parser = parse::heap_parser();
             store = parser.parse(stdin.lock());
             store.view()
         }

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -52,6 +52,20 @@ struct PolBin {
 fn main() {
     let args: PolBin = argh::from_env();
 
+    // A special case for converting from GFA text to an in-place FlatGFA binary.
+    if args.mutate {
+        if let (None, Some(out_name)) = (&args.input, &args.output) {
+            let stdin = std::io::stdin();
+            let toc = file::Toc::guess(5);
+            let mut mmap = map_new_file(out_name, toc.size() as u64);
+            let store = file::init(&mut mmap, toc);
+            let parser = parse::Parser::new(store);
+            parser.parse(stdin.lock());
+            mmap.flush().unwrap();
+            return;
+        }
+    }
+
     // Load the input from a file (binary) or stdin (text).
     let mmap;
     let mut mmap_mut;

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -33,6 +33,20 @@ fn map_file_mut(name: &str) -> MmapMut {
     unsafe { MmapMut::map_mut(&file) }.unwrap()
 }
 
+fn print_stats(gfa: &flatgfa::FlatGFA) {
+    eprintln!("header: {}", gfa.header.len());
+    eprintln!("segs: {}", gfa.segs.len());
+    eprintln!("paths: {}", gfa.paths.len());
+    eprintln!("links: {}", gfa.links.len());
+    eprintln!("steps: {}", gfa.steps.len());
+    eprintln!("seq_data: {}", gfa.seq_data.len());
+    eprintln!("overlaps: {}", gfa.overlaps.len());
+    eprintln!("alignment: {}", gfa.alignment.len());
+    eprintln!("name_data: {}", gfa.name_data.len());
+    eprintln!("optional_data: {}", gfa.optional_data.len());
+    eprintln!("line_order: {}", gfa.line_order.len());
+}
+
 #[derive(FromArgs)]
 /// Convert between GFA text and FlatGFA binary formats.
 struct PolBin {
@@ -47,6 +61,10 @@ struct PolBin {
     /// mutate the input file in place
     #[argh(switch, short = 'm')]
     mutate: bool,
+
+    /// print statistics about the graph
+    #[argh(switch, short = 's')]
+    stats: bool,
 }
 
 fn main() {
@@ -62,7 +80,10 @@ fn main() {
 
             // Parse the input into the file.
             let stdin = std::io::stdin();
-            parse::buf_parse(store, toc, stdin.lock());
+            let store = parse::buf_parse(store, toc, stdin.lock());
+            if args.stats {
+                print_stats(&store.view());
+            }
             mmap.flush().unwrap();
             return;
         }
@@ -90,6 +111,11 @@ fn main() {
             store.view()
         }
     };
+
+    // Perhaps print some statistics.
+    if args.stats {
+        print_stats(&gfa);
+    }
 
     // Write the output to a file (binary) or stdout (text).
     match args.output {

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -65,6 +65,10 @@ struct PolBin {
     /// print statistics about the graph
     #[argh(switch, short = 's')]
     stats: bool,
+
+    /// preallocation size factor
+    #[argh(option, short = 'p', default = "32")]
+    prealloc_factor: usize,
 }
 
 fn main() {
@@ -74,7 +78,7 @@ fn main() {
     if args.mutate {
         if let (None, Some(out_name)) = (&args.input, &args.output) {
             // Create a file with an empty table of contents.
-            let empty_toc = file::Toc::guess(5);
+            let empty_toc = file::Toc::guess(args.prealloc_factor);
             let mut mmap = map_new_file(out_name, empty_toc.size() as u64);
             let (toc, store) = file::init(&mut mmap, empty_toc);
 

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -5,6 +5,7 @@ mod parse;
 mod pool;
 mod print;
 use argh::FromArgs;
+use flatgfa::GFABuilder;
 use memmap::{Mmap, MmapMut};
 
 fn map_file(name: &str) -> Mmap {
@@ -69,7 +70,8 @@ fn main() {
         }
         None => {
             let stdin = std::io::stdin();
-            store = parse::Parser::parse(stdin.lock());
+            let parser = parse::Parser::new(flatgfa::HeapStore::default());
+            store = parser.parse(stdin.lock());
             store.view()
         }
     };

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -16,6 +16,10 @@ struct Deferred {
     paths: Vec<Vec<u8>>,
 }
 
+pub fn heap_parser() -> Parser<flatgfa::HeapStore> {
+    Parser::<flatgfa::HeapStore>::new(flatgfa::HeapStore::default())
+}
+
 impl<B: flatgfa::GFABuilder> Parser<B> {
     pub fn new(builder: B) -> Self {
         Self {

--- a/tests/turnt.toml
+++ b/tests/turnt.toml
@@ -168,5 +168,5 @@ command = "../polbin/target/debug/polbin -o {base}.flatgfa < {filename} ; ../pol
 output.gfa = "-"
 
 [envs.polbin_file_inplace]
-command = "../polbin/target/debug/polbin -o {base}.flatgfa < {filename} ; ../polbin/target/debug/polbin -m -i {base}.flatgfa"
+command = "../polbin/target/debug/polbin -m -p 128 -o {base}.inplace.flatgfa < {filename} ; ../polbin/target/debug/polbin -m -i {base}.inplace.flatgfa"
 output.gfa = "-"

--- a/tests/turnt.toml
+++ b/tests/turnt.toml
@@ -164,9 +164,9 @@ command = "../polbin/target/debug/polbin < {filename}"
 output.gfa = "-"
 
 [envs.polbin_file]
-command = "../polbin/target/debug/polbin < {filename} -o {base}.flatgfa ; ../polbin/target/debug/polbin -i {base}.flatgfa"
+command = "../polbin/target/debug/polbin -o {base}.flatgfa < {filename} ; ../polbin/target/debug/polbin -i {base}.flatgfa"
 output.gfa = "-"
 
 [envs.polbin_file_inplace]
-command = "../polbin/target/debug/polbin < {filename} -o {base}.flatgfa ; ../polbin/target/debug/polbin -m -i {base}.flatgfa"
+command = "../polbin/target/debug/polbin -o {base}.flatgfa < {filename} ; ../polbin/target/debug/polbin -m -i {base}.flatgfa"
 output.gfa = "-"


### PR DESCRIPTION
Finally, FlatGFA can pre-allocate a file to write into, and it can parse GFAs directly into this `mmap`'d region.

This currently uses the simplest possible way to decide how to pre-allocate: a heuristic guess based on a user-provided fudge factor. This wastes a lot of space, in general, and is probably not all that practical. But it does work (the tests now check that it does). But the same machinery will be useful for (a) some smarter method for predicting the output sizes, such as an initial scan before parsing, and (b) future operators that want to mutate a graph or produce a new graph.