### PR TITLE
Use the `memchr` and `atoi` crates

### DIFF
--- a/polbin/Cargo.lock
+++ b/polbin/Cargo.lock
@@ -34,6 +34,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bstr"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +144,7 @@ name = "polbin"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "atoi",
  "bstr",
  "memchr",
  "memmap",

--- a/polbin/Cargo.lock
+++ b/polbin/Cargo.lock
@@ -121,6 +121,7 @@ version = "0.1.0"
 dependencies = [
  "argh",
  "bstr",
+ "memchr",
  "memmap",
  "num_enum",
  "tinyvec",

--- a/polbin/Cargo.toml
+++ b/polbin/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 argh = "0.1.12"
+atoi = "2.0.0"
 bstr = "1.9.1"
 memchr = "2.7.1"
 memmap = "0.7.0"

--- a/polbin/Cargo.toml
+++ b/polbin/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 argh = "0.1.12"
 bstr = "1.9.1"
+memchr = "2.7.1"
 memmap = "0.7.0"
 num_enum = "0.7.2"
 tinyvec = "1.6.0"

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -241,15 +241,11 @@ impl<'a> Iterator for StepsParser<'a> {
                     if byte == b'+' || byte == b'-' {
                         self.state = StepsParseState::Comma;
                         return Some((self.seg, byte == b'+'));
+                    } else if byte.is_ascii_digit() {
+                        self.seg *= 10;
+                        self.seg += (byte - b'0') as usize;
                     } else {
-                        let rest = &self.str[self.index - 1..];
-                        match usize::from_radix_10(rest) {
-                            (_, 0) => return None,
-                            (num, used) => {
-                                self.seg = num;
-                                self.index += used - 1;
-                            }
-                        }
+                        return None;
                     }
                 }
                 StepsParseState::Comma => {

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -241,11 +241,15 @@ impl<'a> Iterator for StepsParser<'a> {
                     if byte == b'+' || byte == b'-' {
                         self.state = StepsParseState::Comma;
                         return Some((self.seg, byte == b'+'));
-                    } else if byte.is_ascii_digit() {
-                        self.seg *= 10;
-                        self.seg += (byte - b'0') as usize;
                     } else {
-                        return None;
+                        let rest = &self.str[self.index - 1..];
+                        match usize::from_radix_10(rest) {
+                            (_, 0) => return None,
+                            (num, used) => {
+                                self.seg = num;
+                                self.index += used - 1;
+                            }
+                        }
                     }
                 }
                 StepsParseState::Comma => {

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -1,4 +1,5 @@
 use crate::flatgfa::{AlignOp, Orientation};
+use memchr;
 
 type ParseResult<T> = Result<T, &'static str>;
 type LineResult<'a> = ParseResult<Line<'a>>;
@@ -126,7 +127,7 @@ fn parse_overlap_list(s: &[u8]) -> PartialParseResult<Vec<Vec<AlignOp>>> {
 
 /// Consume a chunk of a string up to a given marker byte.
 fn parse_until(line: &[u8], marker: u8) -> PartialParseResult<&[u8]> {
-    let end = line.iter().position(|&b| b == marker).unwrap_or(line.len());
+    let end = memchr::memchr(marker, line).unwrap_or(line.len());
     let rest = if end == line.len() {
         &[]
     } else {

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -1,4 +1,5 @@
 use crate::flatgfa::{AlignOp, Orientation};
+use atoi::FromRadix10;
 use memchr;
 
 type ParseResult<T> = Result<T, &'static str>;
@@ -150,23 +151,11 @@ fn parse_byte(s: &[u8], byte: u8) -> ParseResult<&[u8]> {
 }
 
 /// Parse a single integer.
-fn parse_num(line: &[u8]) -> PartialParseResult<usize> {
-    // Scan for digits.
-    let mut index = 0;
-    while index < line.len() && line[index].is_ascii_digit() {
-        index += 1;
+fn parse_num(s: &[u8]) -> PartialParseResult<usize> {
+    match usize::from_radix_10(s) {
+        (_, 0) => Err("expected number"),
+        (num, used) => Ok((num, &s[used..])),
     }
-    if index == 0 {
-        return Err("expected number");
-    }
-
-    // Convert the digits to a number. This is safe because we know the bytes are ASCII.
-    let s = &line[0..index];
-    let num = unsafe { std::str::from_utf8_unchecked(s) }
-        .parse()
-        .map_err(|_| "number too large")?;
-
-    Ok((num, &line[index..]))
 }
 
 /// Parse a segment orientation (+ or -).

--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -151,8 +151,8 @@ fn parse_byte(s: &[u8], byte: u8) -> ParseResult<&[u8]> {
 }
 
 /// Parse a single integer.
-fn parse_num(s: &[u8]) -> PartialParseResult<usize> {
-    match usize::from_radix_10(s) {
+fn parse_num<T: FromRadix10>(s: &[u8]) -> PartialParseResult<T> {
+    match T::from_radix_10(s) {
         (_, 0) => Err("expected number"),
         (num, used) => Ok((num, &s[used..])),
     }
@@ -173,8 +173,7 @@ fn parse_orient(line: &[u8]) -> PartialParseResult<Orientation> {
 
 /// Parse a single CIGAR alignment operation (like `4D`).
 fn parse_align_op(s: &[u8]) -> PartialParseResult<AlignOp> {
-    // TODO just parse a u32
-    let (len, rest) = parse_num(s)?;
+    let (len, rest) = parse_num::<u32>(s)?;
     let op = match rest[0] {
         b'M' => crate::flatgfa::AlignOpcode::Match,
         b'N' => crate::flatgfa::AlignOpcode::Gap,
@@ -182,7 +181,7 @@ fn parse_align_op(s: &[u8]) -> PartialParseResult<AlignOp> {
         b'I' => crate::flatgfa::AlignOpcode::Insertion,
         _ => return Err("expected align op"),
     };
-    Ok((AlignOp::new(op, len.try_into().unwrap()), &rest[1..]))
+    Ok((AlignOp::new(op, len), &rest[1..]))
 }
 
 /// Parse a complete CIGAR alignment string (like `3M2I`).


### PR DESCRIPTION
Some modest performance wins by adopting some extremely popular string-processing crates. The timing on havarti is now 7.0s for chr22 and 11.7s for chr8 (only a tiny bit faster than reported in #154). But I'm glad to have found `memchr`; this will be useful for other things…