### PR TITLE
FlatGFA: Load the GFA text from a file directly

### DIFF
--- a/polbin/src/gfaline.rs
+++ b/polbin/src/gfaline.rs
@@ -1,6 +1,5 @@
 use crate::flatgfa::{AlignOp, Orientation};
 use atoi::FromRadix10;
-use memchr;
 
 type ParseResult<T> = Result<T, &'static str>;
 type LineResult<'a> = ParseResult<Line<'a>>;

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -7,7 +7,6 @@ mod print;
 use argh::FromArgs;
 use flatgfa::GFABuilder;
 use memmap::{Mmap, MmapMut};
-use std::io::BufReader;
 
 fn map_file(name: &str) -> Mmap {
     let file = std::fs::File::open(name).unwrap();
@@ -90,8 +89,8 @@ fn main() {
             // Parse the input into the file.
             let store = match args.input_gfa {
                 Some(name) => {
-                    let file = std::fs::File::open(name).unwrap();
-                    parse::buf_parse(store, toc, BufReader::new(file))
+                    let file = map_file(&name);
+                    parse::buf_parse(store, toc, file.as_ref())
                 }
                 None => {
                     let stdin = std::io::stdin();
@@ -126,8 +125,8 @@ fn main() {
             // Parse from stdin or a file.
             store = match args.input_gfa {
                 Some(name) => {
-                    let file = std::fs::File::open(name).unwrap();
-                    parse::heap_parse(BufReader::new(file))
+                    let file = map_file(&name);
+                    parse::heap_parse(file.as_ref())
                 }
                 None => {
                     let stdin = std::io::stdin();

--- a/polbin/src/parse.rs
+++ b/polbin/src/parse.rs
@@ -86,7 +86,7 @@ impl<B: flatgfa::GFABuilder> Parser<B> {
             }
 
             // Actually parse other lines.
-            let gfa_line = gfaline::parse_line(line.as_ref()).unwrap();
+            let gfa_line = gfaline::parse_line(line).unwrap();
             self.record_line(&gfa_line);
             match gfa_line {
                 gfaline::Line::Header(data) => {

--- a/tests/turnt.toml
+++ b/tests/turnt.toml
@@ -168,5 +168,5 @@ command = "../polbin/target/debug/polbin -o {base}.flatgfa < {filename} ; ../pol
 output.gfa = "-"
 
 [envs.polbin_file_inplace]
-command = "../polbin/target/debug/polbin -m -p 128 -o {base}.inplace.flatgfa < {filename} ; ../polbin/target/debug/polbin -m -i {base}.inplace.flatgfa"
+command = "../polbin/target/debug/polbin -m -p 128 -o {base}.inplace.flatgfa -I {filename} ; ../polbin/target/debug/polbin -m -i {base}.inplace.flatgfa"
 output.gfa = "-"


### PR DESCRIPTION
To parse a GFA file, we previously read the text from stdin. Now, we can read from a filename passed as an argument. This can be more efficient: in particular, we now `mmap` the file and traverse it in memory. This may allow for a future preprocessing step. But for now, it also leads to some efficiency wins: we can use `memchr` to scan for lines, and we do less copying to defer paths/links for later parsing. (We can now just store pointers to where those lines are instead of storing the string itself.)

Returning to our havarti measurement table:

|  | chr22 | chr8 |
|--|-------|------|
| originally | 28s | 49s |
| after #153 | 13s | 18s |
| now, with stdin | 7.0s | 11.8s |
| now, from file | 5.6s | 9.0s |

So we're under 10 seconds on chr8 for the first time! :tada: