### PR TITLE
FlatGFA: Add an `odgi position -v` equivalent

### DIFF
--- a/polbin/src/cmds.rs
+++ b/polbin/src/cmds.rs
@@ -101,7 +101,6 @@ pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static s
         flatgfa::Orientation::Forward,
         "only + is implemented so far"
     );
-    dbg!(path_id, offset, &orientation);
 
     // Traverse the path until we reach the position.
     let mut cur_pos = 0;
@@ -122,7 +121,16 @@ pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static s
     if let Some((handle, seg_off)) = found {
         let seg = gfa.get_handle_seg(handle);
         let seg_name = seg.name;
-        println!("{},{},{}", seg_name, seg_off, handle.orient());
+        println!("#source.path.pos\ttarget.graph.pos");
+        println!(
+            "{},{},{}\t{},{},{}",
+            path_name,
+            offset,
+            orientation,
+            seg_name,
+            seg_off,
+            handle.orient()
+        );
     }
 
     Ok(())

--- a/polbin/src/cmds.rs
+++ b/polbin/src/cmds.rs
@@ -73,6 +73,32 @@ pub fn stats(gfa: &flatgfa::FlatGFA, args: Stats) {
     }
 }
 
+/// find a nucleotide position within a path
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "position")]
+pub struct Position {
+    /// path_name,offset,orientation
+    #[argh(option, short = 'p')]
+    path_pos: String,
+}
+
+pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static str> {
+    // Parse the position triple, which looks like `path,42,+`.
+    let (path_name, offset, orientation) = {
+        let parts: Vec<_> = args.path_pos.split(",").collect();
+        if parts.len() != 3 {
+            return Err("position must be path_name,offset,orientation");
+        }
+        let off: usize = parts[1].parse().or(Err("offset must be a number"))?;
+        let ori: flatgfa::Orientation = parts[2].parse().or(Err("orientation must be + or -"))?;
+        (parts[0], off, ori)
+    };
+
+    let path_id = gfa.find_path(path_name.into()).ok_or("path not found")?;
+    dbg!(path_id, offset, orientation);
+    Ok(())
+}
+
 /// create a subset graph
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "extract")]

--- a/polbin/src/cmds.rs
+++ b/polbin/src/cmds.rs
@@ -107,7 +107,6 @@ pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static s
     let mut found = None;
     for step in gfa.get_steps(path) {
         let seg = gfa.get_handle_seg(*step);
-        // TODO Handle backwards segments!
         let end_pos = cur_pos + seg.len();
         if offset < end_pos {
             // Found it!

--- a/polbin/src/flatgfa.rs
+++ b/polbin/src/flatgfa.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::pool::{Index, Pool, Span};
 use bstr::BStr;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -133,6 +135,20 @@ pub enum Orientation {
     Backward, // -
 }
 
+impl FromStr for Orientation {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "+" {
+            Ok(Orientation::Forward)
+        } else if s == "-" {
+            Ok(Orientation::Backward)
+        } else {
+            Err(())
+        }
+    }
+}
+
 /// An oriented reference to a segment.
 ///
 /// A Handle refers to the forward (+) or backward (-) orientation for a given segment.
@@ -231,6 +247,14 @@ impl<'a> FlatGFA<'a> {
         self.segs
             .iter()
             .position(|seg| seg.name == name)
+            .map(|i| i as Index)
+    }
+
+    /// Look up a path by its name.
+    pub fn find_path(&self, name: &BStr) -> Option<Index> {
+        self.paths
+            .iter()
+            .position(|path| self.get_path_name(path) == name)
             .map(|i| i as Index)
     }
 

--- a/polbin/src/main.rs
+++ b/polbin/src/main.rs
@@ -68,6 +68,7 @@ enum Command {
     Toc(cmds::Toc),
     Paths(cmds::Paths),
     Stats(cmds::Stats),
+    Position(cmds::Position),
     Extract(cmds::Extract),
 }
 
@@ -123,6 +124,9 @@ fn main() -> Result<(), &'static str> {
         }
         Some(Command::Stats(sub_args)) => {
             cmds::stats(&gfa, sub_args);
+        }
+        Some(Command::Position(sub_args)) => {
+            cmds::position(&gfa, sub_args)?;
         }
         Some(Command::Extract(sub_args)) => {
             let store = cmds::extract(&gfa, sub_args)?;


### PR DESCRIPTION
Just a really simple way to look up the position of a given offset within a path (i.e., find which step/segment it belongs to). Not a complicated query, but it's useful for demonstrating interactive use?