### PR TITLE
Tidy `paths` command for blogpost

### DIFF
--- a/slow_odgi/slow_odgi/__main__.py
+++ b/slow_odgi/slow_odgi/__main__.py
@@ -20,6 +20,7 @@ from . import (
     validate,
     norm,
     inject_setup,
+    somepaths,
     validate_setup,
 )
 
@@ -95,8 +96,13 @@ def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
         required=True,
     )
 
-    paths_parser = subparsers.add_parser("paths", help="Lists the paths in the graph.")
-    paths_parser.add_argument(
+    subparsers.add_parser("paths", help="Lists the paths in the graph.")
+
+    somepaths_parser = subparsers.add_parser(
+        "somepaths",
+        help="Lists the paths in the graph, with the option of dropping some.",
+    )
+    somepaths_parser.add_argument(
         "--drop",
         type=int,
         default=0,
@@ -172,7 +178,8 @@ def dispatch(args: argparse.Namespace) -> None:
         "flatten": lambda g: flatten.flatten(g, f"{args.graph[:-4]}.og"),
         "matrix": matrix.matrix,
         "overlap": lambda g: overlap.overlap(g, parse_paths(args.paths)),
-        "paths": lambda g: paths.paths(g, args.drop),
+        "paths": paths.paths,
+        "somepaths": lambda g: somepaths.somepaths(g, args.drop),
         "validate": validate.validate,
         "inject_setup": inject_setup.print_bed,
     }

--- a/slow_odgi/slow_odgi/paths.py
+++ b/slow_odgi/slow_odgi/paths.py
@@ -1,22 +1,14 @@
 import sys
-import random
 import mygfa
 
 
-def paths(graph: mygfa.Graph, droprate: int = 0) -> mygfa.Graph:
-    """Print the names of the paths found in `graph`.
-    The droprate represents the percentage of paths to drop.
-    """
+def paths(graph: mygfa.Graph) -> mygfa.Graph:
+    """Print the names of the paths found in `graph`."""
     pathnames = list(graph.paths.keys())
-    if droprate > 0:
-        random.seed(4)
-        pathnames[:] = random.sample(
-            pathnames, int((100 - droprate) / 100 * len(pathnames))
-        )
     for name in pathnames:
         print(name)
     return graph
 
 
 if __name__ == "__main__":
-    paths(mygfa.Graph.parse(open(sys.argv[1], "r", encoding="utf-8")), int(sys.argv[2]))
+    paths(mygfa.Graph.parse(open(sys.argv[1], "r", encoding="utf-8")))

--- a/slow_odgi/slow_odgi/paths.py
+++ b/slow_odgi/slow_odgi/paths.py
@@ -4,9 +4,8 @@ import mygfa
 
 def paths(graph: mygfa.Graph) -> mygfa.Graph:
     """Print the names of the paths found in `graph`."""
-    pathnames = list(graph.paths.keys())
-    for name in pathnames:
-        print(name)
+    pathnames = graph.paths.keys()
+    print("\n".join(pathnames))
     return graph
 
 

--- a/slow_odgi/slow_odgi/somepaths.py
+++ b/slow_odgi/slow_odgi/somepaths.py
@@ -1,0 +1,24 @@
+import sys
+import random
+import mygfa
+
+
+def somepaths(graph: mygfa.Graph, droprate: int = 0) -> mygfa.Graph:
+    """Print the names of the paths found in `graph`.
+    The droprate represents the percentage of paths to drop.
+    """
+    pathnames = list(graph.paths.keys())
+    if droprate > 0:
+        random.seed(4)
+        pathnames[:] = random.sample(
+            pathnames, int((100 - droprate) / 100 * len(pathnames))
+        )
+    for name in pathnames:
+        print(name)
+    return graph
+
+
+if __name__ == "__main__":
+    somepaths(
+        mygfa.Graph.parse(open(sys.argv[1], "r", encoding="utf-8")), int(sys.argv[2])
+    )

--- a/tests/turnt.toml
+++ b/tests/turnt.toml
@@ -30,7 +30,7 @@ output.degree = "-"
 
 [envs.depth_setup]
 binary = true
-command = "slow_odgi paths --drop 50 {filename}"
+command = "slow_odgi somepaths --drop 50 {filename}"
 output.depthpaths = "-"
 
 [envs.depth_oracle]
@@ -100,7 +100,7 @@ output.norm = "-"
 
 [envs.overlap_setup]
 binary = true
-command = "slow_odgi paths --drop 50 {filename}"
+command = "slow_odgi somepaths --drop 50 {filename}"
 output.overlappaths = "-"
 
 [envs.overlap_oracle]


### PR DESCRIPTION
The code for the command `paths` was a little muddied because I had a whole little option for a "droprate", meaning that a certain percentage of the graph's paths would be dropped from the output. This is not a flag that you'd realistically want to pass to the `paths` command in odgi, but rather a convenience for us: it allowed us to generate a subset of a graph's paths and then pass that subset along when testing the commands `depth` and `overlap`.

This PR separates the command and the utility into their own files. `slow_odgi paths` now takes no options, and is backed up by a short bit of code. A new command `slow_odgi somepaths` now exists, and that is what we use as a setup utility for testing `depth` and `overlap`.