### PR TITLE
Benchmark conversion

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -243,10 +243,13 @@ def bench_main():
     args = parser.parse_args()
 
     # Which tools are we comparing?
-    tools = args.tool or {
-        "paths": ALL_TOOLS,
-        "convert": ["odgi", "flatgfa"],
-    }[args.mode]
+    tools = (
+        args.tool
+        or {
+            "paths": ALL_TOOLS,
+            "convert": ["odgi", "flatgfa"],
+        }[args.mode]
+    )
     for tool in tools:
         assert tool in ALL_TOOLS, "unknown tool name"
 

--- a/bench/summary.py
+++ b/bench/summary.py
@@ -7,7 +7,7 @@ def summary():
     reader = csv.DictReader(sys.stdin)
     by_graph = defaultdict(dict)
     for row in reader:
-        by_graph[row['graph']][row['cmd']] = row
+        by_graph[row["graph"]][row["cmd"]] = row
 
     for graph, cmds in by_graph.items():
         print(graph)
@@ -18,11 +18,11 @@ def summary():
             if mean < 0.2:
                 mean *= 1000
                 stddev *= 1000
-                unit = 'ms'
+                unit = "ms"
             else:
-                unit = 's'
+                unit = "s"
 
-            print(f'  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}')
+            print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}")
 
 
 if __name__ == "__main__":

--- a/bench/summary.py
+++ b/bench/summary.py
@@ -15,14 +15,18 @@ def summary():
             mean = float(row["mean"])
             stddev = float(row["stddev"])
 
-            if mean < 0.2:
-                mean *= 1000
-                stddev *= 1000
-                unit = "ms"
+            if mean > 80:
+                mins = int(mean / 60)
+                secs = int(mean % 60)
+                print(f"  {cmd}: {mins}m{secs}s ± {stddev:.1f}")
             else:
-                unit = "s"
-
-            print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}")
+                if mean < 0.2:
+                    mean *= 1000
+                    stddev *= 1000
+                    unit = "ms"
+                else:
+                    unit = "s"
+                print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}")
 
 
 if __name__ == "__main__":

--- a/bench/summary.py
+++ b/bench/summary.py
@@ -1,0 +1,29 @@
+import csv
+import sys
+from collections import defaultdict
+
+
+def summary():
+    reader = csv.DictReader(sys.stdin)
+    by_graph = defaultdict(dict)
+    for row in reader:
+        by_graph[row['graph']][row['cmd']] = row
+
+    for graph, cmds in by_graph.items():
+        print(graph)
+        for cmd, row in cmds.items():
+            mean = float(row["mean"])
+            stddev = float(row["stddev"])
+
+            if mean < 0.2:
+                mean *= 1000
+                stddev *= 1000
+                unit = 'ms'
+            else:
+                unit = 's'
+
+            print(f'  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}')
+
+
+if __name__ == "__main__":
+    summary()


### PR DESCRIPTION
To our benchmarking harness, add a mode to benchmark data conversion (GFA -> `.og` and GFA -> FlatGFA). Also add a quick script for summarizing results in human-readable units.