### PR TITLE
Simplify some arena types/traits

### DIFF
--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -1,4 +1,4 @@
-use flatgfa::flatgfa::{FlatGFA, GFABuilder, HeapStore};
+use flatgfa::flatgfa::{FlatGFA, HeapStore};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -42,7 +42,7 @@ impl GFARef {
         // once up front and hand it out to the various ancillary objects, but they need
         // to be assured that the store will survive long enough.
         match self.0.get().0 {
-            InternalStore::Heap(ref store) => store.view(),
+            InternalStore::Heap(ref store) => (**store).as_ref(),
             InternalStore::File(ref mmap) => flatgfa::file::view(mmap),
         }
     }

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -96,7 +96,7 @@ pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static s
     };
 
     let path_id = gfa.find_path(path_name.into()).ok_or("path not found")?;
-    let path = &gfa.paths[path_id as usize];
+    let path = gfa.paths.get_id(path_id);
     assert_eq!(
         orientation,
         flatgfa::Orientation::Forward,
@@ -180,7 +180,7 @@ impl<'a> SubgraphBuilder<'a> {
 
     /// Add a segment from the source graph to this subgraph.
     fn include_seg(&mut self, seg_id: Index) {
-        let seg = &self.old.segs[seg_id as usize];
+        let seg = self.old.segs.get_id(seg_id);
         let new_seg_id = self.store.add_seg(
             seg.name,
             self.old.get_seq(seg),
@@ -193,7 +193,7 @@ impl<'a> SubgraphBuilder<'a> {
     fn include_link(&mut self, link: &flatgfa::Link) {
         let from = self.tr_handle(link.from);
         let to = self.tr_handle(link.to);
-        let overlap = self.old.get_alignment(&link.overlap);
+        let overlap = self.old.get_alignment(link.overlap);
         self.store.add_link(from, to, overlap.ops.into());
     }
 

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -1,5 +1,5 @@
 use crate::flatgfa;
-use crate::pool::{self, Index, Pool};
+use crate::pool::{self, Index, PoolTK};
 use argh::FromArgs;
 use bstr::BStr;
 use std::collections::{HashMap, HashSet};

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -1,5 +1,5 @@
 use crate::flatgfa;
-use crate::pool::{self, Index, Pool};
+use crate::pool::{self, Id, Pool};
 use argh::FromArgs;
 use bstr::BStr;
 use std::collections::{HashMap, HashSet};
@@ -59,7 +59,7 @@ pub fn stats(gfa: &flatgfa::FlatGFA, args: Stats) {
             gfa.steps.len()
         );
     } else if args.self_loops {
-        let mut counts: HashMap<Index, usize> = HashMap::new();
+        let mut counts: HashMap<Id, usize> = HashMap::new();
         let mut total: usize = 0;
         for link in gfa.links.iter() {
             if link.from.segment() == link.to.segment() {
@@ -161,12 +161,12 @@ pub fn extract(gfa: &flatgfa::FlatGFA, args: Extract) -> Result<flatgfa::HeapSto
 struct SubgraphBuilder<'a> {
     old: &'a flatgfa::FlatGFA<'a>,
     store: flatgfa::HeapStore,
-    seg_map: HashMap<Index, Index>,
+    seg_map: HashMap<Id, Id>,
 }
 
 struct SubpathStart {
-    step: Index, // The id of the first step in the subpath.
-    pos: usize,  // The bp position at the start of the subpath.
+    step: Id,   // The id of the first step in the subpath.
+    pos: usize, // The bp position at the start of the subpath.
 }
 
 impl<'a> SubgraphBuilder<'a> {
@@ -179,7 +179,7 @@ impl<'a> SubgraphBuilder<'a> {
     }
 
     /// Add a segment from the source graph to this subgraph.
-    fn include_seg(&mut self, seg_id: Index) {
+    fn include_seg(&mut self, seg_id: Id) {
         let seg = self.old.segs.get_id(seg_id);
         let new_seg_id = self.store.add_seg(
             seg.name,
@@ -250,7 +250,7 @@ impl<'a> SubgraphBuilder<'a> {
     }
 
     /// Check whether a segment from the old graph is in the subgraph.
-    fn contains(&self, old_seg_id: Index) -> bool {
+    fn contains(&self, old_seg_id: Id) -> bool {
         self.seg_map.contains_key(&old_seg_id)
     }
 
@@ -259,7 +259,7 @@ impl<'a> SubgraphBuilder<'a> {
     ///
     /// Include any links between the segments in the neighborhood and subpaths crossing
     /// through the neighborhood.
-    fn extract(&mut self, origin: Index, dist: usize) {
+    fn extract(&mut self, origin: Id, dist: usize) {
         self.include_seg(origin);
 
         // Find the set of all segments that are 1 link away.

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -1,7 +1,7 @@
-use crate::flatgfa::{self, GFABuilder};
+use crate::flatgfa;
 use crate::pool::{self, Index, Pool};
-use bstr::BStr;
 use argh::FromArgs;
+use bstr::BStr;
 use std::collections::{HashMap, HashSet};
 
 /// print the FlatGFA table of contents
@@ -296,7 +296,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA) {
     let mut depths = Vec::new();
     depths.resize(gfa.segs.len(), 0);
     // Initialize uniq_paths
-    let mut uniq_paths = Vec::<HashSet::<&BStr>>::new();
+    let mut uniq_paths = Vec::<HashSet<&BStr>>::new();
     uniq_paths.resize(gfa.segs.len(), HashSet::new());
     // do not assume that each handle in `gfa.steps()` is unique
     for path in gfa.paths {

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -1,5 +1,5 @@
 use crate::flatgfa;
-use crate::pool::{self, Index, PoolTK};
+use crate::pool::{self, Index, Pool};
 use argh::FromArgs;
 use bstr::BStr;
 use std::collections::{HashMap, HashSet};

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -400,13 +400,6 @@ impl<'a> PoolFamily<'a> for VecPoolFamily {
     type Pool<T: Clone + 'a> = Vec<T>;
 }
 
-/// A mutable, in-memory data store for `FlatGFA`.
-///
-/// This store contains a bunch of `Vec`s: one per array required to implement a
-/// `FlatGFA`. It exposes an API for building up a GFA data structure, so it is
-/// useful for creating new ones from scratch.
-pub type HeapStore = Store<'static, VecPoolFamily>;
-
 pub struct SliceVecPoolFamily;
 impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
     type Pool<T: Clone + 'a> = SliceVec<'a, T>;
@@ -418,3 +411,10 @@ impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
 /// a fixed region. This means they have a maximum size, but they can directly map
 /// onto the contents of a file.
 pub type SliceStore<'a> = Store<'a, SliceVecPoolFamily>;
+
+/// A mutable, in-memory data store for `FlatGFA`.
+///
+/// This store contains a bunch of `Vec`s: one per array required to implement a
+/// `FlatGFA`. It exposes an API for building up a GFA data structure, so it is
+/// useful for creating new ones from scratch.
+pub type HeapStore = Store<'static, VecPoolFamily>;

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::pool::{Index, Pool, Span};
+use crate::pool::{Index, Pool, PoolTK, Span};
 use bstr::BStr;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use tinyvec::SliceVec;
@@ -375,17 +375,17 @@ impl<'a, P: PoolFamily<'a>> Store<'a, P> {
     /// Borrow a FlatGFA view of this data store.
     pub fn view(&self) -> FlatGFA {
         FlatGFA {
-            header: self.header.all(),
-            segs: self.segs.all(),
-            paths: self.paths.all(),
-            links: self.links.all(),
-            name_data: self.name_data.all(),
-            seq_data: self.seq_data.all(),
-            steps: self.steps.all(),
-            overlaps: self.overlaps.all(),
-            alignment: self.alignment.all(),
-            optional_data: self.optional_data.all(),
-            line_order: self.line_order.all(),
+            header: &self.header,
+            segs: &self.segs,
+            paths: &self.paths,
+            links: &self.links,
+            name_data: &self.name_data,
+            seq_data: &self.seq_data,
+            steps: &self.steps,
+            overlaps: &self.overlaps,
+            alignment: &self.alignment,
+            optional_data: &self.optional_data,
+            line_order: &self.line_order,
         }
     }
 }

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -12,7 +12,7 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes};
 /// `FlatGFAStore` struct contains `Vec`s as backing stores for each of the slices
 /// in this struct. `FlatGFA` itself provides immutable access to the GFA data
 /// structure that is agnostic to the location of the underlying bytes.
-pub struct FlatGFA<'a> {
+pub struct OldDeprecatedFlatGFA<'a> {
     /// A GFA may optionally have a single header line, with a version number.
     /// If this is empty, there is no header line.
     pub header: &'a [u8],
@@ -234,7 +234,23 @@ pub enum LineKind {
     Link,
 }
 
-impl<'a> FlatGFA<'a> {
+/// The data storage pools for a `FlatGFA`.
+#[derive(Default)]
+pub struct Store<'a, P: PoolFamily<'a>> {
+    pub header: P::Pool<u8>,
+    pub segs: P::Pool<Segment>,
+    pub paths: P::Pool<Path>,
+    pub links: P::Pool<Link>,
+    pub steps: P::Pool<Handle>,
+    pub seq_data: P::Pool<u8>,
+    pub overlaps: P::Pool<Span>,
+    pub alignment: P::Pool<AlignOp>,
+    pub name_data: P::Pool<u8>,
+    pub optional_data: P::Pool<u8>,
+    pub line_order: P::Pool<u8>,
+}
+
+impl<'a, P: PoolFamily<'a>> Store<'a, P> {
     /// Get the base-pair sequence for a segment.
     pub fn get_seq(&self, seg: &Segment) -> &BStr {
         self.seq_data[seg.seq.range()].as_ref()
@@ -294,25 +310,7 @@ impl<'a> FlatGFA<'a> {
     pub fn get_line_order(&self) -> impl Iterator<Item = LineKind> + 'a {
         self.line_order.iter().map(|b| (*b).try_into().unwrap())
     }
-}
 
-/// The data storage pools for a `FlatGFA`.
-#[derive(Default)]
-pub struct Store<'a, P: PoolFamily<'a>> {
-    pub header: P::Pool<u8>,
-    pub segs: P::Pool<Segment>,
-    pub paths: P::Pool<Path>,
-    pub links: P::Pool<Link>,
-    pub steps: P::Pool<Handle>,
-    pub seq_data: P::Pool<u8>,
-    pub overlaps: P::Pool<Span>,
-    pub alignment: P::Pool<AlignOp>,
-    pub name_data: P::Pool<u8>,
-    pub optional_data: P::Pool<u8>,
-    pub line_order: P::Pool<u8>,
-}
-
-impl<'a, P: PoolFamily<'a>> Store<'a, P> {
     /// Add a header line for the GFA file. This may only be added once.
     pub fn add_header(&mut self, version: &[u8]) {
         assert!(self.header.count() == 0);
@@ -390,7 +388,11 @@ impl<'a, P: PoolFamily<'a>> Store<'a, P> {
     }
 }
 
-pub trait PoolFamily<'a> {
+pub trait TKSuperPoolFamily<'a> {
+    type Stuff<T: Clone + 'a>;
+}
+
+pub trait PoolFamily<'a>: TKSuperPoolFamily<'a> {
     type Pool<T: Clone + 'a>: crate::pool::Pool<T>;
 }
 
@@ -400,17 +402,17 @@ impl<'a> PoolFamily<'a> for VecPoolFamily {
     type Pool<T: Clone + 'a> = Vec<T>;
 }
 
+pub struct SliceVecPoolFamily;
+impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
+    type Pool<T: Clone + 'a> = SliceVec<'a, T>;
+}
+
 /// A mutable, in-memory data store for `FlatGFA`.
 ///
 /// This store contains a bunch of `Vec`s: one per array required to implement a
 /// `FlatGFA`. It exposes an API for building up a GFA data structure, so it is
 /// useful for creating new ones from scratch.
 pub type HeapStore = Store<'static, VecPoolFamily>;
-
-pub struct SliceVecPoolFamily;
-impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
-    type Pool<T: Clone + 'a> = SliceVec<'a, T>;
-}
 
 /// A store for `FlatGFA` data backed by fixed-size slices.
 ///

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -312,44 +312,15 @@ pub struct Store<'a, P: PoolFamily<'a>> {
     pub line_order: P::Pool<u8>,
 }
 
-pub trait GFABuilder {
+impl<'a, P: PoolFamily<'a>> Store<'a, P> {
     /// Add a header line for the GFA file. This may only be added once.
-    fn add_header(&mut self, version: &[u8]);
-
-    /// Add a new segment to the GFA file.
-    fn add_seg(&mut self, name: usize, seq: &[u8], optional: &[u8]) -> Index;
-
-    /// Add a new path.
-    fn add_path(
-        &mut self,
-        name: &[u8],
-        steps: Span,
-        overlaps: impl Iterator<Item = Vec<AlignOp>>,
-    ) -> Index;
-
-    /// Add a sequence of steps.
-    fn add_steps(&mut self, steps: impl Iterator<Item = Handle>) -> Span;
-
-    /// Add a single step.
-    fn add_step(&mut self, step: Handle) -> Index;
-
-    /// Add a link between two (oriented) segments.
-    fn add_link(&mut self, from: Handle, to: Handle, overlap: Vec<AlignOp>) -> Index;
-
-    /// Record a line type to preserve the line order.
-    fn record_line(&mut self, kind: LineKind);
-
-    /// Borrow a FlatGFA view of this data store.
-    fn view(&self) -> FlatGFA;
-}
-
-impl<'a, P: PoolFamily<'a>> GFABuilder for Store<'a, P> {
-    fn add_header(&mut self, version: &[u8]) {
+    pub fn add_header(&mut self, version: &[u8]) {
         assert!(self.header.count() == 0);
         self.header.add_slice(version);
     }
 
-    fn add_seg(&mut self, name: usize, seq: &[u8], optional: &[u8]) -> Index {
+    /// Add a new segment to the GFA file.
+    pub fn add_seg(&mut self, name: usize, seq: &[u8], optional: &[u8]) -> Index {
         self.segs.add(Segment {
             name,
             seq: self.seq_data.add_slice(seq),
@@ -357,7 +328,8 @@ impl<'a, P: PoolFamily<'a>> GFABuilder for Store<'a, P> {
         })
     }
 
-    fn add_path(
+    /// Add a new path.
+    pub fn add_path(
         &mut self,
         name: &[u8],
         steps: Span,
@@ -376,15 +348,18 @@ impl<'a, P: PoolFamily<'a>> GFABuilder for Store<'a, P> {
         })
     }
 
-    fn add_steps(&mut self, steps: impl Iterator<Item = Handle>) -> Span {
+    /// Add a sequence of steps.
+    pub fn add_steps(&mut self, steps: impl Iterator<Item = Handle>) -> Span {
         self.steps.add_iter(steps)
     }
 
-    fn add_step(&mut self, step: Handle) -> Index {
+    /// Add a single step.
+    pub fn add_step(&mut self, step: Handle) -> Index {
         self.steps.add(step)
     }
 
-    fn add_link(&mut self, from: Handle, to: Handle, overlap: Vec<AlignOp>) -> Index {
+    /// Add a link between two (oriented) segments.
+    pub fn add_link(&mut self, from: Handle, to: Handle, overlap: Vec<AlignOp>) -> Index {
         self.links.add(Link {
             from,
             to,
@@ -392,11 +367,13 @@ impl<'a, P: PoolFamily<'a>> GFABuilder for Store<'a, P> {
         })
     }
 
-    fn record_line(&mut self, kind: LineKind) {
+    /// Record a line type to preserve the line order.
+    pub fn record_line(&mut self, kind: LineKind) {
         self.line_order.add(kind.into());
     }
 
-    fn view(&self) -> FlatGFA {
+    /// Borrow a FlatGFA view of this data store.
+    pub fn view(&self) -> FlatGFA {
         FlatGFA {
             header: self.header.all(),
             segs: self.segs.all(),
@@ -430,9 +407,7 @@ impl<'a> PoolFamily<'a> for VecPoolFamily {
 /// useful for creating new ones from scratch.
 pub type HeapStore = Store<'static, VecPoolFamily>;
 
-pub struct SliceVecPoolFamily {
-    // phantom: std::marker::PhantomData<&'a ()>,
-}
+pub struct SliceVecPoolFamily;
 impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
     type Pool<T: Clone + 'a> = SliceVec<'a, T>;
 }

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -373,7 +373,7 @@ impl<'a, P: PoolFamily<'a>> GFAStore<'a, P> {
     }
 
     /// Borrow a FlatGFA view of this data store.
-    pub fn view(&self) -> FlatGFA {
+    pub fn as_ref(&self) -> FlatGFA {
         FlatGFA {
             header: &self.header,
             segs: &self.segs,

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -9,9 +9,11 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes};
 /// An efficient flattened representation of a GFA file.
 ///
 /// This struct *borrows* the underlying data from some other data store. Namely, the
-/// `FlatGFAStore` struct contains `Vec`s as backing stores for each of the slices
-/// in this struct. `FlatGFA` itself provides immutable access to the GFA data
-/// structure that is agnostic to the location of the underlying bytes.
+/// `GFAStore` structs contain `Vec`s or `Vec`-like arenas as backing stores for each
+/// of the slices in this struct. `FlatGFA` itself provides access to the GFA data
+/// structure that is agnostic to the location of the underlying bytes. However, all
+/// its components have a fixed size; unlike the underlying `GFAStore`, it is not
+/// possible to add new objects.
 pub struct FlatGFA<'a> {
     /// A GFA may optionally have a single header line, with a version number.
     /// If this is empty, there is no header line.

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -237,7 +237,7 @@ pub enum LineKind {
 impl<'a> FlatGFA<'a> {
     /// Get the base-pair sequence for a segment.
     pub fn get_seq(&self, seg: &Segment) -> &BStr {
-        self.seq_data[seg.seq.range()].as_ref()
+        self.seq_data.get_span(seg.seq).as_ref()
     }
 
     /// Look up a segment by its name.
@@ -260,33 +260,33 @@ impl<'a> FlatGFA<'a> {
 
     /// Get all the steps for a path.
     pub fn get_steps(&self, path: &Path) -> &[Handle] {
-        &self.steps[path.steps.range()]
+        &self.steps.get_span(path.steps)
     }
 
     /// Get all the overlaps for a path. This may be empty (`*` in the GFA file).
     pub fn get_overlaps(&self, path: &Path) -> &[Span] {
-        &self.overlaps[path.overlaps.range()]
+        &self.overlaps.get_span(path.overlaps)
     }
 
     /// Get the string name of a path.
     pub fn get_path_name(&self, path: &Path) -> &BStr {
-        self.name_data[path.name.range()].as_ref()
+        self.name_data.get_span(path.name).as_ref()
     }
 
     /// Get a handle's associated segment.
     pub fn get_handle_seg(&self, handle: Handle) -> &Segment {
-        &self.segs[handle.segment() as usize]
+        &self.segs.get_id(handle.segment())
     }
 
     /// Get the optional data for a segment, as a tab-separated string.
     pub fn get_optional_data(&self, seg: &Segment) -> &BStr {
-        self.optional_data[seg.optional.range()].as_ref()
+        self.optional_data.get_span(seg.optional).as_ref()
     }
 
     /// Look up a CIGAR alignment.
-    pub fn get_alignment(&self, overlap: &Span) -> Alignment {
+    pub fn get_alignment(&self, overlap: Span) -> Alignment {
         Alignment {
-            ops: &self.alignment[overlap.range()],
+            ops: &self.alignment.get_span(overlap),
         }
     }
 

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::pool::{Index, Pool, PoolTK, Span};
+use crate::pool::{Index, Pool, Span, Store};
 use bstr::BStr;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use tinyvec::SliceVec;
@@ -298,7 +298,7 @@ impl<'a> FlatGFA<'a> {
 
 /// The data storage pools for a `FlatGFA`.
 #[derive(Default)]
-pub struct Store<'a, P: PoolFamily<'a>> {
+pub struct GFAStore<'a, P: PoolFamily<'a>> {
     pub header: P::Pool<u8>,
     pub segs: P::Pool<Segment>,
     pub paths: P::Pool<Path>,
@@ -312,7 +312,7 @@ pub struct Store<'a, P: PoolFamily<'a>> {
     pub line_order: P::Pool<u8>,
 }
 
-impl<'a, P: PoolFamily<'a>> Store<'a, P> {
+impl<'a, P: PoolFamily<'a>> GFAStore<'a, P> {
     /// Add a header line for the GFA file. This may only be added once.
     pub fn add_header(&mut self, version: &[u8]) {
         assert!(self.header.count() == 0);
@@ -391,7 +391,7 @@ impl<'a, P: PoolFamily<'a>> Store<'a, P> {
 }
 
 pub trait PoolFamily<'a> {
-    type Pool<T: Clone + 'a>: crate::pool::Pool<T>;
+    type Pool<T: Clone + 'a>: crate::pool::Store<T>;
 }
 
 #[derive(Default)]
@@ -410,11 +410,11 @@ impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
 /// This store contains `SliceVec`s, which act like `Vec`s but are allocated within
 /// a fixed region. This means they have a maximum size, but they can directly map
 /// onto the contents of a file.
-pub type SliceStore<'a> = Store<'a, SliceVecPoolFamily>;
+pub type SliceStore<'a> = GFAStore<'a, SliceVecPoolFamily>;
 
 /// A mutable, in-memory data store for `FlatGFA`.
 ///
 /// This store contains a bunch of `Vec`s: one per array required to implement a
 /// `FlatGFA`. It exposes an API for building up a GFA data structure, so it is
 /// useful for creating new ones from scratch.
-pub type HeapStore = Store<'static, VecPoolFamily>;
+pub type HeapStore = GFAStore<'static, VecPoolFamily>;

--- a/flatgfa/src/main.rs
+++ b/flatgfa/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), &'static str> {
             if args.mutate {
                 mmap_mut = file::map_file_mut(&name);
                 slice_store = file::view_store(&mut mmap_mut);
-                slice_store.view()
+                slice_store.as_ref()
             } else {
                 mmap = file::map_file(&name);
                 file::view(&mmap)
@@ -80,7 +80,7 @@ fn main() -> Result<(), &'static str> {
                     Parser::for_heap().parse_stream(stdin.lock())
                 }
             };
-            store.view()
+            store.as_ref()
         }
     };
 
@@ -99,7 +99,7 @@ fn main() -> Result<(), &'static str> {
         }
         Some(Command::Extract(sub_args)) => {
             let store = cmds::extract(&gfa, sub_args)?;
-            dump(&store.view(), &args.output);
+            dump(&store.as_ref(), &args.output);
         }
         Some(Command::Depth(_)) => {
             cmds::depth(&gfa);

--- a/flatgfa/src/main.rs
+++ b/flatgfa/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use flatgfa::flatgfa::{FlatGFA, GFABuilder};
+use flatgfa::flatgfa::FlatGFA;
 use flatgfa::parse::Parser;
 use flatgfa::{cmds, file, parse, print};
 

--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -5,14 +5,14 @@ use std::io::BufRead;
 
 pub struct Parser<'a, P: flatgfa::PoolFamily<'a>> {
     /// The flat representation we're building.
-    flat: flatgfa::Store<'a, P>,
+    flat: flatgfa::GFAStore<'a, P>,
 
     /// All segment IDs, indexed by their names, which we need to refer to segments in paths.
     seg_ids: NameMap,
 }
 
 impl<'a, P: flatgfa::PoolFamily<'a>> Parser<'a, P> {
-    pub fn new(builder: flatgfa::Store<'a, P>) -> Self {
+    pub fn new(builder: flatgfa::GFAStore<'a, P>) -> Self {
         Self {
             flat: builder,
             seg_ids: NameMap::default(),
@@ -20,7 +20,7 @@ impl<'a, P: flatgfa::PoolFamily<'a>> Parser<'a, P> {
     }
 
     /// Parse a GFA text file from an I/O stream.
-    pub fn parse_stream<R: BufRead>(mut self, stream: R) -> flatgfa::Store<'a, P> {
+    pub fn parse_stream<R: BufRead>(mut self, stream: R) -> flatgfa::GFAStore<'a, P> {
         // We can parse sements immediately, but we need to defer links and paths until we have all
         // the segment names that they might refer to.
         let mut deferred_links = Vec::new();
@@ -69,7 +69,7 @@ impl<'a, P: flatgfa::PoolFamily<'a>> Parser<'a, P> {
     }
 
     /// Parse a GFA text file from an in-memory buffer.
-    pub fn parse_mem(mut self, buf: &[u8]) -> flatgfa::Store<'a, P> {
+    pub fn parse_mem(mut self, buf: &[u8]) -> flatgfa::GFAStore<'a, P> {
         let mut deferred_lines = Vec::new();
 
         for line in MemchrSplit::new(b'\n', buf) {

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -48,29 +48,10 @@ pub trait Pool<T: Clone>: Deref<Target = [T]> {
 
     /// Like `add_iter`, but for slices.
     fn add_slice(&mut self, slice: &[T]) -> Span;
-
-    /// Get the number of items in the pool.
-    fn count(&self) -> usize {
-        self.len()
-    }
-
-    /// Get the next available ID.
-    fn next_id(&self) -> Index {
-        self.count().try_into().expect("size too large")
-    }
-
-    /// Get all items in the pool.
-    fn all(&self) -> &[T] {
-        &self.deref()
-    }
 }
 
 impl<T: Clone> Pool<T> for Vec<T> {
     fn add(&mut self, item: T) -> Index {
-        let x: &[T] = self;
-        x.blargle();
-        self.deref().deref().blargle();
-
         let id = self.next_id();
         self.push(item);
         id
@@ -121,26 +102,37 @@ impl<'a, T: Clone> Pool<T> for SliceVec<'a, T> {
     }
 }
 
-pub trait PoolRef<T> {
+/// TK: A too-be-named thing that is just a fixed-size chunk from a pool.
+pub trait PoolTK<T> {
     /// Get a single element from the pool by its ID.
     fn get(&self, index: Index) -> &T;
 
     /// Get a range of elements from the pool using their IDs.
     fn get_span(&self, span: Span) -> &[T];
 
-    fn blargle(&self) {
-        println!("blargle");
-    }
+    /// Get the number of items in the pool.
+    fn count(&self) -> usize;
+
+    /// Get the next available ID.
+    fn next_id(&self) -> Index;
 
     // TODO proper subscripting
 }
 
-impl<T> PoolRef<T> for &[T] {
+impl<T> PoolTK<T> for [T] {
     fn get(&self, index: Index) -> &T {
         &self[index as usize]
     }
 
     fn get_span(&self, span: Span) -> &[T] {
         &self[span.range()]
+    }
+
+    fn count(&self) -> usize {
+        self.len()
+    }
+
+    fn next_id(&self) -> Index {
+        self.count().try_into().expect("size too large")
     }
 }

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -49,16 +49,6 @@ pub trait Pool<T: Clone>: Deref<Target = [T]> {
     /// Like `add_iter`, but for slices.
     fn add_slice(&mut self, slice: &[T]) -> Span;
 
-    /// Get a single element from the pool by its ID.
-    fn get(&self, index: Index) -> &T {
-        &self[index as usize]
-    }
-
-    /// Get a range of elements from the pool using their IDs.
-    fn get_span(&self, span: Span) -> &[T] {
-        &self[span.range()]
-    }
-
     /// Get the number of items in the pool.
     fn count(&self) -> usize {
         self.len()
@@ -77,6 +67,10 @@ pub trait Pool<T: Clone>: Deref<Target = [T]> {
 
 impl<T: Clone> Pool<T> for Vec<T> {
     fn add(&mut self, item: T) -> Index {
+        let x: &[T] = self;
+        x.blargle();
+        self.deref().deref().blargle();
+
         let id = self.next_id();
         self.push(item);
         id
@@ -124,5 +118,29 @@ impl<'a, T: Clone> Pool<T> for SliceVec<'a, T> {
             start,
             end: self.next_id(),
         }
+    }
+}
+
+pub trait PoolRef<T> {
+    /// Get a single element from the pool by its ID.
+    fn get(&self, index: Index) -> &T;
+
+    /// Get a range of elements from the pool using their IDs.
+    fn get_span(&self, span: Span) -> &[T];
+
+    fn blargle(&self) {
+        println!("blargle");
+    }
+
+    // TODO proper subscripting
+}
+
+impl<T> PoolRef<T> for &[T] {
+    fn get(&self, index: Index) -> &T {
+        &self[index as usize]
+    }
+
+    fn get_span(&self, span: Span) -> &[T] {
+        &self[span.range()]
     }
 }

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -108,10 +108,13 @@ impl<'a, T: Clone> Store<T> for SliceVec<'a, T> {
     }
 }
 
-/// TK: A too-be-named thing that is just a fixed-size chunk from a pool.
+/// A fixed-sized arena.
+///
+/// This trait allows index-based access to a fixed-size chunk of objects reflecting
+/// a `Store`. Unlike `Store`, it does not support adding new objects.
 pub trait Pool<T> {
     /// Get a single element from the pool by its ID.
-    fn get(&self, index: Index) -> &T;
+    fn get_id(&self, index: Index) -> &T;
 
     /// Get a range of elements from the pool using their IDs.
     fn get_span(&self, span: Span) -> &[T];
@@ -121,12 +124,10 @@ pub trait Pool<T> {
 
     /// Get the next available ID.
     fn next_id(&self) -> Index;
-
-    // TODO proper subscripting
 }
 
 impl<T> Pool<T> for [T] {
-    fn get(&self, index: Index) -> &T {
+    fn get_id(&self, index: Index) -> &T {
         &self[index as usize]
     }
 

--- a/flatgfa/src/print.rs
+++ b/flatgfa/src/print.rs
@@ -49,9 +49,9 @@ fn print_path(gfa: &flatgfa::FlatGFA, path: &flatgfa::Path) {
     if overlaps.is_empty() {
         print!("*");
     } else {
-        print!("{}", gfa.get_alignment(&overlaps[0]));
+        print!("{}", gfa.get_alignment(overlaps[0]));
         for overlap in overlaps[1..].iter() {
-            print!(",{}", gfa.get_alignment(overlap));
+            print!(",{}", gfa.get_alignment(*overlap));
         }
     }
     println!();
@@ -68,7 +68,7 @@ fn print_link(gfa: &flatgfa::FlatGFA, link: &flatgfa::Link) {
         from.orient(),
         to_name,
         to.orient(),
-        gfa.get_alignment(&link.overlap)
+        gfa.get_alignment(link.overlap)
     );
 }
 


### PR DESCRIPTION
This is just paying off some technical debt w/r/t the little `pool` library that our flat representation is built upon and the way we convert between `GFAStore` (the mutable-size underlying data) and `FlatGFA` (the fixed-size references to in-place data).

I'm still not sure the current philosophy is good: namely, we are providing `Pool` and `Store` traits for existing types (vectors and slices) rather than creating our own newtypes. One consequence, for instance, is that you have to do `pool.get_id(id)` instead of `pool[id]`, because `pool` is just a slice and `slice[i]` already means something. This is maybe worth revisiting someday.