### PR TITLE
Stronger types for indices

### DIFF
--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -302,7 +302,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA) {
     for path in gfa.paths {
         let path_name = gfa.get_path_name(path);
         for step in gfa.get_steps(path) {
-            let seg_id = step.segment() as usize;
+            let seg_id = step.segment().index();
             // Increment depths
             depths[seg_id] = depths[seg_id] + 1;
             // Update uniq_paths

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -1,4 +1,4 @@
-use crate::flatgfa;
+use crate::flatgfa::{self, Handle, Segment};
 use crate::pool::{self, Id, Pool};
 use argh::FromArgs;
 use bstr::BStr;
@@ -59,7 +59,7 @@ pub fn stats(gfa: &flatgfa::FlatGFA, args: Stats) {
             gfa.steps.len()
         );
     } else if args.self_loops {
-        let mut counts: HashMap<Id, usize> = HashMap::new();
+        let mut counts: HashMap<Id<Segment>, usize> = HashMap::new();
         let mut total: usize = 0;
         for link in gfa.links.iter() {
             if link.from.segment() == link.to.segment() {
@@ -161,12 +161,12 @@ pub fn extract(gfa: &flatgfa::FlatGFA, args: Extract) -> Result<flatgfa::HeapSto
 struct SubgraphBuilder<'a> {
     old: &'a flatgfa::FlatGFA<'a>,
     store: flatgfa::HeapStore,
-    seg_map: HashMap<Id, Id>,
+    seg_map: HashMap<Id<Segment>, Id<Segment>>,
 }
 
 struct SubpathStart {
-    step: Id,   // The id of the first step in the subpath.
-    pos: usize, // The bp position at the start of the subpath.
+    step: Id<Handle>, // The id of the first step in the subpath.
+    pos: usize,       // The bp position at the start of the subpath.
 }
 
 impl<'a> SubgraphBuilder<'a> {
@@ -179,7 +179,7 @@ impl<'a> SubgraphBuilder<'a> {
     }
 
     /// Add a segment from the source graph to this subgraph.
-    fn include_seg(&mut self, seg_id: Id) {
+    fn include_seg(&mut self, seg_id: Id<Segment>) {
         let seg = self.old.segs.get_id(seg_id);
         let new_seg_id = self.store.add_seg(
             seg.name,
@@ -199,10 +199,7 @@ impl<'a> SubgraphBuilder<'a> {
 
     /// Add a single subpath from the given path to the subgraph.
     fn include_subpath(&mut self, path: &flatgfa::Path, start: &SubpathStart, end_pos: usize) {
-        let steps = pool::Span {
-            start: start.step,
-            end: self.store.steps.next_id(),
-        };
+        let steps = pool::Span::new(start.step, self.store.steps.next_id());
         let name = format!("{}:{}-{}", self.old.get_path_name(path), start.pos, end_pos);
         self.store
             .add_path(name.as_bytes(), steps, std::iter::empty());
@@ -250,7 +247,7 @@ impl<'a> SubgraphBuilder<'a> {
     }
 
     /// Check whether a segment from the old graph is in the subgraph.
-    fn contains(&self, old_seg_id: Id) -> bool {
+    fn contains(&self, old_seg_id: Id<Segment>) -> bool {
         self.seg_map.contains_key(&old_seg_id)
     }
 
@@ -259,7 +256,7 @@ impl<'a> SubgraphBuilder<'a> {
     ///
     /// Include any links between the segments in the neighborhood and subpaths crossing
     /// through the neighborhood.
-    fn extract(&mut self, origin: Id, dist: usize) {
+    fn extract(&mut self, origin: Id<Segment>, dist: usize) {
         self.include_seg(origin);
 
         // Find the set of all segments that are 1 link away.

--- a/flatgfa/src/file.rs
+++ b/flatgfa/src/file.rs
@@ -70,7 +70,7 @@ impl Toc {
             + self.links.bytes::<flatgfa::Link>()
             + self.steps.bytes::<flatgfa::Handle>()
             + self.seq_data.bytes::<u8>()
-            + self.overlaps.bytes::<Span>()
+            + self.overlaps.bytes::<Span<flatgfa::AlignOp>>()
             + self.alignment.bytes::<flatgfa::AlignOp>()
             + self.name_data.bytes::<u8>()
             + self.optional_data.bytes::<u8>()

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -163,15 +163,16 @@ pub struct Handle(u32);
 impl Handle {
     /// Create a new handle referring to a segment ID and an orientation.
     pub fn new(segment: Id, orient: Orientation) -> Self {
-        assert!(segment & (1 << (u32::BITS - 1)) == 0, "index too large");
+        let seg_num: u32 = segment.into();
+        assert!(seg_num & (1 << (u32::BITS - 1)) == 0, "index too large");
         let orient_bit: u8 = orient.into();
         assert!(orient_bit & !1 == 0, "invalid orientation");
-        Self(segment << 1 | (orient_bit as u32))
+        Self(seg_num << 1 | (orient_bit as u32))
     }
 
     /// Get the segment ID. This is an index in the `segs` pool.
     pub fn segment(&self) -> Id {
-        self.0 >> 1
+        (self.0 >> 1).into()
     }
 
     /// Get the orientation (+ or -) for the handle.
@@ -249,7 +250,7 @@ impl<'a> FlatGFA<'a> {
         self.segs
             .iter()
             .position(|seg| seg.name == name)
-            .map(|i| i as Id)
+            .map(|i| Id::new(i))
     }
 
     /// Look up a path by its name.
@@ -257,7 +258,7 @@ impl<'a> FlatGFA<'a> {
         self.paths
             .iter()
             .position(|path| self.get_path_name(path) == name)
-            .map(|i| i as Id)
+            .map(|i| Id::new(i))
     }
 
     /// Get all the steps for a path.

--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -1,5 +1,6 @@
 use crate::flatgfa::{self, Handle, LineKind, Orientation};
 use crate::gfaline;
+use crate::pool::Id;
 use std::collections::HashMap;
 use std::io::BufRead;
 
@@ -188,23 +189,23 @@ struct NameMap {
     sequential_max: usize,
 
     /// Non-sequential names go here.
-    others: HashMap<usize, u32>,
+    others: HashMap<usize, Id>,
 }
 
 impl NameMap {
-    fn insert(&mut self, name: usize, id: u32) {
+    fn insert(&mut self, name: usize, id: Id) {
         // Is this the next sequential name? If so, no need to record it in our hash table;
         // just bump the number of sequential names we've seen.
-        if (name - 1) == self.sequential_max && (name - 1) == (id as usize) {
+        if (name - 1) == self.sequential_max && (name - 1) == id.index() {
             self.sequential_max += 1;
         } else {
             self.others.insert(name, id);
         }
     }
 
-    fn get(&self, name: usize) -> u32 {
+    fn get(&self, name: usize) -> Id {
         if name <= self.sequential_max {
-            (name - 1) as u32
+            Id::new(name - 1)
         } else {
             self.others[&name]
         }

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -1,32 +1,45 @@
 use std::ops::Deref;
+use std::{hash::Hash, marker::PhantomData};
 use tinyvec::SliceVec;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// An index into a pool.
-///
-/// TODO: Consider using newtypes for each distinct type.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
 #[repr(transparent)]
-pub struct Id(u32);
+pub struct Id<T>(u32, PhantomData<T>);
 
-impl Id {
+impl<T> PartialEq for Id<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> Eq for Id<T> {}
+
+impl<T> Hash for Id<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+impl<T> Id<T> {
     pub fn index(self) -> usize {
         self.0 as usize
     }
 
     pub fn new(index: usize) -> Self {
-        Self(index.try_into().expect("id too large"))
+        Self(index.try_into().expect("id too large"), PhantomData)
     }
 }
 
-impl From<u32> for Id {
+impl<T> From<u32> for Id<T> {
     fn from(v: u32) -> Self {
-        Self(v)
+        Self(v, PhantomData)
     }
 }
 
-impl From<Id> for u32 {
-    fn from(v: Id) -> Self {
+impl<T> From<Id<T>> for u32 {
+    fn from(v: Id<T>) -> Self {
         v.0
     }
 }
@@ -37,24 +50,33 @@ impl From<Id> for u32 {
 /// of start/end.
 #[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(packed)]
-pub struct Span {
-    pub start: Id,
-    pub end: Id,
+pub struct Span<T> {
+    pub start: Id<T>,
+    pub end: Id<T>,
+    _marker: PhantomData<T>,
 }
 
-impl From<Span> for std::ops::Range<usize> {
-    fn from(span: Span) -> std::ops::Range<usize> {
+impl<T> From<Span<T>> for std::ops::Range<usize> {
+    fn from(span: Span<T>) -> std::ops::Range<usize> {
         (span.start.index())..(span.end.index())
     }
 }
 
-impl Span {
+impl<T> Span<T> {
     pub fn is_empty(&self) -> bool {
         self.start.0 == self.end.0
     }
 
     pub fn len(&self) -> usize {
         (self.end.0 - self.start.0) as usize
+    }
+
+    pub fn new(start: Id<T>, end: Id<T>) -> Self {
+        Self {
+            start,
+            end,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -66,65 +88,53 @@ impl Span {
 /// access to the current set of objects (but not addition of new objects).
 pub trait Store<T: Clone>: Deref<Target = [T]> {
     /// Add an item to the pool and get the new id.
-    fn add(&mut self, item: T) -> Id;
+    fn add(&mut self, item: T) -> Id<T>;
 
     /// Add an entire sequence of items to a "pool" vector and return the
     /// range of new indices (IDs).
-    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span;
+    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span<T>;
 
     /// Like `add_iter`, but for slices.
-    fn add_slice(&mut self, slice: &[T]) -> Span;
+    fn add_slice(&mut self, slice: &[T]) -> Span<T>;
 }
 
 impl<T: Clone> Store<T> for Vec<T> {
-    fn add(&mut self, item: T) -> Id {
+    fn add(&mut self, item: T) -> Id<T> {
         let id = self.next_id();
         self.push(item);
         id
     }
 
-    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span {
+    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span<T> {
         let start = self.next_id();
         self.extend(iter);
-        Span {
-            start,
-            end: self.next_id(),
-        }
+        Span::new(start, self.next_id())
     }
 
-    fn add_slice(&mut self, slice: &[T]) -> Span {
+    fn add_slice(&mut self, slice: &[T]) -> Span<T> {
         let start = self.next_id();
         self.extend_from_slice(slice);
-        Span {
-            start,
-            end: self.next_id(),
-        }
+        Span::new(start, self.next_id())
     }
 }
 
 impl<'a, T: Clone> Store<T> for SliceVec<'a, T> {
-    fn add(&mut self, item: T) -> Id {
+    fn add(&mut self, item: T) -> Id<T> {
         let id = self.next_id();
         self.push(item);
         id
     }
 
-    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span {
+    fn add_iter(&mut self, iter: impl IntoIterator<Item = T>) -> Span<T> {
         let start = self.next_id();
         self.extend(iter);
-        Span {
-            start,
-            end: self.next_id(),
-        }
+        Span::new(start, self.next_id())
     }
 
-    fn add_slice(&mut self, slice: &[T]) -> Span {
+    fn add_slice(&mut self, slice: &[T]) -> Span<T> {
         let start = self.next_id();
         self.extend_from_slice(slice);
-        Span {
-            start,
-            end: self.next_id(),
-        }
+        Span::new(start, self.next_id())
     }
 }
 
@@ -134,24 +144,24 @@ impl<'a, T: Clone> Store<T> for SliceVec<'a, T> {
 /// a `Store`. Unlike `Store`, it does not support adding new objects.
 pub trait Pool<T> {
     /// Get a single element from the pool by its ID.
-    fn get_id(&self, id: Id) -> &T;
+    fn get_id(&self, id: Id<T>) -> &T;
 
     /// Get a range of elements from the pool using their IDs.
-    fn get_span(&self, span: Span) -> &[T];
+    fn get_span(&self, span: Span<T>) -> &[T];
 
     /// Get the number of items in the pool.
     fn count(&self) -> usize;
 
     /// Get the next available ID.
-    fn next_id(&self) -> Id;
+    fn next_id(&self) -> Id<T>;
 }
 
 impl<T> Pool<T> for [T] {
-    fn get_id(&self, id: Id) -> &T {
+    fn get_id(&self, id: Id<T>) -> &T {
         &self[id.index()]
     }
 
-    fn get_span(&self, span: Span) -> &[T] {
+    fn get_span(&self, span: Span<T>) -> &[T] {
         &self[std::ops::Range::from(span)]
     }
 
@@ -159,7 +169,7 @@ impl<T> Pool<T> for [T] {
         self.len()
     }
 
-    fn next_id(&self) -> Id {
+    fn next_id(&self) -> Id<T> {
         Id::new(self.count())
     }
 }


### PR DESCRIPTION
This makes the `Id` (previously called `Index`) and `Span` types in our arena library parameterized on the type they refer to. So, for example, `Id<Segment>` is still "just" a `u32`, but it is a distinct type from `Id<Path>` (which is also just a `u32` under the hood, of course). This makes the code a little more self-documenting and makes it impossible to confuse references to different types. It is, of course, still very much possible to confuse ids for different arenas of the _same_ type!

Anyway, this was quite a bit less painful than I was expecting, so I think it's probably a good idea, despite the extra complexity.