### PR TITLE
Use newtypes for the arena types

### DIFF
--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -1,4 +1,5 @@
 use flatgfa::flatgfa::{FlatGFA, HeapGFAStore};
+use flatgfa::pool::Id;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
@@ -117,7 +118,7 @@ impl PySegment {
     /// so it is slow to use for large sequences.
     fn sequence<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
         let view = self.gfa.view();
-        let seg = view.segs.get_id(self.id.into());
+        let seg = &view.segs[Id::from(self.id)];
         let seq = view.get_seq(&seg);
         PyBytes::new_bound(py, seq)
     }
@@ -125,7 +126,7 @@ impl PySegment {
     #[getter]
     fn name(&self) -> usize {
         let view = self.gfa.view();
-        let seg = view.segs.get_id(self.id.into());
+        let seg = view.segs[Id::from(self.id)];
         seg.name
     }
 

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -70,7 +70,7 @@ impl SegmentList {
     }
 
     fn __len__(&self) -> usize {
-        self.gfa.view().segs.count()
+        self.gfa.view().segs.len()
     }
 }
 
@@ -88,7 +88,7 @@ impl SegmentIter {
 
     fn __next__(&mut self) -> Option<PySegment> {
         let view = self.gfa.view();
-        if self.idx < view.segs.count() as u32 {
+        if self.idx < view.segs.len() as u32 {
             let seg = PySegment {
                 gfa: self.gfa.clone(),
                 id: self.idx,

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -106,7 +106,7 @@ pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static s
     // Traverse the path until we reach the position.
     let mut cur_pos = 0;
     let mut found = None;
-    for step in gfa.get_steps(path) {
+    for step in &gfa.steps[path.steps] {
         let seg = gfa.get_handle_seg(*step);
         let end_pos = cur_pos + seg.len();
         if offset < end_pos {
@@ -214,7 +214,7 @@ impl<'a> SubgraphBuilder<'a> {
         let mut cur_subpath_start: Option<SubpathStart> = None;
         let mut path_pos = 0;
 
-        for step in self.old.get_steps(path) {
+        for step in &self.old.steps[path.steps] {
             let in_neighb = self.seg_map.contains_key(&step.segment());
 
             if let (Some(start), false) = (&cur_subpath_start, in_neighb) {
@@ -301,7 +301,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA) {
     // do not assume that each handle in `gfa.steps()` is unique
     for path in gfa.paths.all() {
         let path_name = gfa.get_path_name(path);
-        for step in gfa.get_steps(path) {
+        for step in &gfa.steps[path.steps] {
             let seg_id = step.segment().index();
             // Increment depths
             depths[seg_id] = depths[seg_id] + 1;

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -96,7 +96,7 @@ pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static s
     };
 
     let path_id = gfa.find_path(path_name.into()).ok_or("path not found")?;
-    let path = gfa.paths.get_id(path_id);
+    let path = &gfa.paths[path_id];
     assert_eq!(
         orientation,
         flatgfa::Orientation::Forward,
@@ -183,7 +183,7 @@ impl<'a> SubgraphBuilder<'a> {
 
     /// Add a segment from the source graph to this subgraph.
     fn include_seg(&mut self, seg_id: Id<Segment>) {
-        let seg = self.old.segs.get_id(seg_id);
+        let seg = &self.old.segs[seg_id];
         let new_seg_id = self.store.add_seg(
             seg.name,
             self.old.get_seq(seg),

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -10,17 +10,17 @@ use std::collections::{HashMap, HashSet};
 pub struct Toc {}
 
 pub fn toc(gfa: &flatgfa::FlatGFA) {
-    eprintln!("header: {}", gfa.header.count());
-    eprintln!("segs: {}", gfa.segs.count());
-    eprintln!("paths: {}", gfa.paths.count());
-    eprintln!("links: {}", gfa.links.count());
-    eprintln!("steps: {}", gfa.steps.count());
-    eprintln!("seq_data: {}", gfa.seq_data.count());
-    eprintln!("overlaps: {}", gfa.overlaps.count());
-    eprintln!("alignment: {}", gfa.alignment.count());
-    eprintln!("name_data: {}", gfa.name_data.count());
-    eprintln!("optional_data: {}", gfa.optional_data.count());
-    eprintln!("line_order: {}", gfa.line_order.count());
+    eprintln!("header: {}", gfa.header.len());
+    eprintln!("segs: {}", gfa.segs.len());
+    eprintln!("paths: {}", gfa.paths.len());
+    eprintln!("links: {}", gfa.links.len());
+    eprintln!("steps: {}", gfa.steps.len());
+    eprintln!("seq_data: {}", gfa.seq_data.len());
+    eprintln!("overlaps: {}", gfa.overlaps.len());
+    eprintln!("alignment: {}", gfa.alignment.len());
+    eprintln!("name_data: {}", gfa.name_data.len());
+    eprintln!("optional_data: {}", gfa.optional_data.len());
+    eprintln!("line_order: {}", gfa.line_order.len());
 }
 
 /// list the paths
@@ -52,11 +52,11 @@ pub fn stats(gfa: &flatgfa::FlatGFA, args: Stats) {
         println!("#length\tnodes\tedges\tpaths\tsteps");
         println!(
             "{}\t{}\t{}\t{}\t{}",
-            gfa.seq_data.count(),
-            gfa.segs.count(),
-            gfa.links.count(),
-            gfa.paths.count(),
-            gfa.steps.count()
+            gfa.seq_data.len(),
+            gfa.segs.len(),
+            gfa.links.len(),
+            gfa.paths.len(),
+            gfa.steps.len()
         );
     } else if args.self_loops {
         let mut counts: HashMap<Id<Segment>, usize> = HashMap::new();
@@ -294,10 +294,10 @@ pub struct Depth {}
 pub fn depth(gfa: &flatgfa::FlatGFA) {
     // Initialize node depth
     let mut depths = Vec::new();
-    depths.resize(gfa.segs.count(), 0);
+    depths.resize(gfa.segs.len(), 0);
     // Initialize uniq_paths
     let mut uniq_paths = Vec::<HashSet<&BStr>>::new();
-    uniq_paths.resize(gfa.segs.count(), HashSet::new());
+    uniq_paths.resize(gfa.segs.len(), HashSet::new());
     // do not assume that each handle in `gfa.steps()` is unique
     for path in gfa.paths.all() {
         let path_name = gfa.get_path_name(path);

--- a/flatgfa/src/file.rs
+++ b/flatgfa/src/file.rs
@@ -39,14 +39,14 @@ struct Size {
 impl Size {
     fn of_pool<'a, T>(pool: Pool<'a, T>) -> Self {
         Size {
-            len: pool.count(),
-            capacity: pool.count(),
+            len: pool.len(),
+            capacity: pool.len(),
         }
     }
 
     fn of_store<T: Clone>(store: &FixedStore<'_, T>) -> Self {
         Size {
-            len: store.count(),
+            len: store.len(),
             capacity: store.capacity(),
         }
     }

--- a/flatgfa/src/file.rs
+++ b/flatgfa/src/file.rs
@@ -37,7 +37,7 @@ struct Size {
 }
 
 impl Size {
-    fn of_pool<'a, T>(pool: Pool<'a, T>) -> Self {
+    fn of_pool<T>(pool: Pool<T>) -> Self {
         Size {
             len: pool.len(),
             capacity: pool.len(),

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -256,12 +256,12 @@ impl<'a> FlatGFA<'a> {
 
     /// Get all the steps for a path.
     pub fn get_steps(&self, path: &Path) -> &[Handle] {
-        &self.steps.get_span(path.steps)
+        self.steps.get_span(path.steps)
     }
 
     /// Get all the overlaps for a path. This may be empty (`*` in the GFA file).
     pub fn get_overlaps(&self, path: &Path) -> &[Span<AlignOp>] {
-        &self.overlaps.get_span(path.overlaps)
+        self.overlaps.get_span(path.overlaps)
     }
 
     /// Get the string name of a path.
@@ -271,7 +271,7 @@ impl<'a> FlatGFA<'a> {
 
     /// Get a handle's associated segment.
     pub fn get_handle_seg(&self, handle: Handle) -> &Segment {
-        &self.segs.get_id(handle.segment())
+        self.segs.get_id(handle.segment())
     }
 
     /// Get the optional data for a segment, as a tab-separated string.
@@ -282,7 +282,7 @@ impl<'a> FlatGFA<'a> {
     /// Look up a CIGAR alignment.
     pub fn get_alignment(&self, overlap: Span<AlignOp>) -> Alignment {
         Alignment {
-            ops: &self.alignment.get_span(overlap),
+            ops: self.alignment.get_span(overlap),
         }
     }
 

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -254,18 +254,6 @@ impl<'a> FlatGFA<'a> {
         self.paths.search(|path| self.get_path_name(path) == name)
     }
 
-    /// Get all the steps for a path.
-    pub fn get_steps(&self, path: &Path) -> &[Handle] {
-        // TODO killable
-        &self.steps[path.steps]
-    }
-
-    /// Get all the overlaps for a path. This may be empty (`*` in the GFA file).
-    pub fn get_overlaps(&self, path: &Path) -> &[Span<AlignOp>] {
-        // TODO killable
-        &self.overlaps[path.overlaps]
-    }
-
     /// Get the string name of a path.
     pub fn get_path_name(&self, path: &Path) -> &BStr {
         self.name_data[path.name].as_ref()

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -314,7 +314,7 @@ pub struct GFAStore<'a, P: StoreFamily<'a>> {
 impl<'a, P: StoreFamily<'a>> GFAStore<'a, P> {
     /// Add a header line for the GFA file. This may only be added once.
     pub fn add_header(&mut self, version: &[u8]) {
-        assert!(self.header.as_ref().count() == 0);
+        assert!(self.header.as_ref().is_empty());
         self.header.add_slice(version);
     }
 

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -301,21 +301,21 @@ impl<'a> FlatGFA<'a> {
 
 /// The data storage pools for a `FlatGFA`.
 #[derive(Default)]
-pub struct GFAStore<'a, P: PoolFamily<'a>> {
-    pub header: P::Pool<u8>,
-    pub segs: P::Pool<Segment>,
-    pub paths: P::Pool<Path>,
-    pub links: P::Pool<Link>,
-    pub steps: P::Pool<Handle>,
-    pub seq_data: P::Pool<u8>,
-    pub overlaps: P::Pool<Span<AlignOp>>,
-    pub alignment: P::Pool<AlignOp>,
-    pub name_data: P::Pool<u8>,
-    pub optional_data: P::Pool<u8>,
-    pub line_order: P::Pool<u8>,
+pub struct GFAStore<'a, P: StoreFamily<'a>> {
+    pub header: P::Store<u8>,
+    pub segs: P::Store<Segment>,
+    pub paths: P::Store<Path>,
+    pub links: P::Store<Link>,
+    pub steps: P::Store<Handle>,
+    pub seq_data: P::Store<u8>,
+    pub overlaps: P::Store<Span<AlignOp>>,
+    pub alignment: P::Store<AlignOp>,
+    pub name_data: P::Store<u8>,
+    pub optional_data: P::Store<u8>,
+    pub line_order: P::Store<u8>,
 }
 
-impl<'a, P: PoolFamily<'a>> GFAStore<'a, P> {
+impl<'a, P: StoreFamily<'a>> GFAStore<'a, P> {
     /// Add a header line for the GFA file. This may only be added once.
     pub fn add_header(&mut self, version: &[u8]) {
         assert!(self.header.count() == 0);
@@ -393,19 +393,19 @@ impl<'a, P: PoolFamily<'a>> GFAStore<'a, P> {
     }
 }
 
-pub trait PoolFamily<'a> {
-    type Pool<T: Clone + 'a>: crate::pool::Store<T>;
+pub trait StoreFamily<'a> {
+    type Store<T: Clone + 'a>: crate::pool::Store<T>;
 }
 
 #[derive(Default)]
-pub struct VecPoolFamily;
-impl<'a> PoolFamily<'a> for VecPoolFamily {
-    type Pool<T: Clone + 'a> = Vec<T>;
+pub struct VecFamily;
+impl<'a> StoreFamily<'a> for VecFamily {
+    type Store<T: Clone + 'a> = Vec<T>;
 }
 
-pub struct SliceVecPoolFamily;
-impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
-    type Pool<T: Clone + 'a> = SliceVec<'a, T>;
+pub struct SliceVecFamily;
+impl<'a> StoreFamily<'a> for SliceVecFamily {
+    type Store<T: Clone + 'a> = SliceVec<'a, T>;
 }
 
 /// A store for `FlatGFA` data backed by fixed-size slices.
@@ -413,11 +413,11 @@ impl<'a> PoolFamily<'a> for SliceVecPoolFamily {
 /// This store contains `SliceVec`s, which act like `Vec`s but are allocated within
 /// a fixed region. This means they have a maximum size, but they can directly map
 /// onto the contents of a file.
-pub type SliceStore<'a> = GFAStore<'a, SliceVecPoolFamily>;
+pub type SliceStore<'a> = GFAStore<'a, SliceVecFamily>;
 
 /// A mutable, in-memory data store for `FlatGFA`.
 ///
 /// This store contains a bunch of `Vec`s: one per array required to implement a
 /// `FlatGFA`. It exposes an API for building up a GFA data structure, so it is
 /// useful for creating new ones from scratch.
-pub type HeapStore = GFAStore<'static, VecPoolFamily>;
+pub type HeapStore = GFAStore<'static, VecFamily>;

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -1,9 +1,8 @@
 use std::str::FromStr;
 
-use crate::pool::{Id, Pool, Span, Store};
+use crate::pool::{self, Id, Pool, Span, Store};
 use bstr::BStr;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use tinyvec::SliceVec;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// An efficient flattened representation of a GFA file.
@@ -17,20 +16,20 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes};
 pub struct FlatGFA<'a> {
     /// A GFA may optionally have a single header line, with a version number.
     /// If this is empty, there is no header line.
-    pub header: &'a [u8],
+    pub header: Pool<'a, u8>,
 
     /// The segment (S) lines in the GFA file.
-    pub segs: &'a [Segment],
+    pub segs: Pool<'a, Segment>,
 
     /// The path (P) lines.
-    pub paths: &'a [Path],
+    pub paths: Pool<'a, Path>,
 
     /// The link (L) lines.
-    pub links: &'a [Link],
+    pub links: Pool<'a, Link>,
 
     /// Paths consist of steps. This is a flat pool of steps, chunks of which are
     /// associated with each path.
-    pub steps: &'a [Handle],
+    pub steps: Pool<'a, Handle>,
 
     /// The actual base-pair sequences for the segments. This is a pool of
     /// base-pair symbols, chunks of which are associated with each segment.
@@ -38,30 +37,30 @@ pub struct FlatGFA<'a> {
     /// TODO: This could certainly use a smaller representation than `u8`
     /// (since we care only about 4 base pairs). If we want to pay the cost
     /// of bit-packing.
-    pub seq_data: &'a [u8],
+    pub seq_data: Pool<'a, u8>,
 
     /// Both paths and links can have overlaps, which are CIGAR sequences. They
     /// are all stored together here in a flat pool, elements of which point
     /// to chunks of `alignment`.
-    pub overlaps: &'a [Span<AlignOp>],
+    pub overlaps: Pool<'a, Span<AlignOp>>,
 
     /// The CIGAR aligment operations that make up the overlaps. `overlaps`
     /// contains range of indices in this pool.
-    pub alignment: &'a [AlignOp],
+    pub alignment: Pool<'a, AlignOp>,
 
     /// The string names: currenly, just of paths. (We assume segments have integer
     /// names, so they don't need to be stored separately.)
-    pub name_data: &'a [u8],
+    pub name_data: Pool<'a, u8>,
 
     /// Segments can come with optional extra fields, which we store in a flat pool
     /// as raw characters because we don't currently care about them.
-    pub optional_data: &'a [u8],
+    pub optional_data: Pool<'a, u8>,
 
     /// An "interleaving" order of GFA lines. This is to preserve perfect round-trip
     /// fidelity: we record the order of lines as we saw them when parsing a GFA file
     /// so we can emit them again in that order. Elements should be `LineKind` values
     /// (but they are checked before we use them).
-    pub line_order: &'a [u8],
+    pub line_order: Pool<'a, u8>,
 }
 
 /// GFA graphs consist of "segment" nodes, which are fragments of base-pair sequences
@@ -247,18 +246,12 @@ impl<'a> FlatGFA<'a> {
     pub fn find_seg(&self, name: usize) -> Option<Id<Segment>> {
         // TODO Make this more efficient by maintaining the name index? This would not be
         // too hard; we already have the machinery in `parse.rs`...
-        self.segs
-            .iter()
-            .position(|seg| seg.name == name)
-            .map(|i| Id::new(i))
+        self.segs.search(|seg| seg.name == name)
     }
 
     /// Look up a path by its name.
     pub fn find_path(&self, name: &BStr) -> Option<Id<Path>> {
-        self.paths
-            .iter()
-            .position(|path| self.get_path_name(path) == name)
-            .map(|i| Id::new(i))
+        self.paths.search(|path| self.get_path_name(path) == name)
     }
 
     /// Get all the steps for a path.
@@ -295,7 +288,10 @@ impl<'a> FlatGFA<'a> {
 
     /// Get the recorded order of line kinds.
     pub fn get_line_order(&self) -> impl Iterator<Item = LineKind> + 'a {
-        self.line_order.iter().map(|b| (*b).try_into().unwrap())
+        self.line_order
+            .all()
+            .iter()
+            .map(|b| (*b).try_into().unwrap())
     }
 }
 
@@ -318,7 +314,7 @@ pub struct GFAStore<'a, P: StoreFamily<'a>> {
 impl<'a, P: StoreFamily<'a>> GFAStore<'a, P> {
     /// Add a header line for the GFA file. This may only be added once.
     pub fn add_header(&mut self, version: &[u8]) {
-        assert!(self.header.count() == 0);
+        assert!(self.header.as_ref().count() == 0);
         self.header.add_slice(version);
     }
 
@@ -378,34 +374,34 @@ impl<'a, P: StoreFamily<'a>> GFAStore<'a, P> {
     /// Borrow a FlatGFA view of this data store.
     pub fn as_ref(&self) -> FlatGFA {
         FlatGFA {
-            header: &self.header,
-            segs: &self.segs,
-            paths: &self.paths,
-            links: &self.links,
-            name_data: &self.name_data,
-            seq_data: &self.seq_data,
-            steps: &self.steps,
-            overlaps: &self.overlaps,
-            alignment: &self.alignment,
-            optional_data: &self.optional_data,
-            line_order: &self.line_order,
+            header: self.header.as_ref(),
+            segs: self.segs.as_ref(),
+            paths: self.paths.as_ref(),
+            links: self.links.as_ref(),
+            name_data: self.name_data.as_ref(),
+            seq_data: self.seq_data.as_ref(),
+            steps: self.steps.as_ref(),
+            overlaps: self.overlaps.as_ref(),
+            alignment: self.alignment.as_ref(),
+            optional_data: self.optional_data.as_ref(),
+            line_order: self.line_order.as_ref(),
         }
     }
 }
 
 pub trait StoreFamily<'a> {
-    type Store<T: Clone + 'a>: crate::pool::Store<T>;
+    type Store<T: Clone + 'a>: pool::Store<T>;
 }
 
 #[derive(Default)]
-pub struct VecFamily;
-impl<'a> StoreFamily<'a> for VecFamily {
-    type Store<T: Clone + 'a> = Vec<T>;
+pub struct HeapFamily;
+impl<'a> StoreFamily<'a> for HeapFamily {
+    type Store<T: Clone + 'a> = pool::HeapStore<T>;
 }
 
-pub struct SliceVecFamily;
-impl<'a> StoreFamily<'a> for SliceVecFamily {
-    type Store<T: Clone + 'a> = SliceVec<'a, T>;
+pub struct FixedFamily;
+impl<'a> StoreFamily<'a> for FixedFamily {
+    type Store<T: Clone + 'a> = pool::FixedStore<'a, T>;
 }
 
 /// A store for `FlatGFA` data backed by fixed-size slices.
@@ -413,11 +409,11 @@ impl<'a> StoreFamily<'a> for SliceVecFamily {
 /// This store contains `SliceVec`s, which act like `Vec`s but are allocated within
 /// a fixed region. This means they have a maximum size, but they can directly map
 /// onto the contents of a file.
-pub type SliceStore<'a> = GFAStore<'a, SliceVecFamily>;
+pub type FixedGFAStore<'a> = GFAStore<'a, FixedFamily>;
 
 /// A mutable, in-memory data store for `FlatGFA`.
 ///
 /// This store contains a bunch of `Vec`s: one per array required to implement a
 /// `FlatGFA`. It exposes an API for building up a GFA data structure, so it is
 /// useful for creating new ones from scratch.
-pub type HeapStore = GFAStore<'static, VecFamily>;
+pub type HeapGFAStore = GFAStore<'static, HeapFamily>;

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -239,7 +239,7 @@ pub enum LineKind {
 impl<'a> FlatGFA<'a> {
     /// Get the base-pair sequence for a segment.
     pub fn get_seq(&self, seg: &Segment) -> &BStr {
-        self.seq_data.get_span(seg.seq).as_ref()
+        self.seq_data[seg.seq].as_ref()
     }
 
     /// Look up a segment by its name.
@@ -256,33 +256,35 @@ impl<'a> FlatGFA<'a> {
 
     /// Get all the steps for a path.
     pub fn get_steps(&self, path: &Path) -> &[Handle] {
-        self.steps.get_span(path.steps)
+        // TODO killable
+        &self.steps[path.steps]
     }
 
     /// Get all the overlaps for a path. This may be empty (`*` in the GFA file).
     pub fn get_overlaps(&self, path: &Path) -> &[Span<AlignOp>] {
-        self.overlaps.get_span(path.overlaps)
+        // TODO killable
+        &self.overlaps[path.overlaps]
     }
 
     /// Get the string name of a path.
     pub fn get_path_name(&self, path: &Path) -> &BStr {
-        self.name_data.get_span(path.name).as_ref()
+        self.name_data[path.name].as_ref()
     }
 
     /// Get a handle's associated segment.
     pub fn get_handle_seg(&self, handle: Handle) -> &Segment {
-        self.segs.get_id(handle.segment())
+        &self.segs[handle.segment()]
     }
 
     /// Get the optional data for a segment, as a tab-separated string.
     pub fn get_optional_data(&self, seg: &Segment) -> &BStr {
-        self.optional_data.get_span(seg.optional).as_ref()
+        self.optional_data[seg.optional].as_ref()
     }
 
     /// Look up a CIGAR alignment.
     pub fn get_alignment(&self, overlap: Span<AlignOp>) -> Alignment {
         Alignment {
-            ops: self.alignment.get_span(overlap),
+            ops: &self.alignment[overlap],
         }
     }
 

--- a/flatgfa/src/main.rs
+++ b/flatgfa/src/main.rs
@@ -150,12 +150,12 @@ fn prealloc_translate(in_name: Option<&str>, out_name: &str, prealloc_factor: us
     match input_buf {
         Some(buf) => {
             let store = Parser::for_slice(store).parse_mem(buf);
-            *toc = file::Toc::for_slice_store(&store)
+            *toc = file::Toc::for_fixed_store(&store)
         }
         None => {
             let stdin = std::io::stdin();
             let store = Parser::for_slice(store).parse_stream(stdin.lock());
-            *toc = file::Toc::for_slice_store(&store)
+            *toc = file::Toc::for_fixed_store(&store)
         }
     };
 

--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -169,14 +169,14 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
     }
 }
 
-impl Parser<'static, flatgfa::VecFamily> {
+impl Parser<'static, flatgfa::HeapFamily> {
     pub fn for_heap() -> Self {
-        Self::new(flatgfa::HeapStore::default())
+        Self::new(flatgfa::HeapGFAStore::default())
     }
 }
 
-impl<'a> Parser<'a, flatgfa::SliceVecFamily> {
-    pub fn for_slice(store: flatgfa::SliceStore<'a>) -> Self {
+impl<'a> Parser<'a, flatgfa::FixedFamily> {
+    pub fn for_slice(store: flatgfa::FixedGFAStore<'a>) -> Self {
         Self::new(store)
     }
 }

--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -3,7 +3,7 @@ use crate::gfaline;
 use std::collections::HashMap;
 use std::io::BufRead;
 
-pub struct Parser<'a, P: flatgfa::PoolFamily<'a>> {
+pub struct Parser<'a, P: flatgfa::StoreFamily<'a>> {
     /// The flat representation we're building.
     flat: flatgfa::GFAStore<'a, P>,
 
@@ -11,7 +11,7 @@ pub struct Parser<'a, P: flatgfa::PoolFamily<'a>> {
     seg_ids: NameMap,
 }
 
-impl<'a, P: flatgfa::PoolFamily<'a>> Parser<'a, P> {
+impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
     pub fn new(builder: flatgfa::GFAStore<'a, P>) -> Self {
         Self {
             flat: builder,
@@ -169,13 +169,13 @@ impl<'a, P: flatgfa::PoolFamily<'a>> Parser<'a, P> {
     }
 }
 
-impl Parser<'static, flatgfa::VecPoolFamily> {
+impl Parser<'static, flatgfa::VecFamily> {
     pub fn for_heap() -> Self {
         Self::new(flatgfa::HeapStore::default())
     }
 }
 
-impl<'a> Parser<'a, flatgfa::SliceVecPoolFamily> {
+impl<'a> Parser<'a, flatgfa::SliceVecFamily> {
     pub fn for_slice(store: flatgfa::SliceStore<'a>) -> Self {
         Self::new(store)
     }

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -87,7 +87,7 @@ impl<T> Span<T> {
 /// access to the current set of objects (but not addition of new objects).
 pub trait Store<T: Clone> {
     /// Get a fixed-size view of the arena.
-    fn as_ref<'a>(&'a self) -> Pool<'a, T>;
+    fn as_ref(&self) -> Pool<T>;
 
     /// Add an item to the pool and get the new id.
     fn add(&mut self, item: T) -> Id<T>;
@@ -120,7 +120,7 @@ pub trait Store<T: Clone> {
 pub struct HeapStore<T>(Vec<T>);
 
 impl<T: Clone> Store<T> for HeapStore<T> {
-    fn as_ref<'a>(&'a self) -> Pool<'a, T> {
+    fn as_ref(&self) -> Pool<T> {
         Pool(&self.0)
     }
 
@@ -162,7 +162,7 @@ impl<T> Default for HeapStore<T> {
 pub struct FixedStore<'a, T>(SliceVec<'a, T>);
 
 impl<'a, T: Clone> Store<T> for FixedStore<'a, T> {
-    fn as_ref<'b>(&'b self) -> Pool<'b, T> {
+    fn as_ref(&self) -> Pool<T> {
         Pool(&self.0)
     }
 

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -100,11 +100,16 @@ pub trait Store<T: Clone> {
     fn add_slice(&mut self, slice: &[T]) -> Span<T>;
 
     /// Get the number of items in the pool.
-    fn count(&self) -> usize;
+    fn len(&self) -> usize;
+
+    /// Check whether the pool is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Get the next available ID.
     fn next_id(&self) -> Id<T> {
-        Id::new(self.count())
+        Id::new(self.len())
     }
 }
 
@@ -137,7 +142,7 @@ impl<T: Clone> Store<T> for HeapStore<T> {
         Span::new(start, self.as_ref().next_id())
     }
 
-    fn count(&self) -> usize {
+    fn len(&self) -> usize {
         self.0.len()
     }
 }
@@ -179,8 +184,7 @@ impl<'a, T: Clone> Store<T> for FixedStore<'a, T> {
         Span::new(start, self.next_id())
     }
 
-    // TODO: Rename count to len...
-    fn count(&self) -> usize {
+    fn len(&self) -> usize {
         self.0.len()
     }
 }
@@ -217,13 +221,18 @@ impl<'a, T> Pool<'a, T> {
     }
 
     /// Get the number of items in the pool.
-    pub fn count(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    /// Check if the pool is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     /// Get the next available ID.
     pub fn next_id(&self) -> Id<T> {
-        Id::new(self.count())
+        Id::new(self.len())
     }
 
     /// Get the entire pool as a slice.

--- a/flatgfa/src/print.rs
+++ b/flatgfa/src/print.rs
@@ -90,7 +90,7 @@ fn print_preserved(gfa: &flatgfa::FlatGFA) {
         match kind {
             flatgfa::LineKind::Header => {
                 let version = gfa.header;
-                assert!(version.count() > 0);
+                assert!(!version.is_empty());
                 println!("H\t{}", bstr::BStr::new(version.all()));
             }
             flatgfa::LineKind::Segment => {
@@ -108,7 +108,7 @@ fn print_preserved(gfa: &flatgfa::FlatGFA) {
 
 /// Print a graph in a normalized order, ignoring the original GFA line order.
 pub fn print_normalized(gfa: &flatgfa::FlatGFA) {
-    if gfa.header.count() > 0 {
+    if !gfa.header.is_empty() {
         println!("H\t{}", bstr::BStr::new(gfa.header.all()));
     }
     for seg in gfa.segs.all().iter() {
@@ -124,7 +124,7 @@ pub fn print_normalized(gfa: &flatgfa::FlatGFA) {
 
 /// Print our flat representation as a GFA text file to stdout.
 pub fn print(gfa: &flatgfa::FlatGFA) {
-    if gfa.line_order.count() == 0 {
+    if gfa.line_order.is_empty() {
         print_normalized(gfa);
     } else {
         print_preserved(gfa);

--- a/flatgfa/src/print.rs
+++ b/flatgfa/src/print.rs
@@ -38,14 +38,14 @@ fn print_step(gfa: &flatgfa::FlatGFA, handle: flatgfa::Handle) {
 
 fn print_path(gfa: &flatgfa::FlatGFA, path: &flatgfa::Path) {
     print!("P\t{}\t", gfa.get_path_name(path));
-    let steps = gfa.get_steps(path);
+    let steps = &gfa.steps[path.steps];
     print_step(gfa, steps[0]);
     for step in steps[1..].iter() {
         print!(",");
         print_step(gfa, *step);
     }
     print!("\t");
-    let overlaps = gfa.get_overlaps(path);
+    let overlaps = &gfa.overlaps[path.overlaps];
     if overlaps.is_empty() {
         print!("*");
     } else {

--- a/flatgfa/src/print.rs
+++ b/flatgfa/src/print.rs
@@ -83,15 +83,15 @@ fn print_seg(gfa: &flatgfa::FlatGFA, seg: &flatgfa::Segment) {
 
 /// Print a graph in the order preserved from an original GFA file.
 fn print_preserved(gfa: &flatgfa::FlatGFA) {
-    let mut seg_iter = gfa.segs.iter();
-    let mut path_iter = gfa.paths.iter();
-    let mut link_iter = gfa.links.iter();
+    let mut seg_iter = gfa.segs.all().iter();
+    let mut path_iter = gfa.paths.all().iter();
+    let mut link_iter = gfa.links.all().iter();
     for kind in gfa.get_line_order() {
         match kind {
             flatgfa::LineKind::Header => {
                 let version = gfa.header;
-                assert!(!version.is_empty());
-                println!("H\t{}", bstr::BStr::new(version));
+                assert!(version.count() > 0);
+                println!("H\t{}", bstr::BStr::new(version.all()));
             }
             flatgfa::LineKind::Segment => {
                 print_seg(gfa, seg_iter.next().expect("too few segments"));
@@ -108,23 +108,23 @@ fn print_preserved(gfa: &flatgfa::FlatGFA) {
 
 /// Print a graph in a normalized order, ignoring the original GFA line order.
 pub fn print_normalized(gfa: &flatgfa::FlatGFA) {
-    if !gfa.header.is_empty() {
-        println!("H\t{}", bstr::BStr::new(gfa.header));
+    if gfa.header.count() > 0 {
+        println!("H\t{}", bstr::BStr::new(gfa.header.all()));
     }
-    for seg in gfa.segs.iter() {
+    for seg in gfa.segs.all().iter() {
         print_seg(gfa, seg);
     }
-    for path in gfa.paths.iter() {
+    for path in gfa.paths.all().iter() {
         print_path(gfa, path);
     }
-    for link in gfa.links.iter() {
+    for link in gfa.links.all().iter() {
         print_link(gfa, link);
     }
 }
 
 /// Print our flat representation as a GFA text file to stdout.
 pub fn print(gfa: &flatgfa::FlatGFA) {
-    if gfa.line_order.is_empty() {
+    if gfa.line_order.count() == 0 {
         print_normalized(gfa);
     } else {
         print_preserved(gfa);


### PR DESCRIPTION
Our little homegrown arena library, called `pool`, is a little like [id-arena](https://docs.rs/id-arena/latest/id_arena/) or similar, but with special stuff we need for our "zero-copy" use case.

Previously, it was implemented as special traits that extend plain old Rust types like `&[T]` and `Vec<T>`. This was convenient in some ways but got confusing and prevented some fancier convenience features. I've now wrapped these in newtypes `Store` and `Pool` that let us more carefully control the interface to the arenas. This should be less error-prone in the long run. As an added bonus, it makes it easier to access pools with subscripting: for example, `gfa.segs[id]` works where `id` has type `Id<Segment>`.