### PR TITLE
Python FlatGFA bindings: refactoring, expose Paths

### DIFF
--- a/flatgfa-py/example.py
+++ b/flatgfa-py/example.py
@@ -7,3 +7,5 @@ for seg in g.segments:
 
 g = flatgfa.load("../bench/graphs/test.k.flatgfa")
 print(len(g.segments))
+for path in g.paths:
+    print(path, path.name)

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -1,5 +1,5 @@
-use flatgfa::flatgfa::{FlatGFA, HeapGFAStore, Segment};
 use flatgfa::pool::Id;
+use flatgfa::{self, FlatGFA, HeapGFAStore};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::sync::Arc;
@@ -131,7 +131,7 @@ impl SegmentIter {
 #[pyo3(name = "Segment", module = "flatgfa")]
 struct PySegment {
     store: Arc<Store>,
-    id: Id<Segment>,
+    id: Id<flatgfa::Segment>,
 }
 
 #[pymethods]
@@ -143,7 +143,7 @@ impl PySegment {
     fn sequence<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
         let view = self.store.view();
         let seg = &view.segs[self.id];
-        let seq = view.get_seq(&seg);
+        let seq = view.get_seq(seg);
         PyBytes::new_bound(py, seq)
     }
 

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -109,8 +109,8 @@ impl SegmentIter {
     }
 
     fn __next__(&mut self) -> Option<PySegment> {
-        let view = self.store.view();
-        if self.idx < view.segs.len() as u32 {
+        let gfa = self.store.view();
+        if self.idx < gfa.segs.len() as u32 {
             let seg = PySegment {
                 store: self.store.clone(),
                 id: Id::from(self.idx),
@@ -141,17 +141,16 @@ impl PySegment {
     /// This copies the underlying sequence data to contruct the Python bytes object,
     /// so it is slow to use for large sequences.
     fn sequence<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        let view = self.store.view();
-        let seg = &view.segs[self.id];
-        let seq = view.get_seq(seg);
+        let gfa = self.store.view();
+        let seg = &gfa.segs[self.id];
+        let seq = gfa.get_seq(seg);
         PyBytes::new_bound(py, seq)
     }
 
     /// The segment's name as declared in the GFA file.
     #[getter]
     fn name(&self) -> usize {
-        let view = self.store.view();
-        let seg = view.segs[self.id];
+        let seg = self.store.view().segs[self.id];
         seg.name
     }
 

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -86,7 +86,7 @@ pub struct Position {
 pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static str> {
     // Parse the position triple, which looks like `path,42,+`.
     let (path_name, offset, orientation) = {
-        let parts: Vec<_> = args.path_pos.split(",").collect();
+        let parts: Vec<_> = args.path_pos.split(',').collect();
         if parts.len() != 3 {
             return Err("position must be path_name,offset,orientation");
         }
@@ -293,8 +293,7 @@ pub struct Depth {}
 
 pub fn depth(gfa: &flatgfa::FlatGFA) {
     // Initialize node depth
-    let mut depths = Vec::new();
-    depths.resize(gfa.segs.len(), 0);
+    let mut depths = vec![0; gfa.segs.len()];
     // Initialize uniq_paths
     let mut uniq_paths = Vec::<HashSet<&BStr>>::new();
     uniq_paths.resize(gfa.segs.len(), HashSet::new());
@@ -304,7 +303,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA) {
         for step in &gfa.steps[path.steps] {
             let seg_id = step.segment().index();
             // Increment depths
-            depths[seg_id] = depths[seg_id] + 1;
+            depths[seg_id] += 1;
             // Update uniq_paths
             uniq_paths[seg_id].insert(path_name);
         }

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -79,6 +79,7 @@ pub struct Segment {
 }
 
 impl Segment {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.seq.len()
     }
@@ -214,6 +215,11 @@ impl AlignOp {
     /// Get the length of the operation.
     pub fn len(&self) -> u32 {
         self.0 >> 8
+    }
+
+    /// Check whether there are zero operations in this alignment.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 

--- a/flatgfa/src/lib.rs
+++ b/flatgfa/src/lib.rs
@@ -5,3 +5,5 @@ pub mod gfaline;
 pub mod parse;
 pub mod pool;
 pub mod print;
+
+pub use flatgfa::*;


### PR DESCRIPTION
There's obviously a lot more to be done on the Python bindings, but here's a nearer-term checkpoint. It refactors stuff a bunch to make things more extensible, and it uses that extensibility to expose the paths in a graph. Now, hopefully, exposing stuff like the steps within a path will be a lot easier…