### PR TITLE
Lots more FlatGFA Python business

### DIFF
--- a/flatgfa-py/Cargo.lock
+++ b/flatgfa-py/Cargo.lock
@@ -135,6 +135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "inventory"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+
+[[package]]
 name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +272,7 @@ checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
+ "inventory",
  "libc",
  "memoffset",
  "parking_lot",

--- a/flatgfa-py/Cargo.toml
+++ b/flatgfa-py/Cargo.toml
@@ -8,6 +8,6 @@ name = "flatgfa"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21.2", features = ["abi3-py38"] }
+pyo3 = { version = "0.21.2", features = ["abi3-py38", "multiple-pymethods"] }
 flatgfa = { path = "../flatgfa" }
 memmap = "0.7.0"

--- a/flatgfa-py/example.py
+++ b/flatgfa-py/example.py
@@ -10,13 +10,11 @@ print(len(g.segments))
 for path in g.paths:
     print(path, path.name)
     print(len(path))
-    print(','.join(
-        '{}{}'.format(
-            s.segment.name,
-            '+' if s.is_forward else '-'
+    print(
+        ",".join(
+            "{}{}".format(s.segment.name, "+" if s.is_forward else "-") for s in path
         )
-        for s in path
-    ))
+    )
 for link in g.links:
     print(link, link.from_, link.to)
 

--- a/flatgfa-py/example.py
+++ b/flatgfa-py/example.py
@@ -22,3 +22,5 @@ for link in g.links:
 
 print(g.paths.find(b"x"))
 print(g.segments.find(2))
+
+print(g)

--- a/flatgfa-py/example.py
+++ b/flatgfa-py/example.py
@@ -9,3 +9,11 @@ g = flatgfa.load("../bench/graphs/test.k.flatgfa")
 print(len(g.segments))
 for path in g.paths:
     print(path, path.name)
+    print(len(path))
+    print(','.join(
+        '{}{}'.format(
+            s.segment.name,
+            '+' if s.is_forward else '-'
+        )
+        for s in path
+    ))

--- a/flatgfa-py/example.py
+++ b/flatgfa-py/example.py
@@ -19,3 +19,6 @@ for path in g.paths:
     ))
 for link in g.links:
     print(link, link.from_, link.to)
+
+print(g.paths.find(b"x"))
+print(g.segments.find(2))

--- a/flatgfa-py/example.py
+++ b/flatgfa-py/example.py
@@ -24,3 +24,5 @@ print(g.paths.find(b"x"))
 print(g.segments.find(2))
 
 print(g)
+g.write_gfa("temp.gfa")
+g.write_flatgfa("temp.flatgfa")

--- a/flatgfa-py/example.py
+++ b/flatgfa-py/example.py
@@ -17,3 +17,5 @@ for path in g.paths:
         )
         for s in path
     ))
+for link in g.links:
+    print(link, link.from_, link.to)

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -81,6 +81,11 @@ impl PyFlatGFA {
             store: self.0.clone(),
         }
     }
+
+    fn __str__(&self) -> String {
+        let gfa = self.0.view();
+        format!("{}", &gfa)
+    }
 }
 
 /// Generate the Python types for an iterable container of GFA objects.

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -190,6 +190,19 @@ impl PySegment {
     }
 }
 
+#[pymethods]
+impl SegmentList {
+    /// Find a segment by its name, or return None if not found.
+    fn find(&self, name: usize) -> Option<PySegment> {
+        let gfa = self.store.view();
+        let id = gfa.find_seg(name)?;
+        Some(PySegment {
+            store: self.store.clone(),
+            id,
+        })
+    }
+}
+
 /// A path in a GFA graph.
 ///
 /// Paths are walks through the GFA graph, where each step is an oriented segment.
@@ -233,6 +246,19 @@ impl PyPath {
     fn __len__(&self) -> usize {
         let path = self.store.view().paths[self.id];
         path.steps.len()
+    }
+}
+
+#[pymethods]
+impl PathList {
+    /// Find a path by its name, or return None if not found.
+    fn find(&self, name: &[u8]) -> Option<PyPath> {
+        let gfa = self.store.view();
+        let id = gfa.find_path(name.as_ref())?;
+        Some(PyPath {
+            store: self.store.clone(),
+            id,
+        })
     }
 }
 

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -329,6 +329,7 @@ impl PyLink {
         format!("<Link {}>", u32::from(self.id))
     }
 
+    /// The edge's source handle.
     #[getter]
     fn from_(&self) -> PyHandle {
         PyHandle {
@@ -337,6 +338,7 @@ impl PyLink {
         }
     }
 
+    /// The edge's sink handle.
     #[getter]
     fn to(&self) -> PyHandle {
         PyHandle {

--- a/flatgfa/src/main.rs
+++ b/flatgfa/src/main.rs
@@ -1,7 +1,7 @@
 use argh::FromArgs;
 use flatgfa::flatgfa::FlatGFA;
 use flatgfa::parse::Parser;
-use flatgfa::{cmds, file, parse, print};
+use flatgfa::{cmds, file, parse};
 
 #[derive(FromArgs)]
 /// Convert between GFA text and FlatGFA binary formats.
@@ -122,7 +122,9 @@ fn dump(gfa: &FlatGFA, output: &Option<String>) {
             file::dump(gfa, &mut mmap);
             mmap.flush().unwrap();
         }
-        None => print::print(gfa),
+        None => {
+            print!("{}", gfa);
+        }
     }
 }
 

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -71,6 +71,10 @@ impl<T> Span<T> {
         (self.end.0 - self.start.0) as usize
     }
 
+    pub fn contains(&self, id: Id<T>) -> bool {
+        self.start.0 <= id.0 && id.0 < self.end.0
+    }
+
     pub fn new(start: Id<T>, end: Id<T>) -> Self {
         Self {
             start,

--- a/flatgfa/src/print.rs
+++ b/flatgfa/src/print.rs
@@ -2,7 +2,7 @@ use crate::flatgfa;
 use std::fmt;
 
 impl fmt::Display for flatgfa::Orientation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             flatgfa::Orientation::Forward => write!(f, "+"),
             flatgfa::Orientation::Backward => write!(f, "-"),
@@ -11,7 +11,7 @@ impl fmt::Display for flatgfa::Orientation {
 }
 
 impl fmt::Display for flatgfa::AlignOpcode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             flatgfa::AlignOpcode::Match => write!(f, "M"),
             flatgfa::AlignOpcode::Gap => write!(f, "N"),
@@ -22,7 +22,7 @@ impl fmt::Display for flatgfa::AlignOpcode {
 }
 
 impl<'a> fmt::Display for flatgfa::Alignment<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for op in self.ops {
             write!(f, "{}{}", op.len(), op.op())?;
         }
@@ -30,59 +30,70 @@ impl<'a> fmt::Display for flatgfa::Alignment<'a> {
     }
 }
 
-fn print_step(gfa: &flatgfa::FlatGFA, handle: flatgfa::Handle) {
-    let seg = gfa.get_handle_seg(handle);
-    let name = seg.name;
-    print!("{}{}", name, handle.orient());
+/// A wrapper for displaying components from FlatGFA.
+struct Display<'a, T>(&'a flatgfa::FlatGFA<'a>, T);
+
+impl<'a> fmt::Display for Display<'a, flatgfa::Handle> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let seg = self.0.get_handle_seg(self.1);
+        let name = seg.name;
+        write!(f, "{}{}", name, self.1.orient())
+    }
 }
 
-fn print_path(gfa: &flatgfa::FlatGFA, path: &flatgfa::Path) {
-    print!("P\t{}\t", gfa.get_path_name(path));
-    let steps = &gfa.steps[path.steps];
-    print_step(gfa, steps[0]);
-    for step in steps[1..].iter() {
-        print!(",");
-        print_step(gfa, *step);
-    }
-    print!("\t");
-    let overlaps = &gfa.overlaps[path.overlaps];
-    if overlaps.is_empty() {
-        print!("*");
-    } else {
-        print!("{}", gfa.get_alignment(overlaps[0]));
-        for overlap in overlaps[1..].iter() {
-            print!(",{}", gfa.get_alignment(*overlap));
+impl<'a> fmt::Display for Display<'a, &flatgfa::Path> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "P\t{}\t", self.0.get_path_name(&self.1))?;
+        let steps = &self.0.steps[self.1.steps];
+        write!(f, "{}", Display(self.0, steps[0]))?;
+        for step in steps[1..].iter() {
+            write!(f, ",{}", Display(self.0, *step))?;
         }
+        write!(f, "\t")?;
+        let overlaps = &self.0.overlaps[self.1.overlaps];
+        if overlaps.is_empty() {
+            write!(f, "*")?;
+        } else {
+            write!(f, "{}", self.0.get_alignment(overlaps[0]))?;
+            for overlap in overlaps[1..].iter() {
+                write!(f, ",{}", self.0.get_alignment(*overlap))?;
+            }
+        }
+        writeln!(f)
     }
-    println!();
 }
 
-fn print_link(gfa: &flatgfa::FlatGFA, link: &flatgfa::Link) {
-    let from = link.from;
-    let from_name = gfa.get_handle_seg(from).name;
-    let to = link.to;
-    let to_name = gfa.get_handle_seg(to).name;
-    println!(
-        "L\t{}\t{}\t{}\t{}\t{}",
-        from_name,
-        from.orient(),
-        to_name,
-        to.orient(),
-        gfa.get_alignment(link.overlap)
-    );
+impl<'a> fmt::Display for Display<'a, &flatgfa::Link> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let from = self.1.from;
+        let from_name = self.0.get_handle_seg(from).name;
+        let to = self.1.to;
+        let to_name = self.0.get_handle_seg(to).name;
+        writeln!(
+            f,
+            "L\t{}\t{}\t{}\t{}\t{}",
+            from_name,
+            from.orient(),
+            to_name,
+            to.orient(),
+            self.0.get_alignment(self.1.overlap)
+        )
+    }
 }
 
-fn print_seg(gfa: &flatgfa::FlatGFA, seg: &flatgfa::Segment) {
-    let name = seg.name;
-    print!("S\t{}\t{}", name, gfa.get_seq(seg));
-    if !seg.optional.is_empty() {
-        print!("\t{}", gfa.get_optional_data(seg));
+impl<'a> fmt::Display for Display<'a, &flatgfa::Segment> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = self.1.name;
+        write!(f, "S\t{}\t{}", name, self.0.get_seq(self.1))?;
+        if !self.1.optional.is_empty() {
+            write!(f, "\t{}", self.0.get_optional_data(self.1))?;
+        }
+        writeln!(f)
     }
-    println!();
 }
 
 /// Print a graph in the order preserved from an original GFA file.
-fn print_preserved(gfa: &flatgfa::FlatGFA) {
+fn write_preserved(gfa: &flatgfa::FlatGFA, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let mut seg_iter = gfa.segs.all().iter();
     let mut path_iter = gfa.paths.all().iter();
     let mut link_iter = gfa.links.all().iter();
@@ -91,42 +102,49 @@ fn print_preserved(gfa: &flatgfa::FlatGFA) {
             flatgfa::LineKind::Header => {
                 let version = gfa.header;
                 assert!(!version.is_empty());
-                println!("H\t{}", bstr::BStr::new(version.all()));
+                writeln!(f, "H\t{}", bstr::BStr::new(version.all()))?;
             }
             flatgfa::LineKind::Segment => {
-                print_seg(gfa, seg_iter.next().expect("too few segments"));
+                let seg = seg_iter.next().expect("too few segments");
+                write!(f, "{}", Display(gfa, seg))?;
             }
             flatgfa::LineKind::Path => {
-                print_path(gfa, path_iter.next().expect("too few paths"));
+                let path = path_iter.next().expect("too few paths");
+                write!(f, "{}", Display(gfa, path))?;
             }
             flatgfa::LineKind::Link => {
-                print_link(gfa, link_iter.next().expect("too few links"));
+                let link = link_iter.next().expect("too few links");
+                write!(f, "{}", Display(gfa, link))?;
             }
         }
     }
+    Ok(())
 }
 
 /// Print a graph in a normalized order, ignoring the original GFA line order.
-pub fn print_normalized(gfa: &flatgfa::FlatGFA) {
+pub fn write_normalized(gfa: &flatgfa::FlatGFA, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     if !gfa.header.is_empty() {
-        println!("H\t{}", bstr::BStr::new(gfa.header.all()));
+        writeln!(f, "H\t{}", bstr::BStr::new(gfa.header.all()))?;
     }
     for seg in gfa.segs.all().iter() {
-        print_seg(gfa, seg);
+        write!(f, "{}", Display(gfa, seg))?;
     }
     for path in gfa.paths.all().iter() {
-        print_path(gfa, path);
+        write!(f, "{}", Display(gfa, path))?;
     }
     for link in gfa.links.all().iter() {
-        print_link(gfa, link);
+        write!(f, "{}", Display(gfa, link))?;
     }
+    Ok(())
 }
 
-/// Print our flat representation as a GFA text file to stdout.
-pub fn print(gfa: &flatgfa::FlatGFA) {
-    if gfa.line_order.is_empty() {
-        print_normalized(gfa);
-    } else {
-        print_preserved(gfa);
+/// Print our flat representation as in GFA text format.
+impl<'a> fmt::Display for &'a flatgfa::FlatGFA<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.line_order.is_empty() {
+            write_normalized(self, f)
+        } else {
+            write_preserved(self, f)
+        }
     }
 }


### PR DESCRIPTION
Some new features in the Python FlatGFA bindings:

* expose path steps via `for step in path: ...`
* expose links
* look up paths and segments by name with `g.paths.find()` and `g.segments.find()`
* `str(g)` gives you a GFA string
* write GFAs to files with `g.write_gfa()` and `g.write_flatgfa()`

Getting kinda close to feature-complete for an MVP.