### PR TITLE
Add tests for FlatGFA Python bindings

### DIFF
--- a/flatgfa-py/README.md
+++ b/flatgfa-py/README.md
@@ -21,4 +21,9 @@ Try our example:
 
     python example.py
 
+Or run the tests:
+
+    uv pip install pytest
+    pytest
+
 [maturin]: https://www.maturin.rs

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -1,0 +1,16 @@
+import pytest
+import flatgfa
+
+TEST_GFA = "../tests/k.gfa"
+
+
+@pytest.fixture
+def gfa():
+    return flatgfa.parse(TEST_GFA)
+
+
+def test_segs(gfa):
+    assert len(gfa.segments) == 15
+    seg = gfa.segments[0]
+    assert seg.name == 1
+    assert seg.sequence() == b"CAAATAAG"

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -20,8 +20,13 @@ def test_segs(gfa):
 
 def test_paths(gfa):
     assert len(gfa.paths) == 2
+    assert len(list(gfa.paths)) == 2
     path = gfa.paths[0]
     assert path.name == b"x"
+
+
+def test_path_steps(gfa):
+    path = gfa.paths[1]
     assert len(path) == 10
     step = list(path)[0]
     assert step.segment.name == 1

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -35,6 +35,13 @@ def test_segs(gfa):
     assert seg.name == 3
 
 
+def test_segs_find(gfa):
+    # There is a method to find a segment by its name (with linear search).
+    seg = gfa.segments.find(3)
+    assert seg.id == 2
+    assert seg.sequence() == b"TTG"
+
+
 def test_paths(gfa):
     # `gfa.paths` similarly acts like a list.
     assert len(gfa.paths) == 2
@@ -43,6 +50,13 @@ def test_paths(gfa):
     # Individual paths expose their name (a bytestring).
     path = gfa.paths[0]
     assert path.name == b"one"
+
+
+def test_paths_find(gfa):
+    # There is a method to find a path by its name.
+    path = gfa.paths.find(b"two")
+    assert path.id == 1
+    assert path.name == b"two"
 
 
 def test_path_steps(gfa):

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -13,7 +13,7 @@ L	1	+	2	+	0M
 L	2	+	4	-	0M
 L	2	+	3	+	0M
 L	3	+	4	-	0M
-""".strip()
+"""[1:]
 
 
 @pytest.fixture
@@ -54,3 +54,16 @@ def test_path_steps(gfa):
     # A step (handle) is a reference to a segment and an orientation.
     assert step.segment.name == 1
     assert step.is_forward
+
+
+def test_links(gfa):
+    # You guessed it: `gfa.links` behaves as a list too.
+    assert len(gfa.links) == 4
+    assert len(list(gfa.links)) == 4
+    link = gfa.links[1]
+
+    # A link has a "from" handle and a "to" handle.
+    assert link.from_.segment.name == 2
+    assert link.from_.is_forward
+    assert link.to.segment.name == 4
+    assert not link.to.is_forward

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -1,16 +1,28 @@
 import pytest
 import flatgfa
 
-TEST_GFA = "../tests/k.gfa"
+TINY_GFA = b"""
+H	VN:Z:1.0
+S	1	CAAATAAG
+S	2	AAATTTTCTGGAGTTCTAT
+S	3	TTG
+S	4	CCAACTCTCTG
+P	one	1+,2+,4-	*
+P	two	1+,2+,3+,4-	*
+L	1	+	2	+	0M
+L	2	+	4	-	0M
+L	2	+	3	+	0M
+L	3	+	4	-	0M
+""".strip()
 
 
 @pytest.fixture
 def gfa():
-    return flatgfa.parse(TEST_GFA)
+    return flatgfa.parse_bytes(TINY_GFA)
 
 
 def test_segs(gfa):
-    assert len(gfa.segments) == 15
+    assert len(gfa.segments) == 4
     seg = gfa.segments[0]
     assert seg.name == 1
     assert seg.sequence() == b"CAAATAAG"
@@ -22,12 +34,12 @@ def test_paths(gfa):
     assert len(gfa.paths) == 2
     assert len(list(gfa.paths)) == 2
     path = gfa.paths[0]
-    assert path.name == b"x"
+    assert path.name == b"one"
 
 
 def test_path_steps(gfa):
     path = gfa.paths[1]
-    assert len(path) == 10
+    assert len(path) == 4
     step = list(path)[0]
     assert step.segment.name == 1
     assert step.is_forward

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -67,3 +67,30 @@ def test_links(gfa):
     assert link.from_.is_forward
     assert link.to.segment.name == 4
     assert not link.to.is_forward
+
+
+def test_gfa_str(gfa):
+    # You can serialize a graph as GFA text.
+    assert str(gfa) == TINY_GFA.decode()
+
+
+def test_read_write_gfa(gfa, tmp_path):
+    # You can write FlatGFA objects as GFA text files.
+    gfa_path = str(tmp_path / "tiny.gfa")
+    gfa.write_gfa(gfa_path)
+    with open(gfa_path, 'rb') as f:
+        assert f.read() == TINY_GFA
+
+    # You can also parse GFA text files from the filesystem.
+    new_gfa = flatgfa.parse(gfa_path)
+    assert len(new_gfa.segments) == len(gfa.segments)
+
+
+def test_read_write_flatgfa(gfa, tmp_path):
+    # You can write FlatGFA graphs in our native binary format too.
+    flatgfa_path = str(tmp_path / "tiny.flatgfa")
+    gfa.write_flatgfa(flatgfa_path)
+
+    # And read them back, which should be very fast indeed.
+    new_gfa = flatgfa.load(flatgfa_path)
+    assert len(new_gfa.segments) == len(gfa.segments)

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -22,24 +22,35 @@ def gfa():
 
 
 def test_segs(gfa):
+    # `gfa.segments` acts like a list.
     assert len(gfa.segments) == 4
     seg = gfa.segments[0]
+
+    # An individual segment exposes its name and nucleotide sequence.
     assert seg.name == 1
     assert seg.sequence() == b"CAAATAAG"
+
+    # You can also pull out the entire sequence of segments.
     seg = list(gfa.segments)[2]
     assert seg.name == 3
 
 
 def test_paths(gfa):
+    # `gfa.paths` similarly acts like a list.
     assert len(gfa.paths) == 2
     assert len(list(gfa.paths)) == 2
+
+    # Individual paths expose their name (a bytestring).
     path = gfa.paths[0]
     assert path.name == b"one"
 
 
 def test_path_steps(gfa):
+    # When you get a path, the path itself acts as a list of steps (handles).
     path = gfa.paths[1]
     assert len(path) == 4
     step = list(path)[0]
+
+    # A step (handle) is a reference to a segment and an orientation.
     assert step.segment.name == 1
     assert step.is_forward

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -14,3 +14,15 @@ def test_segs(gfa):
     seg = gfa.segments[0]
     assert seg.name == 1
     assert seg.sequence() == b"CAAATAAG"
+    seg = list(gfa.segments)[2]
+    assert seg.name == 3
+
+
+def test_paths(gfa):
+    assert len(gfa.paths) == 2
+    path = gfa.paths[0]
+    assert path.name == b"x"
+    assert len(path) == 10
+    step = list(path)[0]
+    assert step.segment.name == 1
+    assert step.is_forward

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -13,7 +13,9 @@ L	1	+	2	+	0M
 L	2	+	4	-	0M
 L	2	+	3	+	0M
 L	3	+	4	-	0M
-"""[1:]
+"""[
+    1:
+]
 
 
 @pytest.fixture
@@ -92,7 +94,7 @@ def test_read_write_gfa(gfa, tmp_path):
     # You can write FlatGFA objects as GFA text files.
     gfa_path = str(tmp_path / "tiny.gfa")
     gfa.write_gfa(gfa_path)
-    with open(gfa_path, 'rb') as f:
+    with open(gfa_path, "rb") as f:
         assert f.read() == TINY_GFA
 
     # You can also parse GFA text files from the filesystem.


### PR DESCRIPTION
This just adds a [pytest](https://docs.pytest.org/)-based test suite for the new Python bindings. Hopefully this does double duty as an extremely crude form of documentation.