### PR TITLE
Strings and equality for FlatGFA Python objects

### DIFF
--- a/.github/workflows/flatgfa-py.yml
+++ b/.github/workflows/flatgfa-py.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install flatgfa --find-links dist --force-reinstall
+          pip install ./dist/flatgfa*.whl
           pip install pytest
           cd flatgfa-py && pytest
 
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install flatgfa --find-links dist --force-reinstall
+          pip install ./dist/flatgfa*.whl
           pip install pytest
           cd flatgfa-py && pytest
 
@@ -114,7 +114,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install flatgfa --find-links dist --force-reinstall
+          pip install ./dist/flatgfa*.whl
           pip install pytest
           cd flatgfa-py && pytest
 

--- a/flatgfa-py/docs/index.rst
+++ b/flatgfa-py/docs/index.rst
@@ -90,9 +90,10 @@ The :class:`Handle` class is a segment--orientation pair: both paths and links
 traverse these handles.
 
 To get a GFA text representation of any of these objects, use ``str(obj)``.
-All these objects are equatable (so you can compare them with ``==``); this
-uses equality on the underlying references to the data store, so two objects
-are equal if they refer to the same index in the same :class:`FlatGFA`.
+All these objects are equatable (so you can compare them with ``==``) and
+hashable (so you can store them in dicts and sets). This reflects equality on
+the underlying references to the data store, so two objects are equal if they
+refer to the same index in the same :class:`FlatGFA`.
 
 .. autoclass:: Segment
    :members:

--- a/flatgfa-py/docs/index.rst
+++ b/flatgfa-py/docs/index.rst
@@ -67,6 +67,10 @@ importantly, you can iterate over the :class:`Segment`, :class:`Path`, and
 These containers support both iteration (like the ``for`` above) and random
 access (like ``graph.segments[0]`` above).
 
+You can also write graphs out to disk using :meth:`FlatGFA.write_gfa`
+(producing a standard GFA text file) and :meth:`FlatGFA.write_flatgfa` (our
+binary format). If you just want a GFA string, use `str(graph)`.
+
 .. autoclass:: FlatGFA
    :members:
 

--- a/flatgfa-py/docs/index.rst
+++ b/flatgfa-py/docs/index.rst
@@ -80,6 +80,8 @@ and :class:`Link` for edges in the graph.
 The :class:`Handle` class is a segment--orientation pair: both paths and links
 traverse these handles.
 
+To get a GFA text representation of any of these objects, use ``str(obj)``.
+
 .. autoclass:: Segment
    :members:
 
@@ -104,6 +106,9 @@ The FlatGFA library exposes special container classes to access the
 graph. These classes are meant to behave sort of like Python :class:`list`
 objects while supporting efficient iteration over FlatGFA's internal
 representation.
+
+All of these container objects support subscripting (like
+``graph.segments[i]`` where ``i`` is an integer index) and iteration.
 
 .. autoclass:: SegmentList
    :members:

--- a/flatgfa-py/docs/index.rst
+++ b/flatgfa-py/docs/index.rst
@@ -81,10 +81,18 @@ These classes represent the core data model for GFA graphs:
 :class:`Segment` for vertices in the graph,
 :class:`Path` for walks through the graph,
 and :class:`Link` for edges in the graph.
+Internally, all of these objects only contain references to the underlying
+data stored in a :class:`FlatGFA`, so they are very small, but accessing any
+of the associated data (such as the nucleotide sequence for a segment) require
+further lookups.
+
 The :class:`Handle` class is a segment--orientation pair: both paths and links
 traverse these handles.
 
 To get a GFA text representation of any of these objects, use ``str(obj)``.
+All these objects are equatable (so you can compare them with ``==``); this
+uses equality on the underlying references to the data store, so two objects
+are equal if they refer to the same index in the same :class:`FlatGFA`.
 
 .. autoclass:: Segment
    :members:

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -1,5 +1,5 @@
 use flatgfa::pool::{Id, Span};
-use flatgfa::{self, file, FlatGFA, HeapGFAStore};
+use flatgfa::{self, file, print, FlatGFA, HeapGFAStore};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::io::Write;
@@ -219,6 +219,12 @@ impl PySegment {
     fn __repr__(&self) -> String {
         format!("<Segment {}>", u32::from(self.id))
     }
+
+    fn __str__(&self) -> String {
+        let gfa = self.store.view();
+        let seg = gfa.segs[self.id];
+        format!("{}", print::Display(&gfa, &seg))
+    }
 }
 
 #[pymethods]
@@ -277,6 +283,12 @@ impl PyPath {
 
     fn __repr__(&self) -> String {
         format!("<Path {}>", u32::from(self.id))
+    }
+
+    fn __str__(&self) -> String {
+        let gfa = self.store.view();
+        let path = gfa.paths[self.id];
+        format!("{}", print::Display(&gfa, &path))
     }
 
     fn __iter__(&self) -> StepIter {
@@ -355,6 +367,11 @@ impl PyHandle {
             self.handle.orient()
         )
     }
+
+    fn __str__(&self) -> String {
+        let gfa = self.store.view();
+        format!("{}", print::Display(&gfa, self.handle))
+    }
 }
 
 /// An iterator over the steps in a path.
@@ -408,6 +425,12 @@ impl PyLink {
 
     fn __repr__(&self) -> String {
         format!("<Link {}>", u32::from(self.id))
+    }
+
+    fn __str__(&self) -> String {
+        let gfa = self.store.view();
+        let link = gfa.links[self.id];
+        format!("{}", print::Display(&gfa, &link))
     }
 
     /// The edge's source handle.

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -272,13 +272,13 @@ impl PyPath {
         self.id.into()
     }
 
-    /// Get the name of this path as declared in the GFA file.
+    /// Get the name of this path as declared in the GFA file, as a string.
     #[getter]
-    fn name<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+    fn name(&self) -> String {
         let gfa = self.store.view();
         let path = &gfa.paths[self.id];
         let name = gfa.get_path_name(path);
-        PyBytes::new_bound(py, name)
+        name.try_into().unwrap()
     }
 
     fn __repr__(&self) -> String {
@@ -315,8 +315,8 @@ struct PathList {
 
 #[pymethods]
 impl PathList {
-    /// Find a path by its name a (a `bytes` string), or return `None` if not found.
-    fn find(&self, name: &[u8]) -> Option<PyPath> {
+    /// Find a path by its name (a string), or return `None` if not found.
+    fn find(&self, name: &str) -> Option<PyPath> {
         let gfa = self.store.view();
         let id = gfa.find_path(name.as_ref())?;
         Some(PyPath {

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -225,6 +225,10 @@ impl PySegment {
         let seg = gfa.segs[self.id];
         format!("{}", print::Display(&gfa, &seg))
     }
+
+    fn __eq__(&self, other: &PySegment) -> bool {
+        Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.id == other.id
+    }
 }
 
 #[pymethods]
@@ -289,6 +293,10 @@ impl PyPath {
         let gfa = self.store.view();
         let path = gfa.paths[self.id];
         format!("{}", print::Display(&gfa, &path))
+    }
+
+    fn __eq__(&self, other: &PyPath) -> bool {
+        Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.id == other.id
     }
 
     fn __iter__(&self) -> StepIter {
@@ -372,6 +380,10 @@ impl PyHandle {
         let gfa = self.store.view();
         format!("{}", print::Display(&gfa, self.handle))
     }
+
+    fn __eq__(&self, other: &PyHandle) -> bool {
+        Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.handle == other.handle
+    }
 }
 
 /// An iterator over the steps in a path.
@@ -431,6 +443,10 @@ impl PyLink {
         let gfa = self.store.view();
         let link = gfa.links[self.id];
         format!("{}", print::Display(&gfa, &link))
+    }
+
+    fn __eq__(&self, other: &PyLink) -> bool {
+        Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.id == other.id
     }
 
     /// The edge's source handle.

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -229,6 +229,10 @@ impl PySegment {
     fn __eq__(&self, other: &PySegment) -> bool {
         Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.id == other.id
     }
+
+    fn __hash__(&self) -> isize {
+        u32::from(self.id) as isize
+    }
 }
 
 #[pymethods]
@@ -297,6 +301,10 @@ impl PyPath {
 
     fn __eq__(&self, other: &PyPath) -> bool {
         Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.id == other.id
+    }
+
+    fn __hash__(&self) -> isize {
+        u32::from(self.id) as isize
     }
 
     fn __iter__(&self) -> StepIter {
@@ -384,6 +392,10 @@ impl PyHandle {
     fn __eq__(&self, other: &PyHandle) -> bool {
         Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.handle == other.handle
     }
+
+    fn __hash__(&self) -> isize {
+        (u32::from(self.handle.segment()) as isize) ^ ((self.handle.orient() as isize) << 16)
+    }
 }
 
 /// An iterator over the steps in a path.
@@ -447,6 +459,10 @@ impl PyLink {
 
     fn __eq__(&self, other: &PyLink) -> bool {
         Arc::as_ptr(&self.store) == Arc::as_ptr(&other.store) && self.id == other.id
+    }
+
+    fn __hash__(&self) -> isize {
+        u32::from(self.id) as isize
     }
 
     /// The edge's source handle.

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -54,7 +54,7 @@ def test_paths(gfa):
 
     # Individual paths expose their name (a bytestring).
     path = gfa.paths[0]
-    assert path.name == b"one"
+    assert path.name == "one"
 
     # GFA representation.
     assert str(path) == "P	one	1+,2+,4-	*"
@@ -62,9 +62,9 @@ def test_paths(gfa):
 
 def test_paths_find(gfa):
     # There is a method to find a path by its name.
-    path = gfa.paths.find(b"two")
+    path = gfa.paths.find("two")
     assert path.id == 1
-    assert path.name == b"two"
+    assert path.name == "two"
 
 
 def test_path_steps(gfa):

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -141,12 +141,12 @@ def test_eq(gfa):
 def test_hash(gfa):
     # The objects are also hashable, so you can put them in dicts and sets.
     d = {
-        gfa.segments[0]: 'foo',
-        gfa.paths[0]: 'bar',
-        gfa.links[0]: 'baz',
-        gfa.links[1].from_: 'qux',
+        gfa.segments[0]: "foo",
+        gfa.paths[0]: "bar",
+        gfa.links[0]: "baz",
+        gfa.links[1].from_: "qux",
     }
-    assert d[gfa.segments[0]] == 'foo'
-    assert d[gfa.paths[0]] == 'bar'
-    assert d[gfa.links[0]] == 'baz'
-    assert d[gfa.links[1].from_] == 'qux'
+    assert d[gfa.segments[0]] == "foo"
+    assert d[gfa.paths[0]] == "bar"
+    assert d[gfa.links[0]] == "baz"
+    assert d[gfa.links[1].from_] == "qux"

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -36,6 +36,9 @@ def test_segs(gfa):
     seg = list(gfa.segments)[2]
     assert seg.name == 3
 
+    # Use `str()` to get a GFA representation.
+    assert str(seg) == "S	3	TTG"
+
 
 def test_segs_find(gfa):
     # There is a method to find a segment by its name (with linear search).
@@ -52,6 +55,9 @@ def test_paths(gfa):
     # Individual paths expose their name (a bytestring).
     path = gfa.paths[0]
     assert path.name == b"one"
+
+    # GFA representation.
+    assert str(path) == "P	one	1+,2+,4-	*"
 
 
 def test_paths_find(gfa):
@@ -71,6 +77,9 @@ def test_path_steps(gfa):
     assert step.segment.name == 1
     assert step.is_forward
 
+    # GFA representation.
+    assert str(step) == "1+"
+
 
 def test_links(gfa):
     # You guessed it: `gfa.links` behaves as a list too.
@@ -83,6 +92,9 @@ def test_links(gfa):
     assert link.from_.is_forward
     assert link.to.segment.name == 4
     assert not link.to.is_forward
+
+    # GFA representation.
+    assert str(link) == "L	2	+	4	-	0M"
 
 
 def test_gfa_str(gfa):

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -136,3 +136,17 @@ def test_eq(gfa):
     # Including handles, which do not have their own identity.
     assert gfa.links[1].from_ == gfa.links[2].from_
     assert gfa.links[1].from_ != gfa.links[1].to
+
+
+def test_hash(gfa):
+    # The objects are also hashable, so you can put them in dicts and sets.
+    d = {
+        gfa.segments[0]: 'foo',
+        gfa.paths[0]: 'bar',
+        gfa.links[0]: 'baz',
+        gfa.links[1].from_: 'qux',
+    }
+    assert d[gfa.segments[0]] == 'foo'
+    assert d[gfa.paths[0]] == 'bar'
+    assert d[gfa.links[0]] == 'baz'
+    assert d[gfa.links[1].from_] == 'qux'

--- a/flatgfa-py/test_flatgfa.py
+++ b/flatgfa-py/test_flatgfa.py
@@ -122,3 +122,17 @@ def test_read_write_flatgfa(gfa, tmp_path):
     # And read them back, which should be very fast indeed.
     new_gfa = flatgfa.load(flatgfa_path)
     assert len(new_gfa.segments) == len(gfa.segments)
+
+
+def test_eq(gfa):
+    # The various data components are equatable.
+    assert gfa.segments[0] == gfa.segments[0]
+    assert gfa.segments[0] != gfa.segments[1]
+    assert gfa.paths[0] == gfa.paths[0]
+    assert gfa.paths[0] != gfa.paths[1]
+    assert gfa.links[0] == gfa.links[0]
+    assert gfa.links[0] != gfa.links[1]
+
+    # Including handles, which do not have their own identity.
+    assert gfa.links[1].from_ == gfa.links[2].from_
+    assert gfa.links[1].from_ != gfa.links[1].to

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -156,7 +156,7 @@ impl FromStr for Orientation {
 /// A Handle refers to the forward (+) or backward (-) orientation for a given segment.
 /// So, logically, it consists of a pair of a segment reference (usize) and an
 /// orientation (1 bit). We pack the two values into a single word.
-#[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy)]
+#[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(packed)]
 pub struct Handle(u32);
 

--- a/flatgfa/src/print.rs
+++ b/flatgfa/src/print.rs
@@ -31,7 +31,7 @@ impl<'a> fmt::Display for flatgfa::Alignment<'a> {
 }
 
 /// A wrapper for displaying components from FlatGFA.
-struct Display<'a, T>(&'a flatgfa::FlatGFA<'a>, T);
+pub struct Display<'a, T>(pub &'a flatgfa::FlatGFA<'a>, pub T);
 
 impl<'a> fmt::Display for Display<'a, flatgfa::Handle> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -59,7 +59,7 @@ impl<'a> fmt::Display for Display<'a, &flatgfa::Path> {
                 write!(f, ",{}", self.0.get_alignment(*overlap))?;
             }
         }
-        writeln!(f)
+        Ok(())
     }
 }
 
@@ -69,7 +69,7 @@ impl<'a> fmt::Display for Display<'a, &flatgfa::Link> {
         let from_name = self.0.get_handle_seg(from).name;
         let to = self.1.to;
         let to_name = self.0.get_handle_seg(to).name;
-        writeln!(
+        write!(
             f,
             "L\t{}\t{}\t{}\t{}\t{}",
             from_name,
@@ -88,7 +88,7 @@ impl<'a> fmt::Display for Display<'a, &flatgfa::Segment> {
         if !self.1.optional.is_empty() {
             write!(f, "\t{}", self.0.get_optional_data(self.1))?;
         }
-        writeln!(f)
+        Ok(())
     }
 }
 
@@ -106,15 +106,15 @@ fn write_preserved(gfa: &flatgfa::FlatGFA, f: &mut fmt::Formatter<'_>) -> fmt::R
             }
             flatgfa::LineKind::Segment => {
                 let seg = seg_iter.next().expect("too few segments");
-                write!(f, "{}", Display(gfa, seg))?;
+                writeln!(f, "{}", Display(gfa, seg))?;
             }
             flatgfa::LineKind::Path => {
                 let path = path_iter.next().expect("too few paths");
-                write!(f, "{}", Display(gfa, path))?;
+                writeln!(f, "{}", Display(gfa, path))?;
             }
             flatgfa::LineKind::Link => {
                 let link = link_iter.next().expect("too few links");
-                write!(f, "{}", Display(gfa, link))?;
+                writeln!(f, "{}", Display(gfa, link))?;
             }
         }
     }


### PR DESCRIPTION
This takes care of a few minor things from #179:

* Name of paths are now `str`, not `bytes`.
* All objects can be converted to GFA format with naught more than a `str(obj)`.
* All these objects implement `__eq__` and `__hash__`, which is nice for Python citizenship.