### PR TITLE
Expand benchmarking infrastructure quite a bit

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,12 @@
+{
+  "language_overrides": {
+    "Python": {
+      "formatter": {
+        "external": {
+          "command": "bash",
+          "arguments": ["-c", "ruff format --stdin-filename {buffer_path}"]
+        }
+      }
+    }
+  }
+}

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -22,7 +22,6 @@ GRAPHS_TOML = os.path.join(BASE, "graphs.toml")
 CONFIG_TOML = os.path.join(BASE, "config.toml")
 GRAPHS_DIR = os.path.join(BASE, "graphs")
 RESULTS_DIR = os.path.join(BASE, "results")
-ALL_TOOLS = ["slow_odgi", "odgi", "flatgfa"]
 DECOMPRESS = {
     ".gz": ["gunzip"],
     ".zst": ["zstd", "-d"],
@@ -219,9 +218,13 @@ def run_bench(graph_set, mode, tools, out_csv):
     graph_names = runner.config["graph_sets"][graph_set]
 
     # Which tools are we comparing?
-    tools = tools or list(runner.config["modes"][mode]["cmd"].keys())
-    for tool in tools:
-        assert tool in ALL_TOOLS, "unknown tool name"
+    if tools:
+        # Check that specified tools are supported.
+        for tool in tools:
+            assert tool in runner.config["modes"][mode]["cmd"], f"unknown tool {tool}"
+    else:
+        # Use all supported tools by deefault.
+        tools = list(runner.config["modes"][mode]["cmd"].keys())
 
     # Fetch all the graphs and convert them to both odgi and FlatGFA.
     for graph in graph_names:

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -1,7 +1,7 @@
 try:
     import tomllib
 except ImportError:
-    import tomli as tomllib
+    import tomli as tomllib  # type:ignore
 import os
 import subprocess
 from subprocess import PIPE
@@ -92,6 +92,7 @@ def fetch_file(dest, url):
         with open(dest, "wb") as f:
             curl = subprocess.Popen(["curl", "-L", url], stdout=PIPE)
             decomp = subprocess.Popen(DECOMPRESS[ext], stdin=curl.stdout, stdout=f)
+            assert curl.stdout is not None
             curl.stdout.close()
             check_wait(decomp)
     else:

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -69,11 +69,19 @@ class HyperfineResult:
 def hyperfine(cmds):
     """Run Hyperfine to compare the commands."""
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        hf_cmd = [
+            "hyperfine",
+            "--export-json",
+            tmp.name,
+            "--shell=none",
+            "--warmup=1",
+            "--min-runs=3",
+            "--max-runs=16",
+        ]
+        hf_cmd += cmds
+
         tmp.close()
-        subprocess.run(
-            ["hyperfine", "-N", "-w", "1", "--export-json", tmp.name] + cmds,
-            check=True,
-        )
+        subprocess.run(hf_cmd, check=True)
         with open(tmp.name, "rb") as f:
             data = json.load(f)
             return [HyperfineResult.from_json(r) for r in data["results"]]

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -201,7 +201,7 @@ def run_bench(graph_set, mode, tools, out_csv):
     graph_names = runner.config["graph_sets"][graph_set]
 
     # Which tools are we comparing?
-    tools = tools or runner.config["modes"][mode]["tools"]
+    tools = tools or list(runner.config["modes"][mode]["cmd"].keys())
     for tool in tools:
         assert tool in ALL_TOOLS, "unknown tool name"
 

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -15,6 +15,7 @@ import datetime
 import logging
 from contextlib import contextmanager
 import time
+import platform
 
 BASE = os.path.dirname(__file__)
 GRAPHS_TOML = os.path.join(BASE, "graphs.toml")
@@ -231,8 +232,9 @@ def run_bench(graph_set, mode, tools, out_csv):
 
 
 def gen_csv_name(graph_set, mode):
+    host = platform.node().split(".")[0]
     ts = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S.%f")
-    return os.path.join(RESULTS_DIR, f"{mode}-{graph_set}-{ts}.csv")
+    return os.path.join(RESULTS_DIR, f"{mode}-{graph_set}-{host}-{ts}.csv")
 
 
 def bench_main():

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -220,6 +220,11 @@ def run_bench(graph_set, mode, tools, out_csv):
     # The input graphs we'll be using to do the comparison.
     graph_names = runner.config["graph_sets"][graph_set]
 
+    # Which tools are we comparing?
+    tools = tools or runner.config["modes"][mode]["tools"]
+    for tool in tools:
+        assert tool in ALL_TOOLS, "unknown tool name"
+
     # Fetch all the graphs and convert them to both odgi and FlatGFA.
     for graph in graph_names:
         runner.fetch_graph(graph)
@@ -263,22 +268,10 @@ def bench_main():
 
     args = parser.parse_args()
 
-    # Which tools are we comparing?
-    tools = (
-        args.tool
-        or {
-            "paths": ALL_TOOLS,
-            "convert": ["odgi", "flatgfa"],
-            "roundtrip": ALL_TOOLS,
-        }[args.mode]
-    )
-    for tool in tools:
-        assert tool in ALL_TOOLS, "unknown tool name"
-
     run_bench(
         graph_set=args.graph_set,
         mode=args.mode,
-        tools=tools,
+        tools=args.tool,
         out_csv=args.output or gen_csv_name(args.graph_set, args.mode),
     )
 

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -186,12 +186,10 @@ class Runner:
                 "og": quote(graph_path(graph, "og")),
                 "flatgfa": quote(graph_path(graph, "flatgfa")),
             },
-            **self.config["tools"]
+            **self.config["tools"],
         }
         commands = {
-            k: v.format(**subst)
-            for k, v in mode_info["cmd"].items()
-            if k in tools
+            k: v.format(**subst) for k, v in mode_info["cmd"].items() if k in tools
         }
         yield from self.compare(mode, graph, commands)
 

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -195,6 +195,16 @@ class Runner:
         commands = {k: commands[k] for k in tools}
         yield from self.compare("convert", name, commands)
 
+    def compare_roundtrip(self, name, tools):
+        """Compare round-trip GFA-to-GFA parsing/printing."""
+        commands = {
+            "flatgfa": f'{self.fgfa} -I {quote(graph_path(name, "gfa"))}',
+            "slow_odgi": f'{self.slow_odgi} norm {quote(graph_path(name, "gfa"))}',
+            "odgi": f'{self.odgi} view -g -i {quote(graph_path(name, "gfa"))}',
+        }
+        commands = {k: commands[k] for k in tools}
+        yield from self.compare("roundtrip", name, commands)
+
 
 def run_bench(graph_set, mode, tools, out_csv):
     runner = Runner.default()
@@ -220,6 +230,8 @@ def run_bench(graph_set, mode, tools, out_csv):
                     res = runner.compare_paths(graph, tools)
                 case "convert":
                     res = runner.compare_convert(graph, tools)
+                case "roundtrip":
+                    res = runner.compare_roundtrip(graph, tools)
                 case _:
                     assert False, "unknown mode"
             for row in res:
@@ -248,6 +260,7 @@ def bench_main():
         or {
             "paths": ALL_TOOLS,
             "convert": ["odgi", "flatgfa"],
+            "roundtrip": ALL_TOOLS,
         }[args.mode]
     )
     for tool in tools:

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -176,25 +176,6 @@ class Runner:
                 "n": res.count,
             }
 
-    def compare_paths(self, name, tools):
-        """Compare odgi and FlatGFA implementations of path-name extraction."""
-        commands = {
-            "odgi": f'{self.odgi} paths -i {quote(graph_path(name, "og"))} -L',
-            "flatgfa": f'{self.fgfa} -i {quote(graph_path(name, "flatgfa"))} paths',
-            "slow_odgi": f'{self.slow_odgi} paths {quote(graph_path(name, "gfa"))}',
-        }
-        commands = {k: commands[k] for k in tools}
-        yield from self.compare("paths", name, commands)
-
-    def compare_convert(self, name, tools):
-        """Compare conversion time from GFA to specialized file formats."""
-        commands = {
-            "odgi": f'{self.odgi} build -g {quote(graph_path(name, "gfa"))} -o {quote(graph_path(name, "og"))}',
-            "flatgfa": f'{self.fgfa} -I {quote(graph_path(name, "gfa"))} -o {quote(graph_path(name, "flatgfa"))}',
-        }
-        commands = {k: commands[k] for k in tools}
-        yield from self.compare("convert", name, commands)
-
     def compare_mode(self, mode, graph, tools):
         """Compare a mode across several tools for a single graph."""
         mode_info = self.config["modes"][mode]
@@ -238,16 +219,8 @@ def run_bench(graph_set, mode, tools, out_csv):
         writer = csv.DictWriter(f, ["graph", "cmd", "mean", "stddev", "n"])
         writer.writeheader()
         for graph in graph_names:
-            if mode in runner.config["modes"]:
-                res = runner.compare_mode(mode, graph, tools)
-            else:
-                match mode:
-                    case "paths":
-                        res = runner.compare_paths(graph, tools)
-                    case "convert":
-                        res = runner.compare_convert(graph, tools)
-                    case _:
-                        assert False, "unknown mode"
+            assert mode in runner.config["modes"], "unknown mode"
+            res = runner.compare_mode(mode, graph, tools)
             for row in res:
                 writer.writerow(row)
 

--- a/bench/config.toml
+++ b/bench/config.toml
@@ -14,10 +14,12 @@ cmd.flatgfa = '{fgfa} -i {files[flatgfa]} paths'
 cmd.slow_odgi = '{slow_odgi} paths {files[gfa]}'
 
 [modes.convert]
+convert = false
 cmd.odgi = '{odgi} build -g {files[gfa]} -o {files[og]}'
 cmd.flatgfa = '{fgfa} -I {files[gfa]} -o {files[flatgfa]}'
 
 [modes.roundtrip]
+convert = false
 cmd.flatgfa = '{fgfa} -I {files[gfa]}'
 cmd.slow_odgi = '{slow_odgi} norm {files[gfa]}'
 cmd.odgi = '{odgi} view -g -i {files[gfa]}'

--- a/bench/config.toml
+++ b/bench/config.toml
@@ -9,18 +9,15 @@ mini = ["test.lpa", "test.chr6c4", "hprc.chrM"]
 med = ["hprc.chr20", "hprc.chrX", "1000gont.chr16"]
 
 [modes.paths]
-tools = ["slow_odgi", "odgi", "flatgfa"]
 cmd.odgi = '{odgi} paths -i {files[og]} -L'
 cmd.flatgfa = '{fgfa} -i {files[flatgfa]} paths'
 cmd.slow_odgi = '{slow_odgi} paths {files[gfa]}'
 
 [modes.convert]
-tools = ["odgi", "flatgfa"]
 cmd.odgi = '{odgi} build -g {files[gfa]} -o {files[og]}'
 cmd.flatgfa = '{fgfa} -I {files[gfa]} -o {files[flatgfa]}'
 
 [modes.roundtrip]
-tools = ["slow_odgi", "odgi", "flatgfa"]
 cmd.flatgfa = '{fgfa} -I {files[gfa]}'
 cmd.slow_odgi = '{slow_odgi} norm {files[gfa]}'
 cmd.odgi = '{odgi} view -g -i {files[gfa]}'

--- a/bench/config.toml
+++ b/bench/config.toml
@@ -8,7 +8,14 @@ smoke = ["test.k"]
 mini = ["test.lpa", "test.chr6c4", "hprc.chrM"]
 med = ["hprc.chr20", "hprc.chrX", "1000gont.chr16"]
 
+[modes.paths]
+tools = ["slow_odgi", "odgi", "flatgfa"]
+
+[modes.convert]
+tools = ["odgi", "flatgfa"]
+
 [modes.roundtrip]
+tools = ["slow_odgi", "odgi", "flatgfa"]
 cmd.flatgfa = '{fgfa} -I {files[gfa]}'
 cmd.slow_odgi = '{slow_odgi} norm {files[gfa]}'
 cmd.odgi = '{odgi} view -g -i {files[gfa]}'

--- a/bench/config.toml
+++ b/bench/config.toml
@@ -7,3 +7,8 @@ slow_odgi = "../.venv/bin/slow_odgi"
 smoke = ["test.k"]
 mini = ["test.lpa", "test.chr6c4", "hprc.chrM"]
 med = ["hprc.chr20", "hprc.chrX", "1000gont.chr16"]
+
+[modes.roundtrip]
+cmd.flatgfa = '{fgfa} -I {files[gfa]}'
+cmd.slow_odgi = '{slow_odgi} norm {files[gfa]}'
+cmd.odgi = '{odgi} view -g -i {files[gfa]}'

--- a/bench/config.toml
+++ b/bench/config.toml
@@ -2,6 +2,7 @@
 odgi = "odgi"
 fgfa = "../flatgfa/target/release/fgfa"
 slow_odgi = "../.venv/bin/slow_odgi"
+gfatools = "gfatools"
 
 [graph_sets]
 smoke = ["test.k"]
@@ -23,3 +24,4 @@ convert = false
 cmd.flatgfa = '{fgfa} -I {files[gfa]}'
 cmd.slow_odgi = '{slow_odgi} norm {files[gfa]}'
 cmd.odgi = '{odgi} view -g -i {files[gfa]}'
+cmd.gfatools = "{gfatools} view {files[gfa]}"

--- a/bench/config.toml
+++ b/bench/config.toml
@@ -10,9 +10,14 @@ med = ["hprc.chr20", "hprc.chrX", "1000gont.chr16"]
 
 [modes.paths]
 tools = ["slow_odgi", "odgi", "flatgfa"]
+cmd.odgi = '{odgi} paths -i {files[og]} -L'
+cmd.flatgfa = '{fgfa} -i {files[flatgfa]} paths'
+cmd.slow_odgi = '{slow_odgi} paths {files[gfa]}'
 
 [modes.convert]
 tools = ["odgi", "flatgfa"]
+cmd.odgi = '{odgi} build -g {files[gfa]} -o {files[og]}'
+cmd.flatgfa = '{fgfa} -I {files[gfa]} -o {files[flatgfa]}'
 
 [modes.roundtrip]
 tools = ["slow_odgi", "odgi", "flatgfa"]

--- a/bench/summary.py
+++ b/bench/summary.py
@@ -30,7 +30,7 @@ def summary():
             if mean > 80:
                 mins = int(mean / 60)
                 secs = int(mean % 60)
-                print(f"  {cmd}: {mins}m{secs}s ± {stddev:.1f}", end='')
+                print(f"  {cmd}: {mins}m{secs}s ± {stddev:.1f}", end="")
             else:
                 if mean < 0.2:
                     mean *= 1000
@@ -38,7 +38,7 @@ def summary():
                     unit = "ms"
                 else:
                     unit = "s"
-                print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}", end='')
+                print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}", end="")
 
             print(f" ({ratio:.1f}× {baseline})")
 

--- a/bench/summary.py
+++ b/bench/summary.py
@@ -9,16 +9,24 @@ def summary():
     for row in reader:
         by_graph[row["graph"]][row["cmd"]] = row
 
+    # Guess a suitable baseline by taking the fastest time on the first graph.
+    first_res = next(iter(by_graph.values()))
+    min_row = min(first_res.values(), key=lambda r: r["mean"])
+    baseline = min_row["cmd"]
+
     for graph, cmds in by_graph.items():
+        baseline_time = float(cmds[baseline]["mean"])
+
         print(graph)
         for cmd, row in cmds.items():
             mean = float(row["mean"])
             stddev = float(row["stddev"])
+            ratio = mean / baseline_time
 
             if mean > 80:
                 mins = int(mean / 60)
                 secs = int(mean % 60)
-                print(f"  {cmd}: {mins}m{secs}s ± {stddev:.1f}")
+                print(f"  {cmd}: {mins}m{secs}s ± {stddev:.1f}", end='')
             else:
                 if mean < 0.2:
                     mean *= 1000
@@ -26,7 +34,9 @@ def summary():
                     unit = "ms"
                 else:
                     unit = "s"
-                print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}")
+                print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}", end='')
+
+            print(f" ({ratio:.1f}× {baseline})")
 
 
 if __name__ == "__main__":

--- a/bench/summary.py
+++ b/bench/summary.py
@@ -1,6 +1,7 @@
 import csv
 import sys
 from collections import defaultdict
+from statistics import harmonic_mean
 
 
 def summary():
@@ -14,6 +15,8 @@ def summary():
     min_row = min(first_res.values(), key=lambda r: r["mean"])
     baseline = min_row["cmd"]
 
+    # Show each graph's times.
+    ratios = defaultdict(list)
     for graph, cmds in by_graph.items():
         baseline_time = float(cmds[baseline]["mean"])
 
@@ -22,6 +25,7 @@ def summary():
             mean = float(row["mean"])
             stddev = float(row["stddev"])
             ratio = mean / baseline_time
+            ratios[cmd].append(ratio)
 
             if mean > 80:
                 mins = int(mean / 60)
@@ -37,6 +41,12 @@ def summary():
                 print(f"  {cmd}: {mean:.1f} ± {stddev:.1f} {unit}", end='')
 
             print(f" ({ratio:.1f}× {baseline})")
+
+    # Show the average across graphs.
+    print("harmonic mean")
+    for cmd, cmd_ratios in ratios.items():
+        hmean = harmonic_mean(cmd_ratios)
+        print(f"  {cmd}: {hmean:.1f}× {baseline}")
 
 
 if __name__ == "__main__":

--- a/flatgfa-py/pyproject.toml
+++ b/flatgfa-py/pyproject.toml
@@ -24,7 +24,3 @@ build-backend = "maturin"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
-
-[tool.pyright]
-venvPath = ".."
-venv = ".venv"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".",
+  "venv": ".venv"
+}


### PR DESCRIPTION
I wanted to generate more interesting graphs of FlatGFA performance, so this expands the benchmarking harness a lot. It's now easier to extend in general too, so maybe it'll be easier to add more comparisons in the future when we have something good to compare.

Hyperfine invocations now also specify the minimum/maximum number of executions. This is most useful for the new minimum of 3 (the default minimum is 10), which is plenty for very slow executions and should save a lot of time.

The summary script can now report speedup factors, and it can even take harmonic means over those speedup numbers.