### PR TITLE
Attempt at better modularity of parsing, w/r/t paths

### DIFF
--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -62,7 +62,11 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
             self.add_link(link);
         }
         for line in deferred_paths {
-            self.add_path(&line);
+            if let gfaline::Line::Path(path) = gfaline::parse_line(&line).unwrap() {
+                self.add_path(path);
+            } else {
+                unreachable!("unexpected deferred line")
+            }
         }
 
         self.flat
@@ -103,13 +107,15 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
 
         // "Unwind" the deferred lines.
         for line in deferred_lines {
-            if line[0] == b'P' {
-                self.add_path(line);
-            } else {
-                let gfa_line = gfaline::parse_line(line).unwrap();
-                if let gfaline::Line::Link(link) = gfa_line {
+            let gfa_line = gfaline::parse_line(line).unwrap();
+            match gfa_line {
+                gfaline::Line::Link(link) => { 
                     self.add_link(link);
-                } else {
+                }
+                gfaline::Line::Path(path) => {
+                    self.add_path(path);
+                }
+                gfaline::Line::Header(_) | gfaline::Line::Segment(_) => {
                     unreachable!("unexpected deferred line")
                 }
             }
@@ -139,16 +145,10 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
         self.flat.add_link(from, to, link.overlap);
     }
 
-    fn add_path(&mut self, line: &[u8]) {
-        // This must be a path line.
-        assert_eq!(&line[..2], b"P\t");
-        let line = &line[2..];
-
-        // Parse the name.
-        let (name, rest) = gfaline::parse_field(line).unwrap();
-
+    fn add_path(&mut self, path: gfaline::Path) {
+ 
         // Parse the steps.
-        let mut step_parser = gfaline::StepsParser::new(rest);
+        let mut step_parser = gfaline::StepsParser::new(&path.steps);
         let steps = self.flat.add_steps((&mut step_parser).map(|(name, dir)| {
             Handle::new(
                 self.seg_ids.get(name).into(),
@@ -159,13 +159,9 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
                 },
             )
         }));
-        let rest = step_parser.rest();
+        assert!(step_parser.rest().is_empty());
 
-        // Parse the overlaps.
-        let (overlaps, rest) = gfaline::parse_maybe_overlap_list(rest).unwrap();
-
-        assert!(rest.is_empty());
-        self.flat.add_path(name, steps, overlaps.into_iter());
+        self.flat.add_path(path.name, steps, path.overlaps.into_iter());
     }
 }
 


### PR DESCRIPTION
This is an attempt to delegate more of the parsing of GFA `path` to `gfaline.rs`, along with other GFA lines, as opposed to `parse.rs`.

Because `gfaline::Path` stores references to strings and parsing of paths must be deferred until after steps are parsed, `parse.rs` still stores entire `path` lines to be parsed later, but now makes use of `gfaline::parse_line` much in the same way that it already did for `link`s. Parts of the code are now more elegant, parts of them less so, and I think the only thing this really accomplished is satisfying the compiler's desire that all fields of `gfaline::Path` are read from.