### PR TITLE
FlatGFA: Add a facility for processing GAF files

### DIFF
--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -1,5 +1,5 @@
 use flatgfa::pool::Id;
-use flatgfa::{self, file, print, FlatGFA, HeapGFAStore};
+use flatgfa::{self, file, memfile, print, FlatGFA, HeapGFAStore};
 use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PySlice};
@@ -18,7 +18,7 @@ enum Store {
 impl Store {
     /// Parse a text GFA file.
     fn parse_file(filename: &str) -> Self {
-        let file = file::map_file(filename);
+        let file = memfile::map_file(filename);
         Self::parse_gfa(file.as_ref())
     }
 
@@ -30,7 +30,7 @@ impl Store {
 
     /// Load a FlatGFA binary file.
     fn load(filename: &str) -> Self {
-        let mmap = file::map_file(filename);
+        let mmap = memfile::map_file(filename);
         Self::File(mmap)
     }
 
@@ -121,7 +121,7 @@ impl PyFlatGFA {
     /// You can read the resulting file with :func:`load`.
     fn write_flatgfa(&self, filename: &str) -> PyResult<()> {
         let gfa = self.0.view();
-        let mut mmap = file::map_new_file(filename, file::size(&gfa) as u64);
+        let mut mmap = memfile::map_new_file(filename, file::size(&gfa) as u64);
         file::dump(&gfa, &mut mmap);
         mmap.flush()?;
         Ok(())

--- a/flatgfa/src/file.rs
+++ b/flatgfa/src/file.rs
@@ -1,6 +1,5 @@
 use crate::flatgfa;
 use crate::pool::{FixedStore, Pool, Span, Store};
-use memmap::{Mmap, MmapMut};
 use std::mem::{size_of, size_of_val};
 use tinyvec::SliceVec;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
@@ -308,29 +307,4 @@ pub fn dump(gfa: &flatgfa::FlatGFA, buf: &mut [u8]) {
 /// enough buffer to write the entire FlatGFA into with `dump`.
 pub fn size(gfa: &flatgfa::FlatGFA) -> usize {
     Toc::full(gfa).size()
-}
-
-pub fn map_file(name: &str) -> Mmap {
-    let file = std::fs::File::open(name).unwrap();
-    unsafe { Mmap::map(&file) }.unwrap()
-}
-
-pub fn map_new_file(name: &str, size: u64) -> MmapMut {
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .open(name)
-        .unwrap();
-    file.set_len(size).unwrap();
-    unsafe { MmapMut::map_mut(&file) }.unwrap()
-}
-
-pub fn map_file_mut(name: &str) -> MmapMut {
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(name)
-        .unwrap();
-    unsafe { MmapMut::map_mut(&file) }.unwrap()
 }

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -129,6 +129,14 @@ impl<'a> GAFParser<'a> {
         Some(&self.buf[start..(start + end)])
     }
 
+    fn skip_fields(&mut self, n: usize) -> Option<()> {
+        for _ in 0..n {
+            let end = memchr::memchr(b'\t', &self.buf[self.pos..])?;
+            self.pos += end + 1;
+        }
+        Some(())
+    }
+
     fn int_field(&mut self) -> Option<usize> {
         let val = parse_int(&self.buf, &mut self.pos);
         assert!(matches!(self.buf[self.pos], b'\t' | b'\n'));
@@ -154,18 +162,13 @@ impl<'a> GAFParser<'a> {
         assert!(self.pos < self.buf.len());
 
         let name = BStr::new(self.next_field().unwrap());
-
-        // Skip the other fields up to the actual path. TODO add utility.
-        self.next_field();
-        self.next_field();
-        self.next_field();
-        self.next_field();
+        self.skip_fields(4);
 
         // The actual path string (which we don't parse yet).
         let path = self.next_field().unwrap();
 
         // Get the read's coordinates.
-        self.next_field(); // Skip path length.
+        self.skip_fields(1); // Skip path length.
         let start: usize = self.int_field().unwrap();
         let end: usize = self.int_field().unwrap();
 

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -19,11 +19,7 @@ pub struct GAFLookup {
 
 pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
     // Build a map to efficiently look up segments by name.
-    // TODO Maybe move this to a library?
-    let mut name_map = NameMap::default();
-    for (id, seg) in gfa.segs.items() {
-        name_map.insert(seg.name, id);
-    }
+    let name_map = NameMap::build(gfa);
 
     let gaf_buf = map_file(&args.gaf);
     if args.seqs {

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -22,14 +22,23 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
         for event in PathChunker::new(gfa, read) {
             let seg = gfa.segs[event.handle.segment()];
             let seg_name = seg.name;
-            print!("{}: {}{}", event.index, seg_name, event.handle.orient());
             match event.range {
                 ChunkRange::Partial(len) => {
-                    print!(", {}bp", len);
+                    println!(
+                        "{}: {}{}, {}bp",
+                        event.index,
+                        seg_name,
+                        event.handle.orient(),
+                        len
+                    );
                 }
-                _ => {}
+                ChunkRange::All => {
+                    println!("{}: {}{}", event.index, seg_name, event.handle.orient());
+                }
+                ChunkRange::None => {
+                    println!("{}: (skipped)", event.index);
+                }
             }
-            println!();
         }
     }
 }

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -22,7 +22,7 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GafLookup) {
         // Walk down the path to find the start and end coordinates in the segments.
         let mut pos = 0;
         let mut started = false;
-        for (seg_name, forward) in PathParser::new(read.path) {
+        for (seg_name, forward) in read.steps() {
             let seg_id = gfa.find_seg(seg_name).expect("GAF has unknown segment");
 
             // Accumulate the length to track our position in the path.
@@ -53,7 +53,7 @@ struct GAFRead<'a> {
 }
 
 impl<'a> GAFRead<'a> {
-    pub fn parse(line: &'a [u8]) -> Self {
+    fn parse(line: &'a [u8]) -> Self {
         // Lines in a GAF are tab-separated.
         let mut field_iter = MemchrSplit::new(b'\t', line);
         let name = BStr::new(field_iter.next().unwrap());
@@ -79,6 +79,10 @@ impl<'a> GAFRead<'a> {
             end,
             path,
         }
+    }
+
+    fn steps(&self) -> PathParser {
+        PathParser::new(self.path)
     }
 }
 

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -20,6 +20,7 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
     let gaf_buf = map_file(&args.gaf);
 
     if args.seqs {
+        // Print the actual sequences for each chunk in the GAF.
         for line in MemchrSplit::new(b'\n', &gaf_buf) {
             let read = GAFLine::parse(line);
             print!("{}\t", read.name);
@@ -29,6 +30,7 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
             println!();
         }
     } else {
+        // Just print some info about the offsets in the segments.
         for line in MemchrSplit::new(b'\n', &gaf_buf) {
             let read = GAFLine::parse(line);
             println!("{}", read.name);
@@ -226,6 +228,7 @@ impl<'a> PathParser<'a> {
         Self { str, index: 0 }
     }
 
+    #[allow(dead_code)]
     pub fn rest(&self) -> &[u8] {
         &self.str[self.index..]
     }

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -13,7 +13,7 @@ pub struct GafLookup {
 }
 
 pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GafLookup) {
-    // Read the GAF file, I suppose.
+    // Read the lines in the GAF.
     let gaf_buf = map_file(&args.gaf);
     for line in MemchrSplit::new(b'\n', &gaf_buf) {
         let read = GAFRead::parse(line);
@@ -69,7 +69,7 @@ impl<'a> GAFRead<'a> {
         let path = field_iter.next().unwrap();
 
         // Get the read's coordinates.
-        let path_len: usize = parse_int_all(field_iter.next().unwrap()).unwrap();
+        field_iter.next().unwrap(); // Skip path length.
         let start: usize = parse_int_all(field_iter.next().unwrap()).unwrap();
         let end: usize = parse_int_all(field_iter.next().unwrap()).unwrap();
 

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -1,0 +1,22 @@
+use crate::flatgfa;
+use crate::memfile::{map_file, MemchrSplit};
+use argh::FromArgs;
+
+/// look up positions from a GAF file
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "gaf")]
+pub struct GafLookup {
+    /// path_name,offset,orientation
+    #[argh(positional)]
+    gaf: String,
+}
+
+pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GafLookup) {
+    // Read the GAF file, I suppose.
+    // let file = File::open(args.gaf).unwrap();
+    // for line in io::BufReader::new(file).lines() {}
+    let gaf_buf = map_file(&args.gaf);
+    for line in MemchrSplit::new(b'\n', &gaf_buf) {
+        println!("line {}", line.len());
+    }
+}

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -1,6 +1,6 @@
 use crate::flatgfa;
 use crate::memfile::{map_file, MemchrSplit};
-use crate::parse::NameMap;
+use crate::namemap::NameMap;
 use argh::FromArgs;
 use bstr::BStr;
 

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -27,18 +27,11 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GafLookup) {
         field_iter.next().unwrap();
         field_iter.next().unwrap();
 
-        // Step through the path. Using MemchrSplit is pretty lazy; it would be
+        // Using MemchrSplit to get the GAF fields is pretty lazy; it would be
         // better to manage the indices directly.
         let path = field_iter.next().unwrap();
-        for byte in path {
-            if *byte == b'<' {
-                println!("backward!");
-            } else if *byte == b'>' {
-                println!("forward!");
-            } else {
-                panic!("expected direction (> or <)");
-            }
-            break;
+        for step in PathParser::new(path) {
+            dbg!(step);
         }
     }
 }
@@ -63,6 +56,10 @@ impl<'a> Iterator for PathParser<'a> {
     type Item = (usize, bool);
 
     fn next(&mut self) -> Option<(usize, bool)> {
+        if self.index >= self.str.len() {
+            return None;
+        }
+
         // The first character must be a direction.
         let byte = self.str[self.index];
         self.index += 1;

--- a/flatgfa/src/gaf.rs
+++ b/flatgfa/src/gaf.rs
@@ -20,7 +20,16 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
         println!("{}", read.name);
 
         for event in PathChunker::new(gfa, read) {
-            dbg!(event);
+            let seg = gfa.segs[event.handle.segment()];
+            let seg_name = seg.name;
+            print!("{}: {}{}", event.index, seg_name, event.handle.orient());
+            match event.range {
+                ChunkRange::Partial(len) => {
+                    print!(", {}bp", len);
+                }
+                _ => {}
+            }
+            println!();
         }
     }
 }

--- a/flatgfa/src/lib.rs
+++ b/flatgfa/src/lib.rs
@@ -4,6 +4,7 @@ pub mod flatgfa;
 pub mod gaf;
 pub mod gfaline;
 pub mod memfile;
+pub mod namemap;
 pub mod parse;
 pub mod pool;
 pub mod print;

--- a/flatgfa/src/lib.rs
+++ b/flatgfa/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod cmds;
 pub mod file;
 pub mod flatgfa;
+pub mod gaf;
 pub mod gfaline;
+pub mod memfile;
 pub mod parse;
 pub mod pool;
 pub mod print;

--- a/flatgfa/src/main.rs
+++ b/flatgfa/src/main.rs
@@ -42,7 +42,7 @@ enum Command {
     Extract(cmds::Extract),
     Depth(cmds::Depth),
     Chop(cmds::Chop),
-    GafLookup(gaf::GafLookup),
+    GafLookup(gaf::GAFLookup),
 }
 
 fn main() -> Result<(), &'static str> {

--- a/flatgfa/src/memfile.rs
+++ b/flatgfa/src/memfile.rs
@@ -1,0 +1,53 @@
+use memmap::{Mmap, MmapMut};
+
+pub fn map_file(name: &str) -> Mmap {
+    let file = std::fs::File::open(name).unwrap();
+    unsafe { Mmap::map(&file) }.unwrap()
+}
+
+pub fn map_new_file(name: &str, size: u64) -> MmapMut {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(name)
+        .unwrap();
+    file.set_len(size).unwrap();
+    unsafe { MmapMut::map_mut(&file) }.unwrap()
+}
+
+pub fn map_file_mut(name: &str) -> MmapMut {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(name)
+        .unwrap();
+    unsafe { MmapMut::map_mut(&file) }.unwrap()
+}
+
+pub struct MemchrSplit<'a> {
+    haystack: &'a [u8],
+    memchr: memchr::Memchr<'a>,
+    pos: usize,
+}
+
+impl<'a> Iterator for MemchrSplit<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let start = self.pos;
+        let end = self.memchr.next()?;
+        self.pos = end + 1;
+        Some(&self.haystack[start..end])
+    }
+}
+
+impl MemchrSplit<'_> {
+    pub fn new(needle: u8, haystack: &[u8]) -> MemchrSplit {
+        MemchrSplit {
+            haystack,
+            memchr: memchr::memchr_iter(needle, haystack),
+            pos: 0,
+        }
+    }
+}

--- a/flatgfa/src/namemap.rs
+++ b/flatgfa/src/namemap.rs
@@ -1,0 +1,34 @@
+use crate::flatgfa::Segment;
+use crate::pool::Id;
+use std::collections::HashMap;
+
+/// A fast way to look up segment IDs by their (integer) names.
+#[derive(Default)]
+pub struct NameMap {
+    /// Names at most this are assigned *sequential* IDs, i.e., the ID is just the name
+    /// minus one.
+    sequential_max: usize,
+
+    /// Non-sequential names go here.
+    others: HashMap<usize, u32>,
+}
+
+impl NameMap {
+    pub fn insert(&mut self, name: usize, id: Id<Segment>) {
+        // Is this the next sequential name? If so, no need to record it in our hash table;
+        // just bump the number of sequential names we've seen.
+        if (name - 1) == self.sequential_max && (name - 1) == id.index() {
+            self.sequential_max += 1;
+        } else {
+            self.others.insert(name, id.into());
+        }
+    }
+
+    pub fn get(&self, name: usize) -> Id<Segment> {
+        if name <= self.sequential_max {
+            ((name - 1) as u32).into()
+        } else {
+            self.others[&name].into()
+        }
+    }
+}

--- a/flatgfa/src/namemap.rs
+++ b/flatgfa/src/namemap.rs
@@ -1,4 +1,4 @@
-use crate::flatgfa::Segment;
+use crate::flatgfa::{FlatGFA, Segment};
 use crate::pool::Id;
 use std::collections::HashMap;
 
@@ -30,5 +30,14 @@ impl NameMap {
         } else {
             self.others[&name].into()
         }
+    }
+
+    /// Construct a name map for all the segments in a GFA.
+    pub fn build(gfa: &FlatGFA) -> Self {
+        let mut name_map = NameMap::default();
+        for (id, seg) in gfa.segs.items() {
+            name_map.insert(seg.name, id);
+        }
+        name_map
     }
 }

--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -1,8 +1,7 @@
-use crate::flatgfa::{self, Handle, LineKind, Orientation, Segment};
+use crate::flatgfa::{self, Handle, LineKind, Orientation};
 use crate::gfaline;
 use crate::memfile::MemchrSplit;
-use crate::pool::Id;
-use std::collections::HashMap;
+use crate::namemap::NameMap;
 use std::io::BufRead;
 
 pub struct Parser<'a, P: flatgfa::StoreFamily<'a>> {
@@ -176,36 +175,6 @@ impl Parser<'static, flatgfa::HeapFamily> {
 impl<'a> Parser<'a, flatgfa::FixedFamily> {
     pub fn for_slice(store: flatgfa::FixedGFAStore<'a>) -> Self {
         Self::new(store)
-    }
-}
-
-#[derive(Default)]
-pub struct NameMap {
-    /// Names at most this are assigned *sequential* IDs, i.e., the ID is just the name
-    /// minus one.
-    sequential_max: usize,
-
-    /// Non-sequential names go here.
-    others: HashMap<usize, u32>,
-}
-
-impl NameMap {
-    pub fn insert(&mut self, name: usize, id: Id<Segment>) {
-        // Is this the next sequential name? If so, no need to record it in our hash table;
-        // just bump the number of sequential names we've seen.
-        if (name - 1) == self.sequential_max && (name - 1) == id.index() {
-            self.sequential_max += 1;
-        } else {
-            self.others.insert(name, id.into());
-        }
-    }
-
-    pub fn get(&self, name: usize) -> Id<Segment> {
-        if name <= self.sequential_max {
-            ((name - 1) as u32).into()
-        } else {
-            self.others[&name].into()
-        }
     }
 }
 

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -1,4 +1,4 @@
-use std::ops::{Index, Add, Sub};
+use std::ops::{Add, Index, Sub};
 use std::{hash::Hash, marker::PhantomData};
 use tinyvec::SliceVec;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
@@ -34,16 +34,18 @@ impl<T> Add<u32> for Id<T> {
 impl<T> Sub<u32> for Id<T> {
     type Output = Self;
     #[inline]
-    fn sub(self, rhs:u32) -> Self::Output {
+    fn sub(self, rhs: u32) -> Self::Output {
         Self(self.0 - rhs, PhantomData)
     }
 }
 
 impl<T> Id<T> {
+    /// Get the ID's location in the relevant pool.
     pub fn index(self) -> usize {
         self.0 as usize
     }
 
+    /// Create a new ID pointing to a given pool index.
     pub fn new(index: usize) -> Self {
         Self(index.try_into().expect("id too large"), PhantomData)
     }


### PR DESCRIPTION
The GAF format is explained here:
https://github.com/lh3/gfatools/blob/master/doc/rGFA.md#the-graph-alignment-format-gaf

For our purposes, GAF files contain little "mini-paths" that refer to chunks of sequence data from a GFA graph. This just adds some machinery to parse GAF files and look up the corresponding coordinates in a GFA.