### PR TITLE
Basic parallelism machinery

### DIFF
--- a/flatgfa-py/Cargo.lock
+++ b/flatgfa-py/Cargo.lock
@@ -78,6 +78,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +124,7 @@ dependencies = [
  "memchr",
  "memmap",
  "num_enum",
+ "rayon",
  "tinyvec",
  "zerocopy",
 ]
@@ -335,6 +367,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/flatgfa/Cargo.lock
+++ b/flatgfa/Cargo.lock
@@ -66,6 +66,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +112,7 @@ dependencies = [
  "memchr",
  "memmap",
  "num_enum",
+ "rayon",
  "tinyvec",
  "zerocopy",
 ]
@@ -178,6 +210,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/flatgfa/Cargo.toml
+++ b/flatgfa/Cargo.toml
@@ -14,6 +14,7 @@ bstr = "1.10.0"
 memchr = "2.7.4"
 memmap = "0.7.0"
 num_enum = "0.7.3"
+rayon = "1.10.0"
 tinyvec = "1.8.0"
 zerocopy = { version = "0.7.35", features = ["derive"] }
 

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -1,4 +1,5 @@
 use crate::flatgfa::{self, Handle, Link, Orientation, Path, Segment};
+use crate::memfile;
 use crate::pool::{self, Id, Span, Store};
 use crate::{GFAStore, HeapFamily};
 use argh::FromArgs;
@@ -136,6 +137,27 @@ pub fn position(gfa: &flatgfa::FlatGFA, args: Position) -> Result<(), &'static s
     Ok(())
 }
 
+/// benchmarks
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "bench")]
+pub struct Bench {
+    /// count lines in a text file
+    #[argh(option)]
+    wcl: Option<String>,
+}
+
+pub fn bench(args: Bench) {
+    // TODO: We don't need a GFA for (some of) these? So avoid opening it.
+    match args.wcl {
+        Some(filename) => {
+            let buf = memfile::map_file(&filename);
+            let count = memfile::MemchrSplit::new(b'\n', &buf).count();
+            println!("{}", count);
+        }
+        None => {}
+    }
+}
+
 /// create a subset graph
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "extract")]
@@ -149,12 +171,17 @@ pub struct Extract {
     link_distance: usize,
 
     /// maximum number of basepairs allowed between subpaths s.t. the subpaths are merged together
-    #[argh(option, short = 'd', long = "max-distance-subpaths", default = "300000")]
+    #[argh(
+        option,
+        short = 'd',
+        long = "max-distance-subpaths",
+        default = "300000"
+    )]
     max_distance_subpaths: usize, // TODO: possibly make this bigger
 
     /// maximum number of iterations before we stop merging subpaths
     #[argh(option, short = 'e', long = "max-merging-iterations", default = "6")]
-    num_iterations: usize // TODO: probably make this smaller
+    num_iterations: usize, // TODO: probably make this smaller
 }
 
 pub fn extract(
@@ -165,7 +192,12 @@ pub fn extract(
 
     let mut subgraph = SubgraphBuilder::new(gfa);
     subgraph.add_header();
-    subgraph.extract(origin_seg, args.link_distance, args.max_distance_subpaths, args.num_iterations);
+    subgraph.extract(
+        origin_seg,
+        args.link_distance,
+        args.max_distance_subpaths,
+        args.num_iterations,
+    );
     Ok(subgraph.store)
 }
 
@@ -192,10 +224,10 @@ impl<'a> SubgraphBuilder<'a> {
 
     /// Include the old graph's header
     fn add_header(&mut self) {
-            // pub fn add_header(&mut self, version: &[u8]) {
-            //     assert!(self.header.as_ref().is_empty());
-            //     self.header.add_slice(version);
-            // }
+        // pub fn add_header(&mut self, version: &[u8]) {
+        //     assert!(self.header.as_ref().is_empty());
+        //     self.header.add_slice(version);
+        // }
         assert!(self.store.header.as_ref().is_empty());
         self.store.header.add_slice(self.old.header.all());
     }
@@ -242,7 +274,10 @@ impl<'a> SubgraphBuilder<'a> {
                 // We just entered the subgraph. End the current subpath.
                 if !ignore_path && subpath_length <= max_distance_subpaths {
                     // TODO: type safety
-                    let subpath_span = Span::new(path.steps.start + *start as u32, path.steps.start + idx as u32);
+                    let subpath_span = Span::new(
+                        path.steps.start + *start as u32,
+                        path.steps.start + idx as u32,
+                    );
                     for step in &self.old.steps[subpath_span] {
                         if !self.seg_map.contains_key(&step.segment()) {
                             self.include_seg(step.segment());
@@ -254,7 +289,7 @@ impl<'a> SubgraphBuilder<'a> {
             } else if let (None, false) = (&cur_subpath_start, in_neighb) {
                 // We've exited the current subgraph, start a new subpath
                 cur_subpath_start = Some(idx);
-            } 
+            }
 
             // Track the current bp position in the path.
             subpath_length += self.old.get_handle_seg(*step).len();
@@ -313,7 +348,13 @@ impl<'a> SubgraphBuilder<'a> {
     ///
     /// Include any links between the segments in the neighborhood and subpaths crossing
     /// through the neighborhood.
-    fn extract(&mut self, origin: Id<Segment>, dist: usize, max_distance_subpaths: usize, num_iterations: usize) {
+    fn extract(
+        &mut self,
+        origin: Id<Segment>,
+        dist: usize,
+        max_distance_subpaths: usize,
+        num_iterations: usize,
+    ) {
         self.include_seg(origin);
 
         // Find the set of all segments that are c links away.
@@ -412,10 +453,9 @@ pub fn chop<'a>(
     gfa: &'a flatgfa::FlatGFA<'a>,
     args: Chop,
 ) -> Result<flatgfa::HeapGFAStore, &'static str> {
+    let mut flat = flatgfa::HeapGFAStore::default();
 
-    let mut flat = flatgfa::HeapGFAStore::default();        
-
-    // when segment S is chopped into segments S1 through S2 (exclusive), 
+    // when segment S is chopped into segments S1 through S2 (exclusive),
     // seg_map[S.name] = Span(Id(S1.name), Id(S2.name)). If S is not chopped: S=S1, S2.name = S1.name+1
     let mut seg_map: Vec<Span<Segment>> = Vec::new();
     // The smallest id (>0) which does not already belong to a segment in `flat`
@@ -448,14 +488,14 @@ pub fn chop<'a>(
             let mut offset = seg.seq.start.index();
             let segs_start = flat.segs.next_id();
             // Could also generate end_id by setting it equal to the start_id and
-            // updating it for each segment that is added - only benefits us if we 
+            // updating it for each segment that is added - only benefits us if we
             // don't unroll the last iteration of this loop
             while offset < seq_end.index() - args.c {
                 // Generate a new segment of length c
                 flat.segs.add(Segment {
                     name: max_node_id,
                     seq: Span::new(Id::new(offset), Id::new(offset + args.c)),
-                    optional: Span::new_empty()
+                    optional: Span::new_empty(),
                 });
                 offset += args.c;
                 max_node_id += 1;

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -149,14 +149,11 @@ pub struct Bench {
 
 pub fn bench(args: Bench) {
     // TODO: We don't need a GFA for (some of) these? So avoid opening it.
-    match args.wcl {
-        Some(filename) => {
-            let buf = memfile::map_file(&filename);
-            let split = memfile::MemchrSplit::new(b'\n', &buf);
-            let count = ParallelIterator::count(split);
-            println!("{}", count);
-        }
-        None => {}
+    if let Some(filename) = args.wcl {
+        let buf = memfile::map_file(&filename);
+        let split = memfile::MemchrSplit::new(b'\n', &buf);
+        let count = ParallelIterator::count(split);
+        println!("{}", count);
     }
 }
 

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -3,6 +3,7 @@ use crate::memfile;
 use crate::pool::{self, Id, Span, Store};
 use crate::{GFAStore, HeapFamily};
 use argh::FromArgs;
+use rayon::iter::ParallelIterator;
 use std::collections::{HashMap, HashSet};
 
 /// print the FlatGFA table of contents
@@ -151,7 +152,8 @@ pub fn bench(args: Bench) {
     match args.wcl {
         Some(filename) => {
             let buf = memfile::map_file(&filename);
-            let count = memfile::MemchrSplit::new(b'\n', &buf).count();
+            let split = memfile::MemchrSplit::new(b'\n', &buf);
+            let count = ParallelIterator::count(split);
             println!("{}", count);
         }
         None => {}

--- a/flatgfa/src/cmds.rs
+++ b/flatgfa/src/cmds.rs
@@ -145,6 +145,10 @@ pub struct Bench {
     /// count lines in a text file
     #[argh(option)]
     wcl: Option<String>,
+
+    /// enable parallelism when available
+    #[argh(switch, short = 'p')]
+    parallel: bool,
 }
 
 pub fn bench(args: Bench) {
@@ -152,7 +156,11 @@ pub fn bench(args: Bench) {
     if let Some(filename) = args.wcl {
         let buf = memfile::map_file(&filename);
         let split = memfile::MemchrSplit::new(b'\n', &buf);
-        let count = ParallelIterator::count(split);
+        let count = if args.parallel {
+            ParallelIterator::count(split)
+        } else {
+            Iterator::count(split)
+        };
         println!("{}", count);
     }
 }

--- a/flatgfa/src/main.rs
+++ b/flatgfa/src/main.rs
@@ -43,6 +43,7 @@ enum Command {
     Depth(cmds::Depth),
     Chop(cmds::Chop),
     GafLookup(gaf::GAFLookup),
+    Bench(cmds::Bench),
 }
 
 fn main() -> Result<(), &'static str> {
@@ -131,6 +132,9 @@ fn main() -> Result<(), &'static str> {
         }
         Some(Command::GafLookup(sub_args)) => {
             gaf::gaf_lookup(&gfa, sub_args);
+        }
+        Some(Command::Bench(sub_args)) => {
+            cmds::bench(sub_args);
         }
         None => {
             // Just emit the GFA or FlatGFA file.

--- a/flatgfa/src/memfile.rs
+++ b/flatgfa/src/memfile.rs
@@ -65,7 +65,8 @@ impl<'a> UnindexedProducer for MemchrSplit<'a> {
     type Item = &'a [u8];
 
     fn split(self) -> (Self, Option<Self>) {
-        // TODO Surely there is an off-by-one in here somewhere.
+        // Roughly chop the buffer in half. Maybe this should give up if the current
+        // size is already below a threshold.
         let mid = self.pos + (self.haystack.len() - self.pos) / 2;
         if mid >= self.haystack.len() || mid == 0 {
             return (self, None);
@@ -78,6 +79,7 @@ impl<'a> UnindexedProducer for MemchrSplit<'a> {
             None => return (self, None),
         };
 
+        // Create two sub-iterators.
         let left = Self {
             needle: self.needle,
             haystack: &self.haystack[..right_start],

--- a/flatgfa/src/memfile.rs
+++ b/flatgfa/src/memfile.rs
@@ -71,7 +71,7 @@ impl<'a> UnindexedProducer for MemchrSplit<'a> {
             return (self, None);
         };
 
-        // Advance the midpoint to a line boundary.
+        // Advance the midpoint to a needle boundary.
         let mid_nl = memchr::memchr(self.needle, &self.haystack[mid..]);
         let right_start = match mid_nl {
             Some(mid_nl) => mid + mid_nl + 1,

--- a/flatgfa/src/memfile.rs
+++ b/flatgfa/src/memfile.rs
@@ -1,4 +1,8 @@
 use memmap::{Mmap, MmapMut};
+use rayon::iter::{
+    plumbing::{bridge_unindexed, UnindexedConsumer, UnindexedProducer},
+    ParallelIterator,
+};
 
 pub fn map_file(name: &str) -> Mmap {
     let file = std::fs::File::open(name).unwrap();
@@ -26,15 +30,30 @@ pub fn map_file_mut(name: &str) -> MmapMut {
 }
 
 pub struct MemchrSplit<'a> {
+    needle: u8,
     haystack: &'a [u8],
     memchr: memchr::Memchr<'a>,
     pos: usize,
+}
+
+impl MemchrSplit<'_> {
+    pub fn new(needle: u8, haystack: &[u8]) -> MemchrSplit {
+        MemchrSplit {
+            needle,
+            haystack,
+            memchr: memchr::memchr_iter(needle, haystack),
+            pos: 0,
+        }
+    }
 }
 
 impl<'a> Iterator for MemchrSplit<'a> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.haystack.len() {
+            return None;
+        }
         let start = self.pos;
         let end = self.memchr.next()?;
         self.pos = end + 1;
@@ -42,12 +61,54 @@ impl<'a> Iterator for MemchrSplit<'a> {
     }
 }
 
-impl MemchrSplit<'_> {
-    pub fn new(needle: u8, haystack: &[u8]) -> MemchrSplit {
-        MemchrSplit {
-            haystack,
-            memchr: memchr::memchr_iter(needle, haystack),
+impl<'a> UnindexedProducer for MemchrSplit<'a> {
+    type Item = &'a [u8];
+
+    fn split(self) -> (Self, Option<Self>) {
+        // TODO Surely there is an off-by-one in here somewhere.
+        let mid = self.pos + (self.haystack.len() - self.pos) / 2;
+        if mid >= self.haystack.len() || mid == 0 {
+            return (self, None);
+        };
+
+        // Advance the midpoint to a line boundary.
+        let mid_nl = memchr::memchr(self.needle, &self.haystack[mid..]);
+        let right_start = match mid_nl {
+            Some(mid_nl) => mid + mid_nl + 1,
+            None => return (self, None),
+        };
+
+        let left = Self {
+            needle: self.needle,
+            haystack: &self.haystack[..right_start],
+            memchr: self.memchr,
+            pos: self.pos,
+        };
+        let right_buf = &self.haystack[right_start..];
+        let right = Self {
+            needle: self.needle,
+            haystack: right_buf,
+            memchr: memchr::memchr_iter(self.needle, right_buf),
             pos: 0,
-        }
+        };
+        (left, Some(right))
+    }
+
+    fn fold_with<F>(self, folder: F) -> F
+    where
+        F: rayon::iter::plumbing::Folder<Self::Item>,
+    {
+        folder.consume_iter(self)
+    }
+}
+
+impl<'a> ParallelIterator for MemchrSplit<'a> {
+    type Item = &'a [u8];
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge_unindexed(self, consumer)
     }
 }


### PR DESCRIPTION
Baby's first [Rayon](https://github.com/rayon-rs/rayon) experiment. I tried parallelizing the basic [memchr](https://docs.rs/memchr/latest/memchr/) iteration—not for anything important, just for a really basic `wc -l` (text-file line count) implementation. `fgfa bench --wcl foo.txt` should count the number of lines in the file. This is just a demo to see what it could do; it is not actually useful.

Anyway, the perf results are confusing, at the moment. On my MacBook Pro, `wc -l` itself takes 8.0 seconds to process the big Arabidopsis GAF; the sequential line counter takes 8.7 seconds (seems about right), and the parallel version takes 0.25 seconds (seems way too fast). (They all get the same answer.) This does not make much sense; why would the parallel version be 35 times faster? It's only a 10-core machine. Is it MLP, maybe? Weird effects of splitting up the `memchr` work into smaller chunks? It's a mystery. I guess I will try applying this to the actual GAF parser next to see what happens.