### PR TITLE
Avoid allocations when handling reverse-complement sequence data

### DIFF
--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -283,6 +283,18 @@ impl<'a> Sequence<'a> {
             revcmp: self.revcmp,
         }
     }
+
+    pub fn as_vec(&self) -> Vec<u8> {
+        if self.revcmp {
+            self.data
+                .iter()
+                .rev()
+                .map(|&c| nucleotide_complement(c))
+                .collect()
+        } else {
+            self.data.to_vec()
+        }
+    }
 }
 
 fn nucleotide_complement(c: u8) -> u8 {
@@ -302,9 +314,8 @@ fn nucleotide_complement(c: u8) -> u8 {
 impl<'a> std::fmt::Display for Sequence<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.revcmp {
-            for &c in self.data.iter().rev() {
-                write!(f, "{}", nucleotide_complement(c) as char)?;
-            }
+            let bytes = self.as_vec();
+            write!(f, "{}", BStr::new(&bytes))?;
         } else {
             write!(f, "{}", BStr::new(self.data))?;
         }

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -248,6 +248,47 @@ pub enum LineKind {
     Link,
 }
 
+pub struct Sequence<'a> {
+    data: &'a [u8],
+    revcmp: bool,
+}
+
+impl<'a> Sequence<'a> {
+    pub fn new(data: &'a [u8], ori: Orientation) -> Self {
+        Self {
+            data,
+            revcmp: ori == Orientation::Backward,
+        }
+    }
+}
+
+fn nucleotide_complement(c: u8) -> u8 {
+    match c {
+        b'A' => b'T',
+        b'T' => b'A',
+        b'C' => b'G',
+        b'G' => b'C',
+        b'a' => b't',
+        b't' => b'a',
+        b'c' => b'g',
+        b'g' => b'c',
+        x => x,
+    }
+}
+
+impl<'a> std::fmt::Display for Sequence<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.revcmp {
+            for &c in self.data.iter().rev() {
+                write!(f, "{}", nucleotide_complement(c))?;
+            }
+        } else {
+            write!(f, "{}", BStr::new(self.data))?;
+        }
+        Ok(())
+    }
+}
+
 impl<'a> FlatGFA<'a> {
     /// Get the base-pair sequence for a segment.
     pub fn get_seq(&self, seg: &Segment) -> &BStr {
@@ -287,8 +328,8 @@ impl<'a> FlatGFA<'a> {
 
     /// Look up a CIGAR alignment.
     pub fn get_alignment(&self, overlap: Span<AlignOp>) -> Alignment {
-        Alignment { 
-            ops: &self.alignment[overlap]
+        Alignment {
+            ops: &self.alignment[overlap],
         }
     }
 

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -314,6 +314,10 @@ fn nucleotide_complement(c: u8) -> u8 {
 impl<'a> std::fmt::Display for Sequence<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.revcmp {
+            // For small sequences, it's faster to allocate the reverse-complement
+            // string and write the whole buffer at once. For larger sequences, it
+            // may be more efficient to do it one character at a time to avoid an
+            // allocation? Not sure, but could be worth a try.
             let bytes = self.as_vec();
             write!(f, "{}", BStr::new(&bytes))?;
         } else {


### PR DESCRIPTION
As a follow-up to @AndreaGuarracino's #196, this tries to avoid allocating any buffers for reverse-complements until the last possible second (before printing). Seems to come with a minor but not enormous performance benefit, just for printing.

The idea is to introduce a structure that wraps the underlying `&[u8]` buffer and a flag for reversals. Then, the only actually do the reverse-complement-ing when we `Display`. Index trickery makes it possible to treat this new type mostly as if it were an eagerly-computed string.