### PR TITLE
Parse GAF files in parallel

### DIFF
--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -245,8 +245,8 @@ pub struct GAFLookup {
     seqs: bool,
 
     /// benchmark only: print nothing; limit reads if nonzero
-    #[argh(option, short = 'b')]
-    bench: Option<u32>,
+    #[argh(switch, short = 'b')]
+    bench: bool,
 }
 
 pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
@@ -265,15 +265,12 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
             }
             println!();
         }
-    } else if let Some(limit) = args.bench {
+    } else if args.bench {
         // Benchmarking mode: just process all the chunks but print nothing.
         let mut count = 0;
-        for (i, read) in parser.enumerate() {
+        for read in parser {
             for _event in ops::gaf::PathChunker::new(gfa, &name_map, read) {
                 count += 1;
-            }
-            if limit > 0 && i >= (limit as usize) {
-                break;
             }
         }
         println!("{}", count);

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -262,12 +262,15 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
     let parser = ops::gaf::GAFParser::new(&gaf_buf);
 
     if args.parallel {
-        // TODO actually do useful stuff
-        let count = ParallelIterator::map(parser, |read| {
-            ops::gaf::PathChunker::new(gfa, &name_map, read).count()
-        })
-        .reduce(|| 0, |a, b| a + b);
-        println!("{}", count);
+        if args.bench {
+            let count = ParallelIterator::map(parser, |read| {
+                ops::gaf::PathChunker::new(gfa, &name_map, read).count()
+            })
+            .reduce(|| 0, |a, b| a + b);
+            println!("{}", count);
+        } else {
+            unimplemented!("only the no-op mode is parallel")
+        }
     } else {
         if args.seqs {
             // Print the actual sequences for each chunk in the GAF.

--- a/flatgfa/src/cli/main.rs
+++ b/flatgfa/src/cli/main.rs
@@ -1,6 +1,5 @@
 use argh::FromArgs;
 use flatgfa::flatgfa::FlatGFA;
-use flatgfa::gaf;
 use flatgfa::parse::Parser;
 use flatgfa::pool::Store;
 use flatgfa::{cli::cmds, file, memfile, parse};
@@ -42,7 +41,7 @@ enum Command {
     Extract(cmds::Extract),
     Depth(cmds::Depth),
     Chop(cmds::Chop),
-    GafLookup(gaf::GAFLookup),
+    GafLookup(cmds::GAFLookup),
     Bench(cmds::Bench),
 }
 
@@ -131,7 +130,7 @@ fn main() -> Result<(), &'static str> {
             dump(&flat, &args.output);
         }
         Some(Command::GafLookup(sub_args)) => {
-            gaf::gaf_lookup(&gfa, sub_args);
+            cmds::gaf_lookup(&gfa, sub_args);
         }
         Some(Command::Bench(sub_args)) => {
             cmds::bench(sub_args);

--- a/flatgfa/src/lib.rs
+++ b/flatgfa/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod cli;
 pub mod file;
 pub mod flatgfa;
-pub mod gaf;
 pub mod gfaline;
 pub mod memfile;
 pub mod namemap;

--- a/flatgfa/src/ops/gaf.rs
+++ b/flatgfa/src/ops/gaf.rs
@@ -71,60 +71,17 @@ impl<'a> GAFLineParser<'a> {
 }
 
 pub struct GAFParser<'a> {
-    buf: &'a [u8],
-}
-
-impl<'a> GAFParser<'a> {
-    pub fn new(buf: &[u8]) -> GAFParser {
-        GAFParser { buf }
-    }
-
-    fn advance_line(&mut self) -> bool {
-        let newline_pos = memchr::memchr(b'\n', &self.buf);
-        match newline_pos {
-            None => {
-                self.buf = &self.buf[self.buf.len()..];
-                false
-            }
-            Some(pos) => {
-                self.buf = &self.buf[pos + 1..];
-                true
-            }
-        }
-    }
-
-    fn parse_line(&mut self) -> GAFLine<'a> {
-        let mut parser = GAFLineParser::new(self.buf);
-        let line = parser.parse();
-        self.buf = parser.buf;
-        self.advance_line();
-        line
-    }
-}
-
-impl<'a> Iterator for GAFParser<'a> {
-    type Item = GAFLine<'a>;
-
-    fn next(&mut self) -> Option<GAFLine<'a>> {
-        if self.buf.is_empty() {
-            return None;
-        }
-        Some(self.parse_line())
-    }
-}
-
-pub struct ParallelGAFParser<'a> {
     split: MemchrSplit<'a>,
 }
 
-impl<'a> ParallelGAFParser<'a> {
+impl<'a> GAFParser<'a> {
     pub fn new(buf: &'a [u8]) -> Self {
         let split = MemchrSplit::new(b'\n', buf);
         Self { split }
     }
 }
 
-impl<'a> Iterator for ParallelGAFParser<'a> {
+impl<'a> Iterator for GAFParser<'a> {
     type Item = GAFLine<'a>;
 
     fn next(&mut self) -> Option<GAFLine<'a>> {

--- a/flatgfa/src/ops/mod.rs
+++ b/flatgfa/src/ops/mod.rs
@@ -2,4 +2,5 @@ pub mod bench;
 pub mod chop;
 pub mod depth;
 pub mod extract;
+pub mod gaf;
 pub mod position;


### PR DESCRIPTION
This is truly of dubious utility, but it was sorta fun to experiment with. Presumably, a similar parallel treatment could be applied to the GFA parser someday?

Parsing the GAF in parallel scales pretty well in my experiments. On my M1 Max laptop (10 cores total: 8 performance, 2 efficiency), the parallel version goes from 5.131 seconds to 608.0 ms, so a speedup of 8.4×. Or in terms of lines per second, that's from about 9.6 million to 80.6 million. Nice!

I can't pretend this is actually all that insightful or surprising, but it might be useful.