### PR TITLE
Replace HashMaps with a bit-vector for unique depth computation

### DIFF
--- a/flatgfa/Cargo.lock
+++ b/flatgfa/Cargo.lock
@@ -49,6 +49,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bstr"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +114,7 @@ version = "0.1.0"
 dependencies = [
  "argh",
  "atoi",
+ "bit-vec",
  "bstr",
  "memchr",
  "memmap",

--- a/flatgfa/Cargo.toml
+++ b/flatgfa/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/cli/main.rs"
 [dependencies]
 argh = "0.1.12"
 atoi = "2.0.0"
+bit-vec = "0.8.0"
 bstr = "1.10.0"
 memchr = "2.7.4"
 memmap = "0.7.0"

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -204,7 +204,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA) {
             "{}\t{}\t{}",
             name,
             depths[id.index()],
-            uniq_paths[id.index()].len()
+            uniq_paths[id.index()],
         );
     }
 }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,22 +1,20 @@
 use crate::flatgfa;
-use std::collections::HashSet;
 
 pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
-    let mut depths = vec![0; gfa.segs.len()];
-    // Initialize uniq_paths
-    let mut uniq_paths = Vec::<HashSet<usize>>::new();
-    uniq_paths.resize(gfa.segs.len(), HashSet::new());
-    // do not assume that each handle in `gfa.steps()` is unique
-    for (idx, path) in gfa.paths.all().iter().enumerate() {
+    let mut depths = vec![0; gfa.segs.len()]; // The number of paths that traverse each segment.
+    let mut uniq_depths = vec![0; gfa.segs.len()]; // The number of distinct paths that traverse them.
+
+    for path in gfa.paths.all().iter() {
+        let mut seen = vec![0; gfa.segs.len()]; // Has this path traversed this segment?
         for step in &gfa.steps[path.steps] {
             let seg_id = step.segment().index();
-            // Increment depths
             depths[seg_id] += 1;
-            // Update uniq_paths
-            uniq_paths[seg_id].insert(idx);
+            if seen[seg_id] == 0 {
+                uniq_depths[seg_id] += 1;
+                seen[seg_id] = 1;
+            }
         }
     }
 
-    let uniq_depths = uniq_paths.iter().map(|set| set.len()).collect();
     (depths, uniq_depths)
 }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,8 +1,7 @@
 use crate::flatgfa;
 use std::collections::HashSet;
 
-pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<HashSet<usize>>) {
-    // Initialize node depth
+pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     let mut depths = vec![0; gfa.segs.len()];
     // Initialize uniq_paths
     let mut uniq_paths = Vec::<HashSet<usize>>::new();
@@ -18,5 +17,6 @@ pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<HashSet<usize>>) {
         }
     }
 
-    (depths, uniq_paths)
+    let uniq_depths = uniq_paths.iter().map(|set| set.len()).collect();
+    (depths, uniq_depths)
 }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,17 +1,18 @@
 use crate::flatgfa;
+use bit_vec::BitVec;
 
 pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     let mut depths = vec![0; gfa.segs.len()]; // The number of paths that traverse each segment.
     let mut uniq_depths = vec![0; gfa.segs.len()]; // The number of distinct paths that traverse them.
 
     for path in gfa.paths.all().iter() {
-        let mut seen = vec![0; gfa.segs.len()]; // Has this path traversed this segment?
+        let mut seen = BitVec::from_elem(gfa.segs.len(), false); // Has this path traversed this segment?
         for step in &gfa.steps[path.steps] {
             let seg_id = step.segment().index();
             depths[seg_id] += 1;
-            if seen[seg_id] == 0 {
+            if seen[seg_id] {
                 uniq_depths[seg_id] += 1;
-                seen[seg_id] = 1;
+                seen.set(seg_id, true);
             }
         }
     }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,17 +1,30 @@
 use crate::flatgfa;
 use bit_vec::BitVec;
 
+/// Compute the *depth* of each segment in the variation graph.
+///
+/// The depth is defined to be the number of times that a path traverses a given
+/// segment. We return two values: the ordinary depth and the *unique* depth,
+/// which only counts each path that tarverses a given segment once.
+///
+/// Both outputs are depth values indexed by segment ID.
 pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
-    let mut depths = vec![0; gfa.segs.len()]; // The number of paths that traverse each segment.
-    let mut uniq_depths = vec![0; gfa.segs.len()]; // The number of distinct paths that traverse them.
+    // Our output vectors: the ordinary and unique depths of each segment.
+    let mut depths = vec![0; gfa.segs.len()];
+    let mut uniq_depths = vec![0; gfa.segs.len()];
 
-    let mut seen = BitVec::from_elem(gfa.segs.len(), false); // Has the current path traversed each segment?
+    // This bit vector keeps track of whether the current path has already
+    // traversed a given segment, and therefore whether we should ignore
+    // subsequent traversals (for the purpose of counting unique depth).
+    let mut seen = BitVec::from_elem(gfa.segs.len(), false);
+
     for path in gfa.paths.all().iter() {
-        seen.clear();
+        seen.clear(); // All segments are unseen.
         for step in &gfa.steps[path.steps] {
             let seg_id = step.segment().index();
             depths[seg_id] += 1;
             if seen[seg_id] {
+                // The first traversal of this path over this segment.
                 uniq_depths[seg_id] += 1;
                 seen.set(seg_id, true);
             }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -5,8 +5,9 @@ pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     let mut depths = vec![0; gfa.segs.len()]; // The number of paths that traverse each segment.
     let mut uniq_depths = vec![0; gfa.segs.len()]; // The number of distinct paths that traverse them.
 
+    let mut seen = BitVec::from_elem(gfa.segs.len(), false); // Has the current path traversed each segment?
     for path in gfa.paths.all().iter() {
-        let mut seen = BitVec::from_elem(gfa.segs.len(), false); // Has this path traversed this segment?
+        seen.clear();
         for step in &gfa.steps[path.steps] {
             let seg_id = step.segment().index();
             depths[seg_id] += 1;


### PR DESCRIPTION
Just a low-hanging fruit optimization for this op: instead of a `Vec<HashMap<usize>>`, we can use a single `BitVec`.

I did this in three steps and measured their performance on the chr22 GFA:

* Switching to a dense vector, but not a proper bit vector: 14.7 -> 2.2 seconds
* Switching to a proper bit vector from the [bit-vec](https://docs.rs/bit-vec/latest/bit_vec/) crate: 2.2 -> 2.0 seconds
* Reusing a single bit vector instead of allocating in the loop: no effect; maybe the optimizer already got this

Anyway, a quick profiling run suggests that running `fgfa depth > /dev/null` on this graph is now 90% printing stuff and 10% actual depth computation, so I think we'll call that good.