### PR TITLE
Switch instructions & metadata files to use a modern uv workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,18 +24,14 @@ jobs:
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-uv
-      - name: Create and activate virtualenv with uv
+      - name: uv sync and activate
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv venv
+          uv sync
           echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
-      - name: Install Python tools
-        run: uv pip install -r requirements.txt
 
       # Set up for tests.
-      - name: Install Turnt
-        run: uv pip install turnt
       - name: Problem matcher
         run: echo '::add-matcher::.github/tap-matcher.json'
       - name: Fetch test data
@@ -70,14 +66,12 @@ jobs:
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-uv
-      - name: Create and activate virtualenv with uv
+      - name: uv sync and activate
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv venv
+          uv sync
           echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
-      - name: Install Python tools
-        run: uv pip install -r requirements.txt
 
       # Install odgi
       - name: Pull odgi container

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Similarly, `slow_odgi` is a set of GFA analyses based on `mygfa`; it's meant to 
 
 To set up both of them from this repository, try using [uv][]:
 
-    $ uv venv
-    $ uv pip install -r requirements.txt
-    $ source .venv/bin/activate
+    $ uv run slow_odgi --help
 
-Now type `slow_odgi --help` to see if everything's working.
+Or, alternatively, you can set up and activate the environment manually:
+
+    $ uv sync
+    $ source .venv/bin/activate
+    $ slow_odgi --help
 
 [uv]: https://github.com/astral-sh/uv
 [mygfa-docs]: http://cucapra.github.io/pollen/mygfa/

--- a/flatgfa-py/Cargo.lock
+++ b/flatgfa-py/Cargo.lock
@@ -49,6 +49,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,7 @@ version = "0.1.0"
 dependencies = [
  "argh",
  "atoi",
+ "bit-vec",
  "bstr",
  "memchr",
  "memmap",

--- a/flatgfa-py/README.md
+++ b/flatgfa-py/README.md
@@ -12,28 +12,15 @@ Then, read [the API documentation][flatgfa-py-docs] for details about what it ca
 Development
 -----------
 
-To build this library, first install [Maturin][]:
+The easiest way to get started is with [uv][]:
 
-    $ pipx install maturin
+    $ uv run --package flatgfa python example.py
 
-Next, we'll build and install the Python library in our virtualenv.
-Starting from the repository root:
-
-    $ uv venv  # Unless you already created the virtualenv.
-    $ uv pip install pip  # Maturin depends on pip.
-    $ source .venv/bin/activate
-    $ cd flatgfa-py
-    $ maturin develop
-
-Now the `flatgfa` module is available to Python programs.
-Try our [example][]:
-
-    $ python example.py
+That should build and install the package and then run our `example.py` script.
 
 Or run the tests:
 
-    $ uv pip install pytest
-    $ pytest
+    $ uv run --package flatgfa pytest
 
 [maturin]: https://www.maturin.rs
 [flatgfa-py-docs]: https://cucapra.github.io/pollen/flatgfa/
@@ -41,3 +28,4 @@ Or run the tests:
 [gfa]: https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md
 [flatgfa-pypi]: https://pypi.org/project/flatgfa/
 [example]: https://github.com/cucapra/pollen/blob/main/flatgfa-py/example.py
+[uv]: https://docs.astral.sh/uv/

--- a/flatgfa-py/pyproject.toml
+++ b/flatgfa-py/pyproject.toml
@@ -15,8 +15,8 @@ classifiers = [
 repository = "https://github.com/cucapra/pollen"
 documentation = "https://cucapra.github.io/pollen/flatgfa/"
 
-[project.optional-dependencies]
-test = ["pytest"]
+[dependency-groups]
+dev = ["pytest>=8.3.0"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/pollen_py/README.md
+++ b/pollen_py/README.md
@@ -112,8 +112,7 @@ Clone this repository:
 
 And then install the Python tools using [uv][]:
 
-    $ uv venv
-    $ uv pip install -r requirements.txt
+    $ uv sync
     $ source .venv/bin/activate
 
 [calyx]: https://calyxir.org

--- a/pollen_py/pyproject.toml
+++ b/pollen_py/pyproject.toml
@@ -1,15 +1,14 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "pollen"
-author = "Susan Garry"
-author-email = "shg64@cs.cornell.edu"
-home-page = "https://github.com/cucapra/pollen"
-description-file = "README.md"
-requires-python = ">=3.8"
-requires = []
+[project]
+name = "pollen"
+authors = [
+    { name = "Susan Garry", email = "shg64@cs.cornell.edu" }
+]
+readme = "README.md"
+dynamic = ["version", "description"]
 
-[tool.flit.scripts]
+[project.scripts]
 exine = "pollen.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "slow_odgi",
     "pollen",
     "pollen_data_gen",
+    "turnt",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "pollen_workspace"
+version = "0.0.0"
+requires-python = ">=3.8"
+dependencies = [
+    "mygfa",
+    "slow_odgi",
+    "pollen",
+    "pollen_data_gen",
+]
+
+[tool.uv.sources]
+mygfa = { workspace = true }
+slow_odgi = { workspace = true }
+pollen = { workspace = true }
+pollen_data_gen = { workspace = true }
+
+[tool.uv.workspace]
+members = [
+    "mygfa",
+    "slow_odgi",
+    "pollen_py",
+    "pollen_data_gen",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "slow_odgi",
     "pollen",
     "pollen_data_gen",
-    "turnt",
+    "turnt>=1.11.0",
 ]
 
 [tool.uv.sources]
@@ -15,6 +15,7 @@ mygfa = { workspace = true }
 slow_odgi = { workspace = true }
 pollen = { workspace = true }
 pollen_data_gen = { workspace = true }
+flatgfa = { workspace = true }
 
 [tool.uv.workspace]
 members = [
@@ -22,4 +23,5 @@ members = [
     "slow_odgi",
     "pollen_py",
     "pollen_data_gen",
+    "flatgfa-py",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
--e ./mygfa
--e ./slow_odgi
--e ./pollen_py
--e ./pollen_data_gen
-turnt

--- a/slow_odgi/README.md
+++ b/slow_odgi/README.md
@@ -10,8 +10,7 @@ Think of it as a code-forward spec for `odgi` commands.
 
 One easy way to install everything in the Pollen repo is to use [uv][]:
 
-    $ uv venv
-    $ uv pip install -r requirements.txt
+    $ uv sync
     $ source .venv/bin/activate
 
 [uv]: https://github.com/astral-sh/uv
@@ -30,7 +29,7 @@ To test `slow_odgi`, we treat odgi as an oracle and compare our outputs against 
 To run these tests, you will need:
 
 1. [Odgi][]. Our tests were run against a built-from-source copy of odgi (commit `34f006f`).
-2. [Turnt][]. This is installed automatically if you use `requirements.txt` as above.
+2. [Turnt][]. This is installed automatically if you use `uv` as above.
 
 With these in place, run `make test-slow-odgi`. The "oracle" files will be generated first, and this will toss up a large number of warnings which can all be ignored. Then the tests will begin to run, and the `ok`/`not ok` signals there are actually of interest.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,206 @@
+version = 1
+requires-python = ">=3.8"
+
+[manifest]
+members = [
+    "flatgfa",
+    "mygfa",
+    "pollen",
+    "pollen-data-gen",
+    "pollen-workspace",
+    "slow-odgi",
+]
+
+[[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
+]
+
+[[package]]
+name = "flatgfa"
+version = "0.2.0"
+source = { editable = "flatgfa-py" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.0" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "mygfa"
+version = "0.1"
+source = { editable = "mygfa" }
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pollen"
+version = "1"
+source = { editable = "pollen_py" }
+
+[[package]]
+name = "pollen-data-gen"
+version = "0.1"
+source = { editable = "pollen_data_gen" }
+dependencies = [
+    { name = "mygfa" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "mygfa", editable = "mygfa" }]
+
+[[package]]
+name = "pollen-workspace"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "mygfa" },
+    { name = "pollen" },
+    { name = "pollen-data-gen" },
+    { name = "slow-odgi" },
+    { name = "turnt" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mygfa", editable = "mygfa" },
+    { name = "pollen", editable = "pollen_py" },
+    { name = "pollen-data-gen", editable = "pollen_data_gen" },
+    { name = "slow-odgi", editable = "slow_odgi" },
+    { name = "turnt", specifier = ">=1.11.0" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "slow-odgi"
+version = "0.1"
+source = { editable = "slow_odgi" }
+dependencies = [
+    { name = "mygfa" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "mygfa", editable = "mygfa" }]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "turnt"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/ff/9e3653777373cc13565401685faaa95c941c463e54c8d53abd81e3656ebb/turnt-1.12.0.tar.gz", hash = "sha256:e0aedca86c0a12b19b67e77155ad3abfc6887eba552c2dbdddddbd413fafb01c", size = 19829 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/fe/fe48f721fc4ae86ec5198ddce1f463e3550d954c287feccd5e6bcc2fb110/turnt-1.12.0-py3-none-any.whl", hash = "sha256:dc3fb21df0127ccad3f4efae1cb6147c255c53187080145b9fad889d68daba45", size = 13160 },
+]


### PR DESCRIPTION
The old `requirements.txt`-based workflow for installing/using our Python tools is not the most convenient, and [uv](https://docs.astral.sh/uv/) has progressed a lot since I wrote those original instructions. Now a lot more of this stuff is a convenient one-liner.