### PR TITLE
Basic BED File Parser and Intersect

### DIFF
--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -304,7 +304,6 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
     }
 }
 
-
 /// parse a BED file
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "bed")]
@@ -312,33 +311,31 @@ pub struct BEDIntersect {
     /// first BED file to intersect
     #[argh(option, short = 'a')]
     first_bed_file_path: String,
-    
+
     /// second BED file to intersect
     #[argh(option, short = 'b')]
     second_bed_file_path: String,
 }
 
 pub fn bed_intersect(args: BEDIntersect) {
-
     let bed_file_path = args.first_bed_file_path;
     let bed_file_path2 = args.second_bed_file_path;
 
-        let file = memfile::map_file(&bed_file_path);
-        let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
-        let bed = bed_store.as_ref();
-        
-            let file2 = memfile::map_file(&bed_file_path2);
-            let bed_store2 = BEDParser::for_heap().parse_mem(file2.as_ref());
-            let bed2 = bed_store2.as_ref();
+    let file = memfile::map_file(&bed_file_path);
+    let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
+    let bed = bed_store.as_ref();
 
-            for outer_entries in bed.entries.items() {
-                let intersects = bed2.get_intersects(&bed, outer_entries.1);
-                for val in intersects.iter() {
-                    let name: &BStr = bed2.get_name_of_entry(val);
-                    let start = val.start;
-                    let end = val.end;
-                    println!("{}\t{}\t{}", name, start, end);
-                }
-            }
+    let file2 = memfile::map_file(&bed_file_path2);
+    let bed_store2 = BEDParser::for_heap().parse_mem(file2.as_ref());
+    let bed2 = bed_store2.as_ref();
 
+    for outer_entries in bed.entries.items() {
+        let intersects = bed2.get_intersects(&bed, outer_entries.1);
+        for val in intersects.iter() {
+            let name: &BStr = bed2.get_name_of_entry(val);
+            let start = val.start;
+            let end = val.end;
+            println!("{}\t{}\t{}", name, start, end);
+        }
+    }
 }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -317,6 +317,7 @@ pub struct BEDIntersect {
     second_bed_file_path: String,
 }
 
+/// find intersecting intervals between two BED files
 pub fn bed_intersect(args: BEDIntersect) {
     let bed_file_path = args.first_bed_file_path;
     let bed_file_path2 = args.second_bed_file_path;

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -1,9 +1,11 @@
+use crate::flatbed::BEDParser;
 use crate::flatgfa::{self, Segment};
-use crate::memfile::map_file;
+use crate::memfile::{self, map_file};
 use crate::namemap::NameMap;
 use crate::ops;
 use crate::pool::Id;
 use argh::FromArgs;
+use bstr::BStr;
 use rayon::iter::ParallelIterator;
 use std::collections::HashMap;
 
@@ -300,4 +302,43 @@ pub fn gaf_lookup(gfa: &flatgfa::FlatGFA, args: GAFLookup) {
             }
         }
     }
+}
+
+
+/// parse a BED file
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "bed")]
+pub struct BEDIntersect {
+    /// first BED file to intersect
+    #[argh(option, short = 'a')]
+    first_bed_file_path: String,
+    
+    /// second BED file to intersect
+    #[argh(option, short = 'b')]
+    second_bed_file_path: String,
+}
+
+pub fn bed_intersect(args: BEDIntersect) {
+
+    let bed_file_path = args.first_bed_file_path;
+    let bed_file_path2 = args.second_bed_file_path;
+
+        let file = memfile::map_file(&bed_file_path);
+        let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
+        let bed = bed_store.as_ref();
+        
+            let file2 = memfile::map_file(&bed_file_path2);
+            let bed_store2 = BEDParser::for_heap().parse_mem(file2.as_ref());
+            let bed2 = bed_store2.as_ref();
+
+            for outer_entries in bed.entries.items() {
+                let intersects = bed2.get_intersects(&bed, outer_entries.1);
+                for val in intersects.iter() {
+                    let name: &BStr = bed2.get_name_of_entry(val);
+                    let start = val.start;
+                    let end = val.end;
+                    println!("{}\t{}\t{}", name, start, end);
+                }
+            }
+
 }

--- a/flatgfa/src/cli/main.rs
+++ b/flatgfa/src/cli/main.rs
@@ -1,4 +1,5 @@
 use argh::FromArgs;
+use flatgfa::flatbed::BEDParser;
 use flatgfa::flatgfa::FlatGFA;
 use flatgfa::parse::Parser;
 use flatgfa::pool::Store;
@@ -27,6 +28,10 @@ struct PolBin {
     #[argh(option, short = 'p', default = "32")]
     prealloc_factor: usize,
 
+    /// read a BED file
+    #[argh(option, short = 'b')]
+    bed_file: Option<String>,
+
     #[argh(subcommand)]
     command: Option<Command>,
 }
@@ -54,6 +59,14 @@ fn main() -> Result<(), &'static str> {
             prealloc_translate(args.input_gfa.as_deref(), out_name, args.prealloc_factor);
             return Ok(());
         }
+    }
+
+    if let Some(bed_file_path) = args.bed_file{
+        let file = memfile::map_file(&bed_file_path);
+        let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
+        let bed = bed_store.as_ref();
+        println!("{}", bed.get_num_entries());
+        return Ok(());
     }
 
     // Load the input from a file (binary) or stdin (text).

--- a/flatgfa/src/cli/main.rs
+++ b/flatgfa/src/cli/main.rs
@@ -57,6 +57,8 @@ fn main() -> Result<(), &'static str> {
         }
     }
 
+    // Another special case for parsing BED files,
+    // since we do not parse a GFA file for that.
     if let Some(Command::BedIntersect(sub_args)) = args.command {
         cmds::bed_intersect(sub_args);
         return Ok(());

--- a/flatgfa/src/cli/main.rs
+++ b/flatgfa/src/cli/main.rs
@@ -1,4 +1,5 @@
 use argh::FromArgs;
+use bstr::BStr;
 use flatgfa::flatbed::BEDParser;
 use flatgfa::flatgfa::FlatGFA;
 use flatgfa::parse::Parser;
@@ -31,6 +32,14 @@ struct PolBin {
     /// read a BED file
     #[argh(option, short = 'b')]
     bed_file: Option<String>,
+
+    /// intersect a BED file start
+    #[argh(option, short = 's')]
+    intersect_start: u64,
+
+    /// intersect a BED file end
+    #[argh(option, short = 'e')]
+    intersect_end: u64,
 
     #[argh(subcommand)]
     command: Option<Command>,
@@ -65,7 +74,16 @@ fn main() -> Result<(), &'static str> {
         let file = memfile::map_file(&bed_file_path);
         let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
         let bed = bed_store.as_ref();
-        println!("{}", bed.get_num_entries());
+        println!("Total Number of BED Entries: {}", bed.get_num_entries());
+        
+        let intersects = bed.get_intersects(args.intersect_start, args.intersect_end);
+        println!("Intersections with {} - {}:", args.intersect_start, args.intersect_end);
+        for val in intersects.iter() {
+            let name: &BStr = bed.name_data[val.name].as_ref();
+            let start = val.start;
+            let end = val.end;
+            println!("{}:\t{} - {}", name, start, end);
+        }
         return Ok(());
     }
 

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -1,3 +1,4 @@
+use crate::gfaline::parse_field;
 use crate::memfile::MemchrSplit;
 use crate::pool::{FixedStore, HeapStore, Id, Pool, Span, Store};
 use atoi::FromRadix10;
@@ -127,11 +128,8 @@ impl<'a, P: StoreFamily<'a>> BEDParser<'a, P> {
     /// Parse a BED text file from an in-memory buffer.
     pub fn parse_mem(mut self, buf: &[u8]) -> BEDStore<'a, P> {
         for line in MemchrSplit::new(b'\n', buf) {
-            let first_tab_index = line.iter().position(|&x| x == b'\t').unwrap();
-            let name_slice = &line[0..first_tab_index];
-
-            let rest_of_vec = &line[first_tab_index + 1..];
-            let (start_num, rest) = parse_num(rest_of_vec).unwrap();
+            let (name_slice, rest) = parse_field(line).unwrap();
+            let (start_num, rest) = parse_num(rest).unwrap();
             let (end_num, _) = parse_num(&rest[1..]).unwrap();
 
             self.flat.add_entry(name_slice, start_num, end_num);

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -18,7 +18,7 @@ pub struct FlatBED<'a> {
     pub entries: Pool<'a, BEDEntry>,
 }
 
-impl<'a> FlatBED<'a> {
+impl FlatBED<'_> {
     /// Get the base-pair sequence for a segment.
     pub fn get_num_entries(&self) -> usize {
         self.entries.len()

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -22,6 +22,13 @@ impl<'a> FlatBED<'a> {
     pub fn get_num_entries(&self) -> usize {
         self.entries.len()
     }
+
+    pub fn get_intersects(&self, start: u64, end: u64) -> Vec<BEDEntry> {
+        self.entries.items()
+            .map(|x| x.1.clone())
+            .filter(|x| x.start <= end && x.end >= start)
+            .collect()
+    }
 }
 
 

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -6,7 +6,7 @@ use std::io::BufRead;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct BEDEntry {
     pub name: Span<u8>,
     pub start: u64,

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -1,0 +1,18 @@
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+use crate::pool::{Pool, Span};
+
+#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[repr(packed)]
+pub struct BEDEntry {
+    pub name: Span<u8>,
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[repr(packed)]
+pub struct FlatBED<'a> {
+    pub name_data: Pool<'a, u8>,
+    pub entries: Pool<'a, BEDEntry>,
+}

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -36,6 +36,9 @@ impl FlatBED<'_> {
         self.entries
             .all()
             .iter()
+            // To be compatible with bedtools, entries that partially overlap only
+            // report the overlapping portion, so we need to construct new entries
+            // here to only contain the overlap
             .map(|x| BEDEntry {
                 name: x.name,
                 start: if x.start < entry.start {

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -1,6 +1,9 @@
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
-
-use crate::pool::{Pool, Span};
+use crate::flatgfa::{self, Handle, LineKind, Orientation};
+use crate::memfile::MemchrSplit;
+use crate::namemap::NameMap;
+use std::io::BufRead;
+use crate::pool::{Pool, Span, Store, HeapStore, FixedStore, Id};
 
 #[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
 #[repr(packed)]
@@ -15,4 +18,242 @@ pub struct BEDEntry {
 pub struct FlatBED<'a> {
     pub name_data: Pool<'a, u8>,
     pub entries: Pool<'a, BEDEntry>,
+}
+
+
+
+
+
+
+
+
+
+
+
+/// The data storage pools for a `FlatBED`.
+#[derive(Default)]
+pub struct BEDStore<'a, P: StoreFamily<'a>> {
+    pub name_data: P::Store<u8>,
+    pub entries: P::Store<BEDEntry>,
+}
+
+impl<'a, P: StoreFamily<'a>> BEDStore<'a, P> {
+    pub fn add_entry(&mut self, name: &[u8], start: u64, end: u64) -> Id<BEDEntry> {
+        let name = self.name_data.add_slice(name);
+        self.entries.add(BEDEntry {
+            name,
+            start,
+            end,
+        })
+    }
+}
+
+pub trait StoreFamily<'a> {
+    type Store<T: Clone + 'a>: Store<T>;
+}
+
+#[derive(Default)]
+pub struct HeapFamily;
+impl<'a> StoreFamily<'a> for HeapFamily {
+    type Store<T: Clone + 'a> = HeapStore<T>;
+}
+
+pub struct FixedFamily;
+impl<'a> StoreFamily<'a> for FixedFamily {
+    type Store<T: Clone + 'a> = FixedStore<'a, T>;
+}
+
+/// A store for `FlatBED` data backed by fixed-size slices.
+///
+/// This store contains `SliceVec`s, which act like `Vec`s but are allocated within
+/// a fixed region. This means they have a maximum size, but they can directly map
+/// onto the contents of a file.
+pub type FixedBEDStore<'a> = BEDStore<'a, FixedFamily>;
+
+/// A mutable, in-memory data store for `FlatBED`.
+///
+/// This store contains a bunch of `Vec`s: one per array required to implement a
+/// `FlatBED`. It exposes an API for building up a BED data structure, so it is
+/// useful for creating new ones from scratch.
+pub type HeapGFAStore = BEDStore<'static, HeapFamily>;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+pub struct BEDParser<'a, P: StoreFamily<'a>> {
+    /// The flat representation we're building.
+    flat: BEDStore<'a, P>,
+
+    /// All segment IDs, indexed by their names, which we need to refer to segments in paths.
+    seg_ids: NameMap,
+}
+
+impl<'a, P: StoreFamily<'a>> BEDParser<'a, P> {
+    pub fn new(builder: BEDStore<'a, P>) -> Self {
+        Self {
+            flat: builder,
+            seg_ids: NameMap::default(),
+        }
+    }
+
+    /// Parse a GFA text file from an I/O stream.
+    pub fn parse_stream<R: BufRead>(mut self, stream: R) -> BEDStore<'a, P> {
+        // We can parse segments immediately, but we need to defer links and paths until we have all
+        // the segment names that they might refer to.
+        let mut deferred_links = Vec::new();
+        let mut deferred_paths = Vec::new();
+
+        // Parse or defer each line.
+        for line in stream.split(b'\n') {
+            let line = line.unwrap();
+
+            // Avoid parsing paths entirely for now; just preserve the entire line for later.
+            if line[0] == b'P' {
+                self.flat.record_line(LineKind::Path);
+                deferred_paths.push(line);
+                continue;
+            }
+
+            // Parse other kinds of lines.
+            let gfa_line = gfaline::parse_line(line.as_ref()).unwrap();
+            self.record_line(&gfa_line);
+
+            match gfa_line {
+                gfaline::Line::Header(data) => {
+                    self.flat.add_header(data);
+                }
+                gfaline::Line::Segment(seg) => {
+                    self.add_seg(seg);
+                }
+                gfaline::Line::Link(link) => {
+                    deferred_links.push(link);
+                }
+                gfaline::Line::Path(_) => {
+                    unreachable!("paths handled separately")
+                }
+            }
+        }
+
+        // "Unwind" the deferred links and paths.
+        for link in deferred_links {
+            self.add_link(link);
+        }
+        for line in deferred_paths {
+            if let gfaline::Line::Path(path) = gfaline::parse_line(&line).unwrap() {
+                self.add_path(path);
+            } else {
+                unreachable!("unexpected deferred line")
+            }
+        }
+
+        self.flat
+    }
+
+    /// Parse a GFA text file from an in-memory buffer.
+    pub fn parse_mem(mut self, buf: &[u8]) -> flatgfa::GFAStore<'a, P> {
+        let mut deferred_lines = Vec::new();
+
+        for line in MemchrSplit::new(b'\n', buf) {
+            // When parsing from memory, it's easy to entirely defer parsing of any line: we just keep
+            // pointers to them. So we defer both paths and links.
+            if line[0] == b'P' || line[0] == b'L' {
+                self.flat.record_line(if line[0] == b'P' {
+                    LineKind::Path
+                } else {
+                    LineKind::Link
+                });
+                deferred_lines.push(line);
+                continue;
+            }
+
+            // Actually parse other lines.
+            let gfa_line = gfaline::parse_line(line).unwrap();
+            self.record_line(&gfa_line);
+            match gfa_line {
+                gfaline::Line::Header(data) => {
+                    self.flat.add_header(data);
+                }
+                gfaline::Line::Segment(seg) => {
+                    self.add_seg(seg);
+                }
+                gfaline::Line::Link(_) | gfaline::Line::Path(_) => {
+                    unreachable!("paths and links handled separately")
+                }
+            }
+        }
+
+        // "Unwind" the deferred lines.
+        for line in deferred_lines {
+            let gfa_line = gfaline::parse_line(line).unwrap();
+            match gfa_line {
+                gfaline::Line::Link(link) => {
+                    self.add_link(link);
+                }
+                gfaline::Line::Path(path) => {
+                    self.add_path(path);
+                }
+                gfaline::Line::Header(_) | gfaline::Line::Segment(_) => {
+                    unreachable!("unexpected deferred line")
+                }
+            }
+        }
+
+        self.flat
+    }
+
+    /// Record a marker that captures the original GFA line ordering.
+    fn record_line(&mut self, line: &gfaline::Line) {
+        match line {
+            gfaline::Line::Header(_) => self.flat.record_line(LineKind::Header),
+            gfaline::Line::Segment(_) => self.flat.record_line(LineKind::Segment),
+            gfaline::Line::Link(_) => self.flat.record_line(LineKind::Link),
+            gfaline::Line::Path(_) => self.flat.record_line(LineKind::Path),
+        }
+    }
+
+    fn add_seg(&mut self, seg: gfaline::Segment) {
+        let seg_id = self.flat.add_seg(seg.name, seg.seq, seg.data);
+        self.seg_ids.insert(seg.name, seg_id);
+    }
+
+    fn add_link(&mut self, link: gfaline::Link) {
+        let from = Handle::new(self.seg_ids.get(link.from_seg), link.from_orient);
+        let to = Handle::new(self.seg_ids.get(link.to_seg), link.to_orient);
+        self.flat.add_link(from, to, link.overlap);
+    }
+
+    fn add_path(&mut self, path: gfaline::Path) {
+        // Parse the steps.
+        let mut step_parser = gfaline::StepsParser::new(&path.steps);
+        let steps = self.flat.add_steps((&mut step_parser).map(|(name, dir)| {
+            Handle::new(
+                self.seg_ids.get(name),
+                if dir {
+                    Orientation::Forward
+                } else {
+                    Orientation::Backward
+                },
+            )
+        }));
+        assert!(step_parser.rest().is_empty());
+
+        self.flat
+            .add_path(path.name, steps, path.overlaps.into_iter());
+    }
 }

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -35,7 +35,7 @@ impl FlatBED<'_> {
     pub fn get_intersects(&self, bed: &FlatBED, entry: &BEDEntry) -> Vec<BEDEntry> {
         self.entries
             .all()
-            .into_iter()
+            .iter()
             .map(|x| BEDEntry {
                 name: x.name,
                 start: if x.start < entry.start {

--- a/flatgfa/src/lib.rs
+++ b/flatgfa/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod file;
+pub mod flatbed;
 pub mod flatgfa;
 pub mod gfaline;
 pub mod memfile;
@@ -8,6 +9,5 @@ pub mod ops;
 pub mod parse;
 pub mod pool;
 pub mod print;
-pub mod flatbed;
 
 pub use flatgfa::*;

--- a/flatgfa/src/lib.rs
+++ b/flatgfa/src/lib.rs
@@ -8,5 +8,6 @@ pub mod ops;
 pub mod parse;
 pub mod pool;
 pub mod print;
+pub mod flatbed;
 
 pub use flatgfa::*;


### PR DESCRIPTION
Add an extremely basic BED parser that allows the user to intersect two 3-column BED files.

Format: `fgfa.exe bed -a file1.bed -b file2.bed`

Output should match the result of `bedtools intersect -a file1.bed -b file2.bed

Behavior is undefined on BED files with more than 3 columns for now.