### PR TITLE
Bump some Rust dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,12 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -608,19 +602,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -418,15 +418,15 @@ checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -469,9 +469,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,12 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,9 +142,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -182,16 +176,6 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "memchr"
@@ -255,29 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,16 +264,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
  "inventory",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -322,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -332,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -342,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -354,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -395,15 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,12 +372,6 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -448,12 +394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
-
-[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tinyvec"
@@ -526,70 +466,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/flatgfa-py/Cargo.toml
+++ b/flatgfa-py/Cargo.toml
@@ -8,6 +8,6 @@ name = "flatgfa"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21.2", features = ["abi3-py38", "multiple-pymethods"] }
+pyo3 = { version = "0.24.2", features = ["abi3-py38", "multiple-pymethods"] }
 flatgfa = { path = "../flatgfa" }
 memmap = "0.7.0"

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -737,10 +737,7 @@ impl PyHandle {
 /// Get the components of a Python slice object.
 ///
 /// This wraps an underlying PyO3 utility but supports a `usize` length.
-fn py_slice_indices<'py>(
-    slice: Bound<'py, PySlice>,
-    len: u32,
-) -> PyResult<pyo3::types::PySliceIndices> {
+fn py_slice_indices(slice: Bound<'_, PySlice>, len: u32) -> PyResult<pyo3::types::PySliceIndices> {
     // Depending on the size of a C `long`, this may or may not need a fallible
     // conversion. This is a workaround to avoid either errors or Clippy
     // warnings, depending on the platform.

--- a/flatgfa-py/src/lib.rs
+++ b/flatgfa-py/src/lib.rs
@@ -254,8 +254,8 @@ impl EntityRef {
 /// Stolen from this GitHub discussion:
 /// https://github.com/PyO3/pyo3/issues/1855#issuecomment-962573796
 #[derive(FromPyObject)]
-enum SliceOrInt<'a> {
-    Slice(&'a PySlice),
+enum SliceOrInt<'py> {
+    Slice(Bound<'py, PySlice>),
     Int(isize),
 }
 
@@ -724,7 +724,10 @@ impl PyHandle {
 /// Get the components of a Python slice object.
 ///
 /// This wraps an underlying PyO3 utility but supports a `usize` length.
-fn py_slice_indices(slice: &PySlice, len: u32) -> PyResult<pyo3::types::PySliceIndices> {
+fn py_slice_indices<'py>(
+    slice: Bound<'py, PySlice>,
+    len: u32,
+) -> PyResult<pyo3::types::PySliceIndices> {
     // Depending on the size of a C `long`, this may or may not need a fallible
     // conversion. This is a workaround to avoid either errors or Clippy
     // warnings, depending on the platform.

--- a/flatgfa/Cargo.toml
+++ b/flatgfa/Cargo.toml
@@ -8,13 +8,13 @@ name = "fgfa"
 path = "src/cli/main.rs"
 
 [dependencies]
-argh = "0.1.12"
+argh = "0.1.13"
 atoi = "2.0.0"
 bit-vec = "0.8.0"
-bstr = "1.10.0"
+bstr = "1.12.0"
 memchr = "2.7.4"
 memmap = "0.7.0"
 num_enum = "0.7.3"
 rayon = "1.10.0"
-tinyvec = "1.8.0"
-zerocopy = { version = "0.7.35", features = ["derive"] }
+tinyvec = "1.9.0"
+zerocopy = { version = "0.8.25", features = ["derive"] }

--- a/flatgfa/src/file.rs
+++ b/flatgfa/src/file.rs
@@ -4,12 +4,12 @@ use crate::flatgfa;
 use crate::pool::{FixedStore, Pool, Span, Store};
 use std::mem::{size_of, size_of_val};
 use tinyvec::SliceVec;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 const MAGIC_NUMBER: u64 = 0xB101_1054;
 
 /// A table of contents for the FlatGFA file.
-#[derive(FromBytes, FromZeroes, AsBytes, Debug)]
+#[derive(FromBytes, IntoBytes, Debug, Immutable, KnownLayout)]
 #[repr(packed)]
 pub struct Toc {
     magic: u64,
@@ -27,7 +27,7 @@ pub struct Toc {
 }
 
 /// A table-of-contents entry for a pool in the FlatGFA file.
-#[derive(FromBytes, FromZeroes, AsBytes, Clone, Copy, Debug)]
+#[derive(FromBytes, IntoBytes, Clone, Copy, Debug, Immutable)]
 #[repr(packed)]
 struct Size {
     /// The number of actual elements in the pool.
@@ -160,7 +160,7 @@ impl Toc {
 
 /// Consume `size.len` items from a byte slice, skip the remainder of `size.capacity`
 /// elements, and return the items and the rest of the slice.
-fn slice_prefix<T: FromBytes>(data: &[u8], size: Size) -> (&[T], &[u8]) {
+fn slice_prefix<T: FromBytes + Immutable>(data: &[u8], size: Size) -> (&[T], &[u8]) {
     let (prefix, rest) = T::slice_from_prefix(data, size.len).unwrap();
     let pad = size_of::<T>() * (size.capacity - size.len);
     (prefix, &rest[pad..])
@@ -168,8 +168,7 @@ fn slice_prefix<T: FromBytes>(data: &[u8], size: Size) -> (&[T], &[u8]) {
 
 /// Read the table of contents from a prefix of the byte buffer.
 fn read_toc(data: &[u8]) -> (&Toc, &[u8]) {
-    let toc = Toc::ref_from_prefix(data).unwrap();
-    let rest = &data[size_of::<Toc>()..];
+    let (toc, rest) = Toc::ref_from_prefix(data).unwrap();
     let magic = toc.magic;
     assert_eq!(magic, MAGIC_NUMBER);
     (toc, rest)
@@ -215,7 +214,7 @@ pub fn view(data: &[u8]) -> flatgfa::FlatGFA {
 }
 
 /// Like `slice_prefix`, but produce a `SliceVec`.
-fn slice_vec_prefix<T: FromBytes + AsBytes>(
+fn slice_vec_prefix<T: FromBytes + IntoBytes>(
     data: &mut [u8],
     size: Size,
 ) -> (SliceVec<T>, &mut [u8]) {
@@ -273,10 +272,13 @@ pub fn init(data: &mut [u8], toc: Toc) -> (&mut Toc, flatgfa::FixedGFAStore) {
     (toc_mut, slice_store(rest, &toc))
 }
 
-fn write_bump<'a, T: AsBytes + ?Sized>(buf: &'a mut [u8], data: &T) -> Option<&'a mut [u8]> {
+fn write_bump<'a, T: IntoBytes + Immutable + ?Sized>(
+    buf: &'a mut [u8],
+    data: &'a T,
+) -> Result<&'a mut [u8], zerocopy::SizeError<&'a T, &'a mut [u8]>> {
     let len = size_of_val(data);
     data.write_to_prefix(buf)?;
-    Some(&mut buf[len..])
+    Ok(&mut buf[len..])
 }
 
 fn write_bytes<'a>(buf: &'a mut [u8], data: &[u8]) -> Option<&'a mut [u8]> {

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -3,10 +3,10 @@ use crate::memfile::MemchrSplit;
 use crate::pool::{FixedStore, HeapStore, Id, Pool, Span, Store};
 use atoi::FromRadix10;
 use bstr::BStr;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, IntoBytes};
 
 /// A single interval from a BED file.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[derive(Debug, FromBytes, IntoBytes, Clone, Copy)]
 #[repr(C, packed)]
 pub struct BEDEntry {
     pub name: Span<u8>,

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use crate::pool::{self, Id, Pool, Span, Store};
 use bstr::BStr;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// An efficient flattened representation of a GFA file.
 ///
@@ -68,7 +68,7 @@ pub struct FlatGFA<'a> {
 
 /// GFA graphs consist of "segment" nodes, which are fragments of base-pair sequences
 /// that can be strung together into paths.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[derive(Debug, FromBytes, IntoBytes, Clone, Copy, Immutable)]
 #[repr(packed)]
 pub struct Segment {
     /// The segment's name. We assume all names are just plain numbers.
@@ -89,7 +89,7 @@ impl Segment {
 }
 
 /// A path is a sequence of oriented references to segments.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[derive(Debug, FromBytes, IntoBytes, Clone, Copy, Immutable)]
 #[repr(packed)]
 pub struct Path {
     /// The path's name. This can be an arbitrary string. It is a range in the
@@ -111,7 +111,7 @@ impl Path {
 }
 
 /// An allowed edge between two oriented segments.
-#[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy)]
+#[derive(Debug, FromBytes, IntoBytes, Clone, Copy, Immutable)]
 #[repr(packed)]
 pub struct Link {
     /// The source of the edge.
@@ -165,7 +165,7 @@ impl FromStr for Orientation {
 /// A Handle refers to the forward (+) or backward (-) orientation for a given segment.
 /// So, logically, it consists of a pair of a segment reference (usize) and an
 /// orientation (1 bit). We pack the two values into a single word.
-#[derive(Debug, FromBytes, FromZeroes, AsBytes, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, FromBytes, IntoBytes, Clone, Copy, PartialEq, Eq, Hash, Immutable)]
 #[repr(packed)]
 pub struct Handle(u32);
 
@@ -204,7 +204,7 @@ pub enum AlignOpcode {
 ///
 /// Logically, this is a pair of a number and an `AlignOpcode`. We pack the two
 /// into a single u32.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[derive(Debug, FromBytes, IntoBytes, Clone, Copy, Immutable)]
 #[repr(packed)]
 pub struct AlignOp(u32);
 

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -3,10 +3,10 @@
 use std::ops::{Add, Index, Sub};
 use std::{hash::Hash, marker::PhantomData};
 use tinyvec::SliceVec;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// An index into a pool.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy)]
+#[derive(Debug, Immutable, FromBytes, IntoBytes, Clone, Copy)]
 #[repr(transparent)]
 pub struct Id<T>(u32, PhantomData<T>);
 
@@ -69,7 +69,7 @@ impl<T> From<Id<T>> for u32 {
 ///
 /// TODO: Consider smaller indices for this, and possibly base/offset instead
 /// of start/end.
-#[derive(Debug, FromZeroes, FromBytes, AsBytes, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Immutable, FromBytes, IntoBytes, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(packed)]
 pub struct Span<T> {
     pub start: Id<T>,


### PR DESCRIPTION
I updated several dependent crates. The only interesting stuff here was some API churn and deprecation in both PyO3 and zerocopy, both of which required some tricky fiddling to get right. But it feels good to be on the latest version!