### PR TITLE
Add some convenience utilities re. Orientation and Handle

### DIFF
--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -88,6 +88,13 @@ impl Segment {
     }
 }
 
+impl Id<Segment> {
+    /// A convenient way to construct a handle for a segment.
+    pub fn handle(self, orient: Orientation) -> Handle {
+        Handle::new(self, orient)
+    }
+}
+
 /// A path is a sequence of oriented references to segments.
 #[derive(Debug, FromBytes, IntoBytes, Clone, Copy, Immutable)]
 #[repr(packed)]

--- a/flatgfa/src/flatgfa.rs
+++ b/flatgfa/src/flatgfa.rs
@@ -167,6 +167,17 @@ impl FromStr for Orientation {
     }
 }
 
+impl From<bool> for Orientation {
+    /// Convert a `bool` indicating forwardness to an `Orientation`.
+    fn from(fwd: bool) -> Self {
+        if fwd {
+            Orientation::Forward
+        } else {
+            Orientation::Backward
+        }
+    }
+}
+
 /// An oriented reference to a segment.
 ///
 /// A Handle refers to the forward (+) or backward (-) orientation for a given segment.

--- a/flatgfa/src/ops/chop.rs
+++ b/flatgfa/src/ops/chop.rs
@@ -118,7 +118,7 @@ pub fn chop(gfa: &flatgfa::FlatGFA, max_size: usize, incl_links: bool) -> flatgf
                     Orientation::Forward => chopped_segs.end - 1,
                     Orientation::Backward => chopped_segs.start,
                 };
-                Handle::new(seg_id, old_from.orient())
+                seg_id.handle(old_from.orient())
             };
             let new_to = {
                 let old_to = link.to;
@@ -127,7 +127,7 @@ pub fn chop(gfa: &flatgfa::FlatGFA, max_size: usize, incl_links: bool) -> flatgf
                     Orientation::Forward => chopped_segs.start,
                     Orientation::Backward => chopped_segs.end - 1,
                 };
-                Handle::new(seg_id, old_to.orient())
+                seg_id.handle(old_to.orient())
             };
             flat.add_link(new_from, new_to, vec![]);
         }

--- a/flatgfa/src/ops/extract.rs
+++ b/flatgfa/src/ops/extract.rs
@@ -136,7 +136,7 @@ impl<'a> SubgraphBuilder<'a> {
     /// Translate a handle from the source graph to this subgraph.
     fn tr_handle(&self, old_handle: flatgfa::Handle) -> flatgfa::Handle {
         // TODO: is this just generating the handle or should we add it to the new graph?
-        flatgfa::Handle::new(self.seg_map[&old_handle.segment()], old_handle.orient())
+        self.seg_map[&old_handle.segment()].handle(old_handle.orient())
     }
 
     /// Check whether a segment from the old graph is in the subgraph.

--- a/flatgfa/src/ops/gaf.rs
+++ b/flatgfa/src/ops/gaf.rs
@@ -205,10 +205,7 @@ impl Iterator for PathChunker<'_, '_> {
 
         // Get the corresponding handle from the GFA.
         let seg_id = self.name_map.get(seg_name);
-        let handle = seg_id.handle(match forward {
-            true => flatgfa::Orientation::Forward,
-            false => flatgfa::Orientation::Backward,
-        });
+        let handle = seg_id.handle(forward.into());
 
         // Accumulate the length to track our position in the path.
         let seg_len = self.gfa.segs[seg_id].len();

--- a/flatgfa/src/ops/gaf.rs
+++ b/flatgfa/src/ops/gaf.rs
@@ -205,11 +205,10 @@ impl Iterator for PathChunker<'_, '_> {
 
         // Get the corresponding handle from the GFA.
         let seg_id = self.name_map.get(seg_name);
-        let dir = match forward {
+        let handle = seg_id.handle(match forward {
             true => flatgfa::Orientation::Forward,
             false => flatgfa::Orientation::Backward,
-        };
-        let handle = flatgfa::Handle::new(seg_id, dir);
+        });
 
         // Accumulate the length to track our position in the path.
         let seg_len = self.gfa.segs[seg_id].len();

--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::flatgfa::{self, LineKind, Orientation};
+use crate::flatgfa::{self, LineKind};
 use crate::gfaline;
 use crate::memfile::MemchrSplit;
 use crate::namemap::NameMap;
@@ -149,13 +149,9 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
     fn add_path(&mut self, path: gfaline::Path) {
         // Parse the steps.
         let mut step_parser = gfaline::StepsParser::new(path.steps);
-        let steps = self.flat.add_steps((&mut step_parser).map(|(name, dir)| {
-            self.seg_ids.get(name).handle(if dir {
-                Orientation::Forward
-            } else {
-                Orientation::Backward
-            })
-        }));
+        let steps = self.flat.add_steps(
+            (&mut step_parser).map(|(name, dir)| self.seg_ids.get(name).handle(dir.into())),
+        );
         assert!(step_parser.rest().is_empty());
 
         self.flat

--- a/flatgfa/src/parse.rs
+++ b/flatgfa/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::flatgfa::{self, Handle, LineKind, Orientation};
+use crate::flatgfa::{self, LineKind, Orientation};
 use crate::gfaline;
 use crate::memfile::MemchrSplit;
 use crate::namemap::NameMap;
@@ -141,8 +141,8 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
     }
 
     fn add_link(&mut self, link: gfaline::Link) {
-        let from = Handle::new(self.seg_ids.get(link.from_seg), link.from_orient);
-        let to = Handle::new(self.seg_ids.get(link.to_seg), link.to_orient);
+        let from = self.seg_ids.get(link.from_seg).handle(link.from_orient);
+        let to = self.seg_ids.get(link.to_seg).handle(link.to_orient);
         self.flat.add_link(from, to, link.overlap);
     }
 
@@ -150,14 +150,11 @@ impl<'a, P: flatgfa::StoreFamily<'a>> Parser<'a, P> {
         // Parse the steps.
         let mut step_parser = gfaline::StepsParser::new(path.steps);
         let steps = self.flat.add_steps((&mut step_parser).map(|(name, dir)| {
-            Handle::new(
-                self.seg_ids.get(name),
-                if dir {
-                    Orientation::Forward
-                } else {
-                    Orientation::Backward
-                },
-            )
+            self.seg_ids.get(name).handle(if dir {
+                Orientation::Forward
+            } else {
+                Orientation::Backward
+            })
         }));
         assert!(step_parser.rest().is_empty());
 


### PR DESCRIPTION
I noticed a while back that it would be useful sometimes to do `seg_id.handle(ori)` to construct a handle, as a shorthand for `Handle::new(seg_id, ori)`. I know it's a small thing, but it makes me happy!

As a bonus, `b.into()` now works to convert a boolean `b` indicating "forwardness" into our `Orientation` enum.