### PR TITLE
Some refinements to PackedSeqVec and its tests

### DIFF
--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -338,7 +338,7 @@ pub fn seq_export(args: SeqExport) {
         .map(|c| packedseq::Nucleotide::from(c))
         .collect();
 
-    let store = packedseq::PackedSeqStore::create(vec);
+    let store = packedseq::PackedSeqStore::create(&vec);
     let view = store.as_ref();
     packedseq::export(view, &args.filename);
 }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -2,7 +2,7 @@ use crate::flatgfa::{self, Segment};
 use crate::memfile::{self, map_file};
 use crate::namemap::NameMap;
 use crate::ops;
-use crate::packedseq::{self, PackedSeqStore, PackedSeqView};
+use crate::packedseq::{self, PackedSeqView};
 use crate::pool::Id;
 use argh::FromArgs;
 use rayon::iter::ParallelIterator;

--- a/flatgfa/src/packedseq.rs
+++ b/flatgfa/src/packedseq.rs
@@ -472,6 +472,8 @@ mod tests {
         }
     }
 
+    /// Test conversion to and from a byte buffer (which we use to read and
+    /// write files).
     #[test]
     fn test_bytes_export_import() {
         let len = 10;

--- a/flatgfa/src/packedseq.rs
+++ b/flatgfa/src/packedseq.rs
@@ -445,20 +445,28 @@ mod tests {
         assert_eq!(vec.as_ref().get(1), Nucleotide::G);
     }
 
+    /// Test the `get_elements` method that decompresses data to a
+    /// `Vec<Nucleotide>` "in bulk."
     #[test]
-    fn test_export_import() {
+    fn test_get_elements() {
         let len = 10;
         let num_trials = 10;
         let mut rng = rand::thread_rng();
+
         for _ in 0..num_trials {
+            // Create a random (uncompressed) nucleotide sequence.
             let mut vec: Vec<Nucleotide> = Vec::new();
             for _ in 0..len {
                 let rand_num = rng.gen_range(0..=3);
                 vec.push(Nucleotide::from(rand_num));
             }
+
+            // "Round trip" through a compressed representation, producing a new
+            // decompressed vector.
             let store = PackedSeqStore::create(&vec);
             let view = store.as_ref();
             let new_vec = view.get_elements();
+
             assert_eq!(vec, new_vec);
         }
     }

--- a/flatgfa/src/packedseq.rs
+++ b/flatgfa/src/packedseq.rs
@@ -336,7 +336,7 @@ pub fn export(seq: PackedSeqView, filename: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{thread_rng, Rng};
+    use rand::{rngs::ThreadRng, thread_rng, Rng};
 
     #[test]
     fn test_vec() {
@@ -445,27 +445,31 @@ mod tests {
         assert_eq!(vec.as_ref().get(1), Nucleotide::G);
     }
 
+    /// Randomly generate an uncompressed nucleotide sequence.
+    fn random_seq(rng: &mut ThreadRng, len: usize) -> Vec<Nucleotide> {
+        let mut vec: Vec<Nucleotide> = Vec::new();
+        for _ in 0..len {
+            let rand_num = rng.gen_range(0..=3);
+            vec.push(Nucleotide::from(rand_num));
+        }
+        vec
+    }
+
     /// Test the `get_elements` method that decompresses data to a
     /// `Vec<Nucleotide>` "in bulk."
     #[test]
     fn test_get_elements() {
         let len = 10;
         let num_trials = 10;
-        let mut rng = rand::thread_rng();
+        let mut rng = thread_rng();
 
         for _ in 0..num_trials {
-            // Create a random (uncompressed) nucleotide sequence.
-            let mut vec: Vec<Nucleotide> = Vec::new();
-            for _ in 0..len {
-                let rand_num = rng.gen_range(0..=3);
-                vec.push(Nucleotide::from(rand_num));
-            }
+            let vec = random_seq(&mut rng, len);
 
             // "Round trip" through a compressed representation, producing a new
             // decompressed vector.
             let store = PackedSeqStore::create(&vec);
-            let view = store.as_ref();
-            let new_vec = view.get_elements();
+            let new_vec = store.as_ref().get_elements();
 
             assert_eq!(vec, new_vec);
         }
@@ -478,14 +482,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         for _ in 0..num_trials {
-            // Create a random (uncompressed) nucleotide sequence.
-            let mut vec: Vec<Nucleotide> = Vec::new();
-            for _ in 0..len {
-                let rand_num = rng.gen_range(0..=3);
-                vec.push(Nucleotide::from(rand_num));
-            }
-
-            // Compress it.
+            let vec = random_seq(&mut rng, len);
             let store = PackedSeqStore::create(&vec);
 
             // Copy the compressed representation to a byte buffer.

--- a/flatgfa/src/packedseq.rs
+++ b/flatgfa/src/packedseq.rs
@@ -1,11 +1,5 @@
 use crate::file::*;
-use crate::flatgfa;
-use crate::memfile;
 use crate::memfile::map_new_file;
-use crate::pool::*;
-use crate::FixedFamily;
-use crate::HeapFamily;
-use crate::StoreFamily;
 use std::fmt;
 
 use zerocopy::*;

--- a/flatgfa/src/packedseq.rs
+++ b/flatgfa/src/packedseq.rs
@@ -447,12 +447,9 @@ mod tests {
 
     /// Randomly generate an uncompressed nucleotide sequence.
     fn random_seq(rng: &mut ThreadRng, len: usize) -> Vec<Nucleotide> {
-        let mut vec: Vec<Nucleotide> = Vec::new();
-        for _ in 0..len {
-            let rand_num = rng.gen_range(0..=3);
-            vec.push(Nucleotide::from(rand_num));
-        }
-        vec
+        (0..len)
+            .map(|_| Nucleotide::from(rng.gen_range(0..=3)))
+            .collect()
     }
 
     /// Test the `get_elements` method that decompresses data to a

--- a/flatgfa/src/packedseq.rs
+++ b/flatgfa/src/packedseq.rs
@@ -256,10 +256,10 @@ impl PackedSeqStore {
     }
 
     /// Returns a compressed PackedSeqStore given an uncompressed vector `arr`
-    pub fn create(arr: Vec<Nucleotide>) -> Self {
+    pub fn create(arr: &[Nucleotide]) -> Self {
         let mut new_vec = PackedSeqStore::new();
         for item in arr {
-            new_vec.push(item);
+            new_vec.push(*item);
         }
         new_vec
     }
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn test_vec() {
-        let mut vec = PackedSeqStore::create(vec![
+        let mut vec = PackedSeqStore::create(&[
             Nucleotide::A,
             Nucleotide::C,
             Nucleotide::G,
@@ -359,12 +359,8 @@ mod tests {
 
     #[test]
     fn test_vec_push() {
-        let mut vec = PackedSeqStore::create(vec![
-            Nucleotide::A,
-            Nucleotide::C,
-            Nucleotide::G,
-            Nucleotide::T,
-        ]);
+        let mut vec =
+            PackedSeqStore::create(&[Nucleotide::A, Nucleotide::C, Nucleotide::G, Nucleotide::T]);
         vec.push(Nucleotide::A);
         vec.push(Nucleotide::C);
         vec.push(Nucleotide::G);
@@ -383,7 +379,7 @@ mod tests {
     #[test]
     fn test_slice() {
         let span = 1..4;
-        let vec = PackedSeqStore::create(vec![
+        let vec = PackedSeqStore::create(&[
             Nucleotide::A,
             Nucleotide::C,
             Nucleotide::G,
@@ -401,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_display_even() {
-        let vec = PackedSeqStore::create(vec![
+        let vec = PackedSeqStore::create(&[
             Nucleotide::C,
             Nucleotide::A,
             Nucleotide::T,
@@ -414,13 +410,13 @@ mod tests {
 
     #[test]
     fn test_display_single() {
-        let vec = PackedSeqStore::create(vec![Nucleotide::T.into()]);
+        let vec = PackedSeqStore::create(&[Nucleotide::T.into()]);
         assert_eq!("[T]", vec.as_ref().to_string());
     }
 
     #[test]
     fn test_display_odd() {
-        let vec = PackedSeqStore::create(vec![
+        let vec = PackedSeqStore::create(&[
             Nucleotide::C,
             Nucleotide::A,
             Nucleotide::T,
@@ -434,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_getter_setter() {
-        let mut vec = PackedSeqStore::create(vec![
+        let mut vec = PackedSeqStore::create(&[
             Nucleotide::A,
             Nucleotide::A,
             Nucleotide::T,
@@ -460,11 +456,10 @@ mod tests {
                 let rand_num = rng.gen_range(0..=3);
                 vec.push(Nucleotide::from(rand_num));
             }
-            let old_vec = vec.clone();
-            let store = PackedSeqStore::create(vec);
+            let store = PackedSeqStore::create(&vec);
             let view = store.as_ref();
             let new_vec = view.get_elements();
-            assert_eq!(old_vec, new_vec);
+            assert_eq!(vec, new_vec);
         }
     }
 }

--- a/flatgfa/src/packedseq.rs
+++ b/flatgfa/src/packedseq.rs
@@ -470,4 +470,34 @@ mod tests {
             assert_eq!(vec, new_vec);
         }
     }
+
+    #[test]
+    fn test_bytes_export_import() {
+        let len = 10;
+        let num_trials = 10;
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..num_trials {
+            // Create a random (uncompressed) nucleotide sequence.
+            let mut vec: Vec<Nucleotide> = Vec::new();
+            for _ in 0..len {
+                let rand_num = rng.gen_range(0..=3);
+                vec.push(Nucleotide::from(rand_num));
+            }
+
+            // Compress it.
+            let store = PackedSeqStore::create(&vec);
+
+            // Copy the compressed representation to a byte buffer.
+            let seq = store.as_ref();
+            let num_bytes = seq.file_size();
+            let mut mem = vec![0u8; num_bytes];
+            seq.write_file(&mut mem);
+
+            // "Reawaken" a sequence from this byte buffer.
+            let new_seq = PackedSeqView::read_file(&mem);
+
+            assert_eq!(vec, new_seq.get_elements());
+        }
+    }
 }


### PR DESCRIPTION
This PR does two main things:

* Resolve some API discomfort by making `PackedSeqVec::create` (which initializes a `PackedSeqVec` from a plain old `Vec<Nucleotide>`) borrow its argument instead of taking ownership.
* Add a new test for reading and writing raw bytes. This is meant to test *everything but* actually accessing the file system, avoiding the annoyance of creating and deleting temporary files but still testing the conversion to/from a file-like bag of bytes.

Please see the commit messages within for some additional details about the Rusty justifications.