### PR TITLE
cpp compatibility for header

### DIFF
--- a/flatgfa-c/build.rs
+++ b/flatgfa-c/build.rs
@@ -6,6 +6,7 @@ fn main() {
     cbindgen::Builder::new()
         .with_crate(crate_dir)
         .with_language(cbindgen::Language::C)
+        .with_cpp_compat(true)
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file("include/flatgfa.h");


### PR DESCRIPTION
@sampsyo we probably want cbindgen automatically add #ifdef __cplusplus / extern "C" guards. 

With this we should be able to just use it from both C and CPP.