### PR TITLE
Path depth

### DIFF
--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -14,7 +14,7 @@ You can run normal shell commands, which really do run subprocesses:
 $ flash -c 'cat example.sh'
 #!/usr/bin/env ../target/debug/flash
 odgi depth -d -i ../tests/note5.gfa
-odgi depth -d -i ../tests/overlap.gfa
+odgi depth -i ../tests/note5.gfa
 
 $ flash -c 'head -n1 < README.md'
 The FlatGFA Fake Shell
@@ -42,17 +42,9 @@ $ flash example.sh
 2	0	0
 3	2	2
 4	2	2
-#node.id	depth	depth.uniq
-1	1	1
-2	2	2
-3	1	1
-4	1	1
-5	2	2
-6	4	3
-7	1	1
-8	2	2
-9	2	2
-10	1	1
+#path	start	end	mean.depth
+5	0	13	2
+5-	0	13	2
 
 ```
 
@@ -65,15 +57,18 @@ Here are some things that we currently parse (not all of which are implemented i
 
 ```console
 $ flash -p -c 'odgi depth'
-depth(stdin) -> stdout
+path_depth(stdin) -> stdout
+
+$ flash -p -c 'odgi depth -d'
+node_depth(stdin) -> stdout
 
 $ flash -p -c 'odgi depth -i chr8.gfa'
-depth("chr8.gfa") -> stdout
+path_depth("chr8.gfa") -> stdout
 
 $ flash -p -c 'odgi depth -i chr8.gfa -r "chm13#chr8"'
-depth("chr8.gfa", path="chm13#chr8") -> stdout
+path_depth("chr8.gfa", path="chm13#chr8") -> stdout
 
 $ flash -p -c 'odgi depth < chr8.gfa > depth.tsv'
-depth("chr8.gfa") -> "depth.tsv"
+path_depth("chr8.gfa") -> "depth.tsv"
 
 ```

--- a/flatgfa-sh/example.sh
+++ b/flatgfa-sh/example.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env ../target/debug/flash
 odgi depth -d -i ../tests/note5.gfa
-odgi depth -d -i ../tests/overlap.gfa
+odgi depth -i ../tests/note5.gfa

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -12,7 +12,8 @@ trait Eval {
 impl Eval for ir::Instr {
     fn eval(&self, env: &Env) {
         match self {
-            Self::Depth(instr) => instr.eval(env),
+            Self::NodeDepth(instr) => instr.eval(env),
+            Self::PathDepth(instr) => instr.eval(env),
             Self::Exec(instr) => instr.eval(env),
         }
     }
@@ -34,20 +35,30 @@ fn parse_gfa(rsrc: &ir::Resource) -> HeapGFAStore {
     }
 }
 
-impl Eval for ir::DepthInstr {
+impl Eval for ir::NodeDepthInstr {
     fn eval(&self, env: &Env) {
         let store = parse_gfa(&env.rsrc[self.input.0]);
         let gfa = store.as_ref();
         // TODO Do something about the output resource...
-        match self.mode {
-            ir::DepthOutputMode::NodeTable => {
-                let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
-                ops::depth::print_seg_depth(&gfa, depths, uniq_depths);
-            }
-            ir::DepthOutputMode::PathTable => {
-                let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
-                ops::depth::print_seg_depth(&gfa, depths, uniq_depths);
-            }
+        let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
+        ops::depth::print_seg_depth(&gfa, depths, uniq_depths);
+    }
+}
+
+impl Eval for ir::PathDepthInstr {
+    fn eval(&self, env: &Env) {
+        let store = parse_gfa(&env.rsrc[self.input.0]);
+        let gfa = store.as_ref();
+        if let Some(path_name) = &self.path {
+            // TODO More elegantly handle missing paths.
+            let path_id = gfa
+                .find_path(path_name.as_bytes().into())
+                .expect("no such path found");
+            let (depths, uniq_depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
+            ops::depth::print_path_depth(&gfa, depths, uniq_depths, std::iter::once(path_id));
+        } else {
+            let (depths, uniq_depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
+            ops::depth::print_path_depth(&gfa, depths, uniq_depths, gfa.paths.ids());
         }
     }
 }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,5 +1,5 @@
 use crate::ir;
-use flatgfa::{self, cli, flatgfa::HeapGFAStore, memfile};
+use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops};
 
 struct Env {
     rsrc: Vec<ir::Resource>,
@@ -40,8 +40,14 @@ impl Eval for ir::DepthInstr {
         let gfa = store.as_ref();
         // TODO Do something about the output resource...
         match self.mode {
-            ir::DepthOutputMode::NodeTable => cli::cmds::depth(&gfa),
-            _ => unimplemented!("only node depth is supported"),
+            ir::DepthOutputMode::NodeTable => {
+                let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
+                ops::depth::print_seg_depth(&gfa, depths, uniq_depths);
+            }
+            ir::DepthOutputMode::PathTable => {
+                let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
+                ops::depth::print_seg_depth(&gfa, depths, uniq_depths);
+            }
         }
     }
 }

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -8,17 +8,16 @@ pub enum Resource {
 }
 
 #[derive(Debug)]
-pub enum DepthOutputMode {
-    PathTable,
-    NodeTable,
+pub struct NodeDepthInstr {
+    pub input: ResourceRef,
+    pub output: ResourceRef,
 }
 
 #[derive(Debug)]
-pub struct DepthInstr {
+pub struct PathDepthInstr {
     pub input: ResourceRef,
     pub output: ResourceRef,
     pub path: Option<String>,
-    pub mode: DepthOutputMode,
 }
 
 /// An instruction that just runs an external shell command.
@@ -32,7 +31,8 @@ pub struct ExecInstr {
 
 #[derive(Debug)]
 pub enum Instr {
-    Depth(DepthInstr),
+    NodeDepth(NodeDepthInstr),
+    PathDepth(PathDepthInstr),
     Exec(ExecInstr),
 }
 

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -36,18 +36,17 @@ fn cmd_to_ir(builder: &mut Builder, name: String, args: Vec<String>, redirects: 
                 // In the `odgi depth` command line, the default is a per-path
                 // table, and `-d` switches to a per-node table. (There are
                 // other modes, such as `-D`, to support...)
-                let mode = if argp.contains("-d") {
-                    ir::DepthOutputMode::NodeTable
+                let instr = if argp.contains("-d") {
+                    ir::Instr::NodeDepth(ir::NodeDepthInstr { input, output })
                 } else {
-                    ir::DepthOutputMode::PathTable
+                    ir::Instr::PathDepth(ir::PathDepthInstr {
+                        input,
+                        output,
+                        path: argp.opt_value_from_str("-r").unwrap(),
+                    })
                 };
 
-                builder.add_instr(ir::Instr::Depth(ir::DepthInstr {
-                    input,
-                    output,
-                    path: argp.opt_value_from_str("-r").unwrap(),
-                    mode,
-                }));
+                builder.add_instr(instr);
             }
             _ => unimplemented!("unsupported odgi subcommand"),
         }

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -13,7 +13,8 @@ trait Print {
 impl Print for ir::Instr {
     fn print(&self, ctx: &Context, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Depth(instr) => instr.print(ctx, f),
+            Self::NodeDepth(instr) => instr.print(ctx, f),
+            Self::PathDepth(instr) => instr.print(ctx, f),
             Self::Exec(instr) => instr.print(ctx, f),
         }
     }
@@ -26,9 +27,19 @@ impl Print for ir::ResourceRef {
     }
 }
 
-impl Print for ir::DepthInstr {
+impl Print for ir::NodeDepthInstr {
     fn print(&self, ctx: &Context, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "depth(")?;
+        write!(f, "node_depth(")?;
+        self.input.print(ctx, f)?;
+        write!(f, ") -> ")?;
+        self.output.print(ctx, f)?;
+        writeln!(f)
+    }
+}
+
+impl Print for ir::PathDepthInstr {
+    fn print(&self, ctx: &Context, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "path_depth(")?;
         self.input.print(ctx, f)?;
         if let Some(path) = &self.path {
             write!(f, ", path=\"{}\"", path)?;

--- a/flatgfa/examples/window_depth.rs
+++ b/flatgfa/examples/window_depth.rs
@@ -91,7 +91,7 @@ fn create_bed(
     let max_line = 40;
     let mut bed_file = memfile::map_new_file(bed_name, (num_windows * max_line) as u64);
     let mut offset = 0;
-    let depth = depth::depth(&flatgfa).0;
+    let depth = depth::seg_depth(&flatgfa).0;
     let mut windows = window_vec;
     if windows == Vec::new() {
         windows = compute_windows(path_len, window_size);

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -233,13 +233,22 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
         ops::depth::print_seg_depth(gfa, depths, uniq_depths);
     } else {
         // Path depth table.
-        let path_ids: Vec<_> = args
-            .path
-            .into_iter()
-            .filter_map(|n| gfa.find_path(n.as_ref()))
-            .collect();
-        let (lengths, depths) = ops::depth::path_depth(gfa);
-        ops::depth::print_path_depth(gfa, lengths, depths);
+        if args.path.is_empty() {
+            // All paths.
+            let (lengths, depths) = ops::depth::path_depth(gfa, gfa.paths.ids());
+            ops::depth::print_path_depth(gfa, lengths, depths);
+        } else {
+            // A subset of paths.
+            let path_ids = ops::depth::SparseSubset::new(
+                args.path
+                    .into_iter()
+                    .filter_map(|n| gfa.find_path(n.as_ref()))
+                    .collect(),
+            );
+            let (lengths, depths) = ops::depth::path_depth(gfa, path_ids);
+            dbg!(lengths, depths);
+            todo!();
+        }
     }
 }
 

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -225,29 +225,12 @@ pub struct Depth {
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
     if args.seg_depth {
         // Segment depth table.
-        let (depths, uniq_paths) = ops::depth::seg_depth(gfa);
-        println!("#node.id\tdepth\tdepth.uniq");
-        for (id, seg) in gfa.segs.items() {
-            let name: u32 = seg.name as u32;
-            println!(
-                "{}\t{}\t{}",
-                name,
-                depths[id.index()],
-                uniq_paths[id.index()],
-            );
-        }
+        let (depths, uniq_depths) = ops::depth::seg_depth(gfa);
+        ops::depth::print_seg_depth(gfa, depths, uniq_depths);
     } else {
         // Path depth table.
         let (lengths, depths) = ops::depth::path_depth(gfa);
-        println!("#path\tstart\tend\tmean.depth");
-        for (id, path) in gfa.paths.items() {
-            println!(
-                "{}\t0\t{}\t{}",
-                gfa.get_path_name(path),
-                lengths[id.index()],
-                depths[id.index()],
-            );
-        }
+        ops::depth::print_path_depth(gfa, lengths, depths);
     }
 }
 

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -236,7 +236,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
         if args.path.is_empty() {
             // All paths.
             let (lengths, depths) = ops::depth::path_depth(gfa, gfa.paths.ids());
-            ops::depth::print_path_depth(gfa, lengths, depths);
+            ops::depth::print_path_depth(gfa, lengths, depths, gfa.paths.ids());
         } else {
             // A subset of paths.
             let path_ids: Vec<_> = args
@@ -245,8 +245,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
                 .filter_map(|n| gfa.find_path(n.as_ref()))
                 .collect();
             let (lengths, depths) = ops::depth::path_depth(gfa, path_ids.iter().copied());
-            dbg!(lengths, depths);
-            todo!();
+            ops::depth::print_path_depth(gfa, lengths, depths, path_ids.iter().copied());
         }
     }
 }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -213,23 +213,41 @@ pub fn extract(
     Ok(subgraph.store)
 }
 
-/// compute node depth, the number of times paths cross a node
+/// compute depth: the number of times paths cross a node
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "depth")]
-pub struct Depth {}
+pub struct Depth {
+    /// compute node depth instead of path depth
+    #[argh(switch, long = "graph-depth-table", short = 'd')]
+    seg_depth: bool,
+}
 
-pub fn depth(gfa: &flatgfa::FlatGFA) {
-    let (depths, uniq_paths) = ops::depth::depth(gfa);
-
-    println!("#node.id\tdepth\tdepth.uniq");
-    for (id, seg) in gfa.segs.items() {
-        let name: u32 = seg.name as u32;
-        println!(
-            "{}\t{}\t{}",
-            name,
-            depths[id.index()],
-            uniq_paths[id.index()],
-        );
+pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
+    if args.seg_depth {
+        // Segment depth table.
+        let (depths, uniq_paths) = ops::depth::seg_depth(gfa);
+        println!("#node.id\tdepth\tdepth.uniq");
+        for (id, seg) in gfa.segs.items() {
+            let name: u32 = seg.name as u32;
+            println!(
+                "{}\t{}\t{}",
+                name,
+                depths[id.index()],
+                uniq_paths[id.index()],
+            );
+        }
+    } else {
+        // Path depth table.
+        let (lengths, depths) = ops::depth::path_depth(gfa);
+        println!("#path\tstart\tend\tmean.depth");
+        for (id, path) in gfa.paths.items() {
+            println!(
+                "{}\t0\t{}\t{}",
+                gfa.get_path_name(path),
+                lengths[id.index()],
+                depths[id.index()],
+            );
+        }
     }
 }
 

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -239,13 +239,12 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
             ops::depth::print_path_depth(gfa, lengths, depths);
         } else {
             // A subset of paths.
-            let path_ids = ops::depth::SparseSubset::new(
-                args.path
-                    .into_iter()
-                    .filter_map(|n| gfa.find_path(n.as_ref()))
-                    .collect(),
-            );
-            let (lengths, depths) = ops::depth::path_depth(gfa, path_ids);
+            let path_ids: Vec<_> = args
+                .path
+                .into_iter()
+                .filter_map(|n| gfa.find_path(n.as_ref()))
+                .collect();
+            let (lengths, depths) = ops::depth::path_depth(gfa, path_ids.iter().copied());
             dbg!(lengths, depths);
             todo!();
         }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -220,6 +220,10 @@ pub struct Depth {
     /// compute node depth instead of path depth
     #[argh(switch, long = "graph-depth-table", short = 'd')]
     seg_depth: bool,
+
+    /// in path mode, show only the namedpath
+    #[argh(option, short = 'r')]
+    path: Vec<bstr::BString>,
 }
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
@@ -229,6 +233,11 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
         ops::depth::print_seg_depth(gfa, depths, uniq_depths);
     } else {
         // Path depth table.
+        let path_ids: Vec<_> = args
+            .path
+            .into_iter()
+            .filter_map(|n| gfa.find_path(n.as_ref()))
+            .collect();
         let (lengths, depths) = ops::depth::path_depth(gfa);
         ops::depth::print_path_depth(gfa, lengths, depths);
     }

--- a/flatgfa/src/cli/main.rs
+++ b/flatgfa/src/cli/main.rs
@@ -132,8 +132,8 @@ fn main() -> Result<(), &'static str> {
             let store = cmds::extract(&gfa, sub_args)?;
             dump(&store.as_ref(), &args.output, &args.output_gfa);
         }
-        Some(Command::Depth(_)) => {
-            cmds::depth(&gfa);
+        Some(Command::Depth(sub_args)) => {
+            cmds::depth(&gfa, sub_args);
         }
         Some(Command::Chop(sub_args)) => {
             let store = cmds::chop(&gfa, sub_args)?;

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -8,7 +8,7 @@ use bit_vec::BitVec;
 /// which only counts each path that tarverses a given segment once.
 ///
 /// Both outputs are depth values indexed by segment ID.
-pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
+pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     // Our output vectors: the ordinary and unique depths of each segment.
     let mut depths = vec![0; gfa.segs.len()];
     let mut uniq_depths = vec![0; gfa.segs.len()];
@@ -32,4 +32,36 @@ pub fn depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     }
 
     (depths, uniq_depths)
+}
+
+/// Compute the mean depth of each *path* in the variation graph.
+///
+/// A path's mean depth is defined to be the average of all the segment depths that appear in the path.
+pub fn path_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<f64>) {
+    // Compute (non-unique) segment depth.
+    let mut seg_depths = vec![0; gfa.segs.len()];
+    for path in gfa.paths.all().iter() {
+        for step in &gfa.steps[path.steps] {
+            let seg_id = step.segment().index();
+            seg_depths[seg_id] += 1;
+        }
+    }
+
+    // Weighted average across each path.
+    let mut path_lengths = Vec::with_capacity(gfa.paths.len());
+    let mut path_depths = Vec::with_capacity(gfa.paths.len());
+    for path in gfa.paths.all().iter() {
+        let mut total_depth = 0;
+        let mut total_length = 0;
+        for step in &gfa.steps[path.steps] {
+            let len = gfa.segs[step.segment()].len();
+            total_depth += seg_depths[step.segment().index()] * len;
+            total_length += len;
+        }
+
+        path_depths.push((total_depth as f64) / (total_length as f64));
+        path_lengths.push(total_length);
+    }
+
+    (path_lengths, path_depths)
 }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,4 +1,5 @@
 use crate::flatgfa;
+use crate::pool::Id;
 use bit_vec::BitVec;
 
 /// Compute the *depth* of each segment in the variation graph.
@@ -67,20 +68,33 @@ pub fn path_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<f64>) {
     // Weighted average across each path.
     let mut path_lengths = Vec::with_capacity(gfa.paths.len());
     let mut path_depths = Vec::with_capacity(gfa.paths.len());
-    for path in gfa.paths.all().iter() {
-        let mut total_depth = 0;
-        let mut total_length = 0;
-        for step in &gfa.steps[path.steps] {
-            let len = gfa.segs[step.segment()].len();
-            total_depth += seg_depths[step.segment().index()] * len;
-            total_length += len;
-        }
-
-        path_depths.push((total_depth as f64) / (total_length as f64));
-        path_lengths.push(total_length);
+    for path in gfa.paths.ids() {
+        let (length, depth) = measure_path(gfa, path, &seg_depths);
+        path_lengths.push(length);
+        path_depths.push(depth);
     }
 
     (path_lengths, path_depths)
+}
+
+/// Get a path's length (in base pairs) and average depth.
+///
+/// Requires walking the path to measure its total length.
+fn measure_path(
+    gfa: &flatgfa::FlatGFA,
+    path: Id<flatgfa::Path>,
+    seg_depths: &[usize],
+) -> (usize, f64) {
+    let mut depth = 0;
+    let mut length = 0;
+    let path = gfa.paths[path];
+    for step in &gfa.steps[path.steps] {
+        let len = gfa.segs[step.segment()].len();
+        depth += seg_depths[step.segment().index()] * len;
+        length += len;
+    }
+    let avg_depth = (depth as f64) / (length as f64);
+    (length, avg_depth)
 }
 
 /// Print a path depth table.

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -51,9 +51,6 @@ pub fn print_seg_depth(gfa: &flatgfa::FlatGFA, depths: Vec<usize>, uniq_depths: 
     }
 }
 
-// TODO Need a way to pass one of two kinds of iterators to `path_depth`: one
-// that says "take everything" and one that walks over a subset.
-
 /// Compute the mean depth of each *path* in the variation graph.
 ///
 /// A path's mean depth is defined to be the average of all the segment depths

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -51,6 +51,9 @@ pub fn print_seg_depth(gfa: &flatgfa::FlatGFA, depths: Vec<usize>, uniq_depths: 
     }
 }
 
+// TODO Need a way to pass one of two kinds of iterators to `path_depth`: one
+// that says "take everything" and one that walks over a subset.
+
 /// Compute the mean depth of each *path* in the variation graph.
 ///
 /// A path's mean depth is defined to be the average of all the segment depths

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -58,7 +58,10 @@ pub fn print_seg_depth(gfa: &flatgfa::FlatGFA, depths: Vec<usize>, uniq_depths: 
 ///
 /// A path's mean depth is defined to be the average of all the segment depths
 /// that appear in the path.
-pub fn path_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<f64>) {
+pub fn path_depth<I>(gfa: &flatgfa::FlatGFA, paths: I) -> (Vec<usize>, Vec<f64>)
+where
+    I: Iterator<Item = Id<flatgfa::Path>>,
+{
     // Compute (non-unique) segment depth.
     let mut seg_depths = vec![0; gfa.segs.len()];
     for path in gfa.paths.all().iter() {
@@ -71,8 +74,8 @@ pub fn path_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<f64>) {
     // Weighted average across each path.
     let mut path_lengths = Vec::with_capacity(gfa.paths.len());
     let mut path_depths = Vec::with_capacity(gfa.paths.len());
-    for path in gfa.paths.ids() {
-        let (length, depth) = measure_path(gfa, path, &seg_depths);
+    for path_id in paths {
+        let (length, depth) = measure_path(gfa, path_id, &seg_depths);
         path_lengths.push(length);
         path_depths.push(depth);
     }
@@ -112,5 +115,30 @@ pub fn print_path_depth(gfa: &flatgfa::FlatGFA, lengths: Vec<usize>, depths: Vec
             lengths[id.index()],
             depths[id.index()],
         );
+    }
+}
+
+pub struct SparseSubset<T> {
+    ids: Vec<Id<T>>,
+    start: usize,
+}
+
+impl<T> Iterator for SparseSubset<T> {
+    type Item = Id<T>;
+
+    fn next(&mut self) -> Option<Id<T>> {
+        if self.start >= self.ids.len() {
+            None
+        } else {
+            let id = self.ids[self.start];
+            self.start += 1;
+            Some(id)
+        }
+    }
+}
+
+impl<T> SparseSubset<T> {
+    pub fn new(ids: Vec<Id<T>>) -> Self {
+        Self { ids, start: 0 }
     }
 }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -34,9 +34,26 @@ pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     (depths, uniq_depths)
 }
 
+/// Print a segment depth table.
+///
+/// Format the result of `seg_depth` in an odgi-style TSV.
+pub fn print_seg_depth(gfa: &flatgfa::FlatGFA, depths: Vec<usize>, uniq_depths: Vec<usize>) {
+    println!("#node.id\tdepth\tdepth.uniq");
+    for (id, seg) in gfa.segs.items() {
+        let name: u32 = seg.name as u32;
+        println!(
+            "{}\t{}\t{}",
+            name,
+            depths[id.index()],
+            uniq_depths[id.index()],
+        );
+    }
+}
+
 /// Compute the mean depth of each *path* in the variation graph.
 ///
-/// A path's mean depth is defined to be the average of all the segment depths that appear in the path.
+/// A path's mean depth is defined to be the average of all the segment depths
+/// that appear in the path.
 pub fn path_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<f64>) {
     // Compute (non-unique) segment depth.
     let mut seg_depths = vec![0; gfa.segs.len()];
@@ -64,4 +81,19 @@ pub fn path_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<f64>) {
     }
 
     (path_lengths, path_depths)
+}
+
+/// Print a path depth table.
+///
+/// Format the result of `path_depth` in an odgi-style TSV.
+pub fn print_path_depth(gfa: &flatgfa::FlatGFA, lengths: Vec<usize>, depths: Vec<f64>) {
+    println!("#path\tstart\tend\tmean.depth");
+    for (id, path) in gfa.paths.items() {
+        println!(
+            "{}\t0\t{}\t{}",
+            gfa.get_path_name(path),
+            lengths[id.index()],
+            depths[id.index()],
+        );
+    }
 }

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -117,28 +117,3 @@ pub fn print_path_depth(gfa: &flatgfa::FlatGFA, lengths: Vec<usize>, depths: Vec
         );
     }
 }
-
-pub struct SparseSubset<T> {
-    ids: Vec<Id<T>>,
-    start: usize,
-}
-
-impl<T> Iterator for SparseSubset<T> {
-    type Item = Id<T>;
-
-    fn next(&mut self) -> Option<Id<T>> {
-        if self.start >= self.ids.len() {
-            None
-        } else {
-            let id = self.ids[self.start];
-            self.start += 1;
-            Some(id)
-        }
-    }
-}
-
-impl<T> SparseSubset<T> {
-    pub fn new(ids: Vec<Id<T>>) -> Self {
-        Self { ids, start: 0 }
-    }
-}

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -106,14 +106,17 @@ fn measure_path(
 /// Print a path depth table.
 ///
 /// Format the result of `path_depth` in an odgi-style TSV.
-pub fn print_path_depth(gfa: &flatgfa::FlatGFA, lengths: Vec<usize>, depths: Vec<f64>) {
+pub fn print_path_depth<I>(gfa: &flatgfa::FlatGFA, lengths: Vec<usize>, depths: Vec<f64>, paths: I)
+where
+    I: Iterator<Item = Id<flatgfa::Path>>,
+{
     println!("#path\tstart\tend\tmean.depth");
-    for (id, path) in gfa.paths.items() {
+    for (idx, id) in paths.enumerate() {
         println!(
             "{}\t0\t{}\t{}",
-            gfa.get_path_name(path),
-            lengths[id.index()],
-            depths[id.index()],
+            gfa.get_path_name(&gfa.paths[id]),
+            lengths[idx],
+            depths[idx],
         );
     }
 }

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -279,6 +279,11 @@ impl<'a, T> Pool<'a, T> {
             .map(|(i, item)| (Id::new(i), item))
     }
 
+    /// Iterate over all ids in the pool.
+    pub fn ids(&self) -> impl Iterator<Item = Id<T>> {
+        (0..self.len()).map(Id::new)
+    }
+
     /// Get the in-memory size of the pool in bytes.
     pub fn size(&self) -> usize {
         std::mem::size_of_val(self.0)

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -6,7 +6,7 @@ use tinyvec::SliceVec;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// An index into a pool.
-#[derive(Debug, Immutable, FromBytes, IntoBytes, Clone, Copy)]
+#[derive(Debug, Immutable, FromBytes, IntoBytes)]
 #[repr(transparent)]
 pub struct Id<T>(u32, PhantomData<T>);
 
@@ -65,6 +65,14 @@ impl<T> From<Id<T>> for u32 {
     }
 }
 
+impl<T> Clone for Id<T> {
+    fn clone(&self) -> Self {
+        Id(self.0, PhantomData)
+    }
+}
+
+impl<T> Copy for Id<T> {}
+
 /// A range of indices into a pool.
 ///
 /// TODO: Consider smaller indices for this, and possibly base/offset instead
@@ -112,6 +120,21 @@ impl<T> Span<T> {
 
     pub fn new_empty() -> Self {
         Span::new(Id::new(0), Id::new(0))
+    }
+}
+
+impl<T> Iterator for Span<T> {
+    type Item = Id<T>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Id<T>> {
+        if self.is_empty() {
+            None
+        } else {
+            let idx = self.start.0;
+            self.start = Id(idx + 1, PhantomData);
+            Some(Id(idx, PhantomData))
+        }
     }
 }
 
@@ -279,9 +302,9 @@ impl<'a, T> Pool<'a, T> {
             .map(|(i, item)| (Id::new(i), item))
     }
 
-    /// Iterate over all ids in the pool.
-    pub fn ids(&self) -> impl Iterator<Item = Id<T>> {
-        (0..self.len()).map(Id::new)
+    /// A span covering all the ids in the pool.
+    pub fn ids(&self) -> Span<T> {
+        Span::new(0.into(), (self.len() as u32).into())
     }
 
     /// Get the in-memory size of the pool in bytes.

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -67,7 +67,7 @@ impl<T> From<Id<T>> for u32 {
 
 impl<T> Clone for Id<T> {
     fn clone(&self) -> Self {
-        Id(self.0, PhantomData)
+        *self
     }
 }
 

--- a/tests/turnt.toml
+++ b/tests/turnt.toml
@@ -177,7 +177,7 @@ command = "odgi depth -d -i {filename}"
 output.depth = "-"
 
 [envs.flatgfa_depth]
-command = "../target/debug/fgfa -I {filename} depth"
+command = "../target/debug/fgfa -I {filename} depth -d"
 output.depth = "-"
 
 [envs.chop_oracle_fgfa]


### PR DESCRIPTION
`odgi depth` operates in (at least) two modes: node depth and path depth. We were previously only doing node depth. This adds path depth.

Path depth is defined as the weighted average of node depth across a given path. So I borrowed from @johnpalsberg's #252 (which does an analogous thing for windows instead of paths) to make this work.

This changes `fgfa depth` to print path depth by default; to get node depth, you use `fgfa depth -d`, as with odgi. I also added support for both modes to flash. Finally, there is support for specifying *which* path you want to see, with `-r`.