### PR TITLE
Limited-precision float printing in depth output

### DIFF
--- a/flatgfa/examples/window_depth.rs
+++ b/flatgfa/examples/window_depth.rs
@@ -67,13 +67,6 @@ fn assign_depths(seg_depth: &Vec<SegmentDepth>, windows: &Vec<(usize, usize)>) -
     depths
 }
 
-fn format_float(x: f64) -> String {
-    let s = format!("{:.6}", x);
-    let s = s.trim_end_matches('0');
-    let s = s.trim_end_matches('.');
-    s.to_string()
-}
-
 fn create_bed(
     gfa_name: &str,
     bed_name: &str,
@@ -101,7 +94,7 @@ fn create_bed(
     for i in 0..windows.len() {
         let start = windows[i].0;
         let end = windows[i].1;
-        let depth_str = format_float(depths_final[i]);
+        let depth_str = depth::format_float(depths_final[i]);
         let line = format!("{chrom_name}\t{start}\t{end}\t{depth_str}\n");
         let bytes = line.as_bytes();
         bed_file[offset..offset + bytes.len()].copy_from_slice(bytes);

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -113,7 +113,20 @@ where
             "{}\t0\t{}\t{}",
             gfa.get_path_name(&gfa.paths[id]),
             lengths[idx],
-            depths[idx],
+            format_float(depths[idx]),
         );
     }
+}
+
+/// Format an `f64` in an odgi-like way, with limited decimal digits and without
+/// trailing zeroes.
+///
+/// This is currently inefficient: it first formats with trailing zeroes, and
+/// then it trims those zeroes. Surely there is an option out there for avoiding
+/// this extra work...
+pub fn format_float(x: f64) -> String {
+    format!("{:.2}", x)
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_string()
 }


### PR DESCRIPTION
This promotes `float_format` from @johnpalsberg's #252 into the FlatGFA library and uses it in `fgfa depth` output as well. At least in some limited testing, `fgfa depth` in path mode now exactly matches `odgi depth`.

I am slightly sad that I couldn't find an easy, correct way to make this more efficient (to avoid producing zeroes just to delete them again). But surely this is not a bottleneck anyway...

Checks a box in #254.