### PR TITLE
flash: Pipelines

### DIFF
--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -19,6 +19,9 @@ odgi depth -i ../tests/note5.gfa
 $ flash -c 'head -n1 < README.md'
 The FlatGFA Fake Shell
 
+$ flash -c 'head -n1 < README.md | rev'
+llehS ekaF AFGtalF ehT
+
 ```
 
 But more importantly, you can also use odgi subcommands, which are implemented using in-process calls to the FlatGFA library, without forking anything:

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -53,7 +53,7 @@ Supported Syntax
 ----------------
 
 Use the `-p` flag for "pretend mode" to see how `flash` parses your shell command.
-Here are some things that we currently parse (not all of which are implemented in the evaluator just yet):
+Here are some things that we currently parse:
 
 ```console
 $ flash -p -c 'odgi depth'
@@ -70,5 +70,20 @@ path_depth("chr8.gfa", path="chm13#chr8") -> stdout
 
 $ flash -p -c 'odgi depth < chr8.gfa > depth.tsv'
 path_depth("chr8.gfa") -> "depth.tsv"
+
+```
+
+Here's how pipelines get parsed:
+
+```console
+$ flash -p -c 'foo | bar | baz'
+shell("foo", [], input=stdin) -> pipe-2
+shell("bar", [], input=pipe-2) -> pipe-3
+shell("baz", [], input=pipe-3) -> stdout
+
+$ flash -p -c 'foo | bar | baz > qux'
+shell("foo", [], input=stdin) -> pipe-2
+shell("bar", [], input=pipe-2) -> pipe-3
+shell("baz", [], input=pipe-3) -> "qux"
 
 ```

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -36,6 +36,14 @@ $ flash -c 'odgi depth -d -i ../tests/note5.gfa'
 
 ```
 
+Built-in commands even compose with external commands via pipes:
+
+```console
+$ flash -c 'odgi depth -d -i ../tests/note5.gfa | tail -n1'
+4	2	2
+
+```
+
 You can also run shell script files:
 
 ```console

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,5 +1,5 @@
 use crate::ir::{self, Resource, ResourceRef};
-use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops, ops::depth::Emit};
+use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile, ops};
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter};
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,5 +1,5 @@
 use crate::ir::{self, Resource, ResourceRef};
-use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops};
+use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops, ops::depth::Emit};
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter};
 
@@ -121,16 +121,26 @@ impl Eval for ir::NodeDepthInstr {
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
 
         match env.output(self.output) {
-            Output::Stdout(mut s) => {
-                ops::depth::write_seg_depth(&mut s, &gfa, depths, uniq_depths).unwrap()
+            Output::Stdout(mut s) => ops::depth::SegDepth {
+                gfa: &gfa,
+                depths,
+                uniq_depths,
             }
-            Output::File(mut s) => {
-                ops::depth::write_seg_depth(&mut s, &gfa, depths, uniq_depths).unwrap()
+            .emit(&mut s),
+            Output::File(mut s) => ops::depth::SegDepth {
+                gfa: &gfa,
+                depths,
+                uniq_depths,
             }
-            Output::Pipe(mut s) => {
-                ops::depth::write_seg_depth(&mut s, &gfa, depths, uniq_depths).unwrap()
+            .emit(&mut s),
+            Output::Pipe(mut s) => ops::depth::SegDepth {
+                gfa: &gfa,
+                depths,
+                uniq_depths,
             }
+            .emit(&mut s),
         }
+        .unwrap();
     }
 }
 
@@ -143,51 +153,59 @@ impl Eval for ir::PathDepthInstr {
             let path_id = gfa
                 .find_path(path_name.as_bytes().into())
                 .expect("no such path found");
-            let (depths, uniq_depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
+            let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
 
             match env.output(self.output) {
-                Output::Stdout(mut s) => ops::depth::write_path_depth(
-                    &mut s,
-                    &gfa,
+                Output::Stdout(mut s) => ops::depth::PathDepth {
+                    gfa: &gfa,
                     depths,
-                    uniq_depths,
-                    std::iter::once(path_id),
-                )
-                .unwrap(),
-                Output::File(mut s) => ops::depth::write_path_depth(
-                    &mut s,
-                    &gfa,
+                    lengths,
+                    paths: std::iter::once(path_id),
+                }
+                .emit(&mut s),
+                Output::File(mut s) => ops::depth::PathDepth {
+                    gfa: &gfa,
                     depths,
-                    uniq_depths,
-                    std::iter::once(path_id),
-                )
-                .unwrap(),
-                Output::Pipe(mut s) => ops::depth::write_path_depth(
-                    &mut s,
-                    &gfa,
+                    lengths,
+                    paths: std::iter::once(path_id),
+                }
+                .emit(&mut s),
+                Output::Pipe(mut s) => ops::depth::PathDepth {
+                    gfa: &gfa,
                     depths,
-                    uniq_depths,
-                    std::iter::once(path_id),
-                )
-                .unwrap(),
+                    lengths,
+                    paths: std::iter::once(path_id),
+                }
+                .emit(&mut s),
             }
+            .unwrap();
         } else {
-            let (depths, uniq_depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
+            let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
 
             match env.output(self.output) {
-                Output::Stdout(mut s) => {
-                    ops::depth::write_path_depth(&mut s, &gfa, depths, uniq_depths, gfa.paths.ids())
-                        .unwrap()
+                Output::Stdout(mut s) => ops::depth::PathDepth {
+                    gfa: &gfa,
+                    depths,
+                    lengths,
+                    paths: gfa.paths.ids(),
                 }
-                Output::File(mut s) => {
-                    ops::depth::write_path_depth(&mut s, &gfa, depths, uniq_depths, gfa.paths.ids())
-                        .unwrap()
+                .emit(&mut s),
+                Output::File(mut s) => ops::depth::PathDepth {
+                    gfa: &gfa,
+                    depths,
+                    lengths,
+                    paths: gfa.paths.ids(),
                 }
-                Output::Pipe(mut s) => {
-                    ops::depth::write_path_depth(&mut s, &gfa, depths, uniq_depths, gfa.paths.ids())
-                        .unwrap()
+                .emit(&mut s),
+                Output::Pipe(mut s) => ops::depth::PathDepth {
+                    gfa: &gfa,
+                    depths,
+                    lengths,
+                    paths: gfa.paths.ids(),
                 }
+                .emit(&mut s),
             }
+            .unwrap();
         }
     }
 }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -47,6 +47,7 @@ impl Env {
         }
     }
 
+    #[allow(dead_code)]
     fn input(&mut self, rsrc: ResourceRef) -> Input {
         match &self.rsrc[rsrc.0] {
             Resource::Stdin => Input::Stdin(std::io::stdin().lock()),
@@ -86,6 +87,7 @@ impl Env {
     }
 }
 
+#[allow(dead_code)]
 enum Input {
     Stdin(std::io::StdinLock<'static>),
     File(BufReader<File>),

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,7 +1,7 @@
 use crate::ir::{self, Resource, ResourceRef};
 use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops};
 use std::fs::File;
-use std::io::{self, BufReader, PipeReader, PipeWriter};
+use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter};
 
 struct Env {
     /// All the resource descriptions used in this program.
@@ -49,19 +49,19 @@ impl Env {
 
     fn input(&mut self, rsrc: ResourceRef) -> Input {
         match &self.rsrc[rsrc.0] {
-            Resource::Stdin => Input::Stdin(std::io::stdin()),
+            Resource::Stdin => Input::Stdin(std::io::stdin().lock()),
             Resource::Stdout => panic!("cannot read from stdout"),
-            Resource::File(name) => Input::File(File::open(name).unwrap()),
-            Resource::Pipe => Input::Pipe(self.read_pipe(rsrc).unwrap()),
+            Resource::File(name) => Input::File(BufReader::new(File::open(name).unwrap())),
+            Resource::Pipe => Input::Pipe(BufReader::new(self.read_pipe(rsrc).unwrap())),
         }
     }
 
     fn output(&mut self, rsrc: ResourceRef) -> Output {
         match &self.rsrc[rsrc.0] {
             Resource::Stdin => panic!("cannot write to stdin"),
-            Resource::Stdout => Output::Stdout(std::io::stdout()),
-            Resource::File(name) => Output::File(File::create(name).unwrap()),
-            Resource::Pipe => Output::Pipe(self.write_pipe(rsrc).unwrap()),
+            Resource::Stdout => Output::Stdout(std::io::stdout().lock()),
+            Resource::File(name) => Output::File(BufWriter::new(File::create(name).unwrap())),
+            Resource::Pipe => Output::Pipe(BufWriter::new(self.write_pipe(rsrc).unwrap())),
         }
     }
 
@@ -87,15 +87,15 @@ impl Env {
 }
 
 enum Input {
-    Stdin(std::io::Stdin),
-    File(File),
-    Pipe(PipeReader),
+    Stdin(std::io::StdinLock<'static>),
+    File(BufReader<File>),
+    Pipe(BufReader<PipeReader>),
 }
 
 enum Output {
-    Stdout(std::io::Stdout),
-    File(File),
-    Pipe(PipeWriter),
+    Stdout(std::io::StdoutLock<'static>),
+    File(BufWriter<File>),
+    Pipe(BufWriter<PipeWriter>),
 }
 
 trait Eval {

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,16 +1,58 @@
-use crate::ir;
+use crate::ir::{self, ResourceRef};
 use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops};
+use std::io::{self, PipeReader, PipeWriter};
 
 struct Env {
+    /// All the resource descriptions used in this program.
     rsrc: Vec<ir::Resource>,
+
+    /// The currently open Unix pipes for operations in this program.
+    ///
+    /// This has the same length as `rsrc`. For every resource index that is a
+    /// `Pipe`, this may contain the currently open pipe. We lazily populate
+    /// these slots when the first instruction uses the pipe. The first use of
+    /// either "side" of the pipe consumes it.
+    pipes: Vec<(Option<PipeReader>, Option<PipeWriter>)>,
+}
+
+impl Env {
+    fn new(rsrc: Vec<ir::Resource>) -> Self {
+        let mut pipes = Vec::with_capacity(rsrc.len());
+        pipes.resize_with(rsrc.len(), Default::default);
+        Self { rsrc, pipes }
+    }
+
+    fn read_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeReader> {
+        let idx = rsrc.0;
+        debug_assert!(matches!(self.rsrc[idx], ir::Resource::Pipe));
+        if let Some(reader) = self.pipes[idx].0.take() {
+            Ok(reader)
+        } else {
+            let (reader, writer) = io::pipe()?;
+            self.pipes[idx].1 = Some(writer);
+            Ok(reader)
+        }
+    }
+
+    fn write_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeWriter> {
+        let idx = rsrc.0;
+        debug_assert!(matches!(self.rsrc[idx], ir::Resource::Pipe));
+        if let Some(writer) = self.pipes[idx].1.take() {
+            Ok(writer)
+        } else {
+            let (reader, writer) = io::pipe()?;
+            self.pipes[idx].0 = Some(reader);
+            Ok(writer)
+        }
+    }
 }
 
 trait Eval {
-    fn eval(&self, env: &Env);
+    fn eval(&self, env: &mut Env);
 }
 
 impl Eval for ir::Instr {
-    fn eval(&self, env: &Env) {
+    fn eval(&self, env: &mut Env) {
         match self {
             Self::NodeDepth(instr) => instr.eval(env),
             Self::PathDepth(instr) => instr.eval(env),
@@ -36,7 +78,7 @@ fn parse_gfa(rsrc: &ir::Resource) -> HeapGFAStore {
 }
 
 impl Eval for ir::NodeDepthInstr {
-    fn eval(&self, env: &Env) {
+    fn eval(&self, env: &mut Env) {
         let store = parse_gfa(&env.rsrc[self.input.0]);
         let gfa = store.as_ref();
         // TODO Do something about the output resource...
@@ -46,7 +88,7 @@ impl Eval for ir::NodeDepthInstr {
 }
 
 impl Eval for ir::PathDepthInstr {
-    fn eval(&self, env: &Env) {
+    fn eval(&self, env: &mut Env) {
         let store = parse_gfa(&env.rsrc[self.input.0]);
         let gfa = store.as_ref();
         if let Some(path_name) = &self.path {
@@ -64,17 +106,33 @@ impl Eval for ir::PathDepthInstr {
 }
 
 impl Eval for ir::ExecInstr {
-    fn eval(&self, env: &Env) {
+    fn eval(&self, env: &mut Env) {
         use std::fs::File;
         use std::process::Command;
 
         let mut cmd = Command::new(&self.command);
         cmd.args(&self.args);
-        if let ir::Resource::File(name) = &env.rsrc[self.input.0] {
-            cmd.stdin(File::open(name).unwrap());
+
+        match &env.rsrc[self.input.0] {
+            ir::Resource::Stdin => (),
+            ir::Resource::Stdout => panic!("cannot read from stdout"),
+            ir::Resource::File(name) => {
+                cmd.stdin(File::open(name).unwrap());
+            }
+            ir::Resource::Pipe => {
+                cmd.stdin(env.read_pipe(self.input).unwrap());
+            }
         }
-        if let ir::Resource::File(name) = &env.rsrc[self.output.0] {
-            cmd.stdout(File::create(name).unwrap());
+
+        match &env.rsrc[self.output.0] {
+            ir::Resource::Stdin => panic!("cannot write to stdin"),
+            ir::Resource::Stdout => (),
+            ir::Resource::File(name) => {
+                cmd.stdout(File::create(name).unwrap());
+            }
+            ir::Resource::Pipe => {
+                cmd.stdout(env.write_pipe(self.output).unwrap());
+            }
         }
 
         // TODO: Do anything with the status?
@@ -83,8 +141,8 @@ impl Eval for ir::ExecInstr {
 }
 
 pub fn run(prog: ir::Program) {
-    let env = Env { rsrc: prog.rsrc };
+    let mut env = Env::new(prog.rsrc);
     for op in prog.instrs {
-        op.eval(&env);
+        op.eval(&mut env);
     }
 }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,10 +1,11 @@
-use crate::ir::{self, ResourceRef};
+use crate::ir::{self, Resource, ResourceRef};
 use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops};
-use std::io::{self, BufReader, PipeReader, PipeWriter};
+use std::fs::File;
+use std::io::{self, BufReader, PipeReader, PipeWriter, stdout};
 
 struct Env {
     /// All the resource descriptions used in this program.
-    rsrc: Vec<ir::Resource>,
+    rsrc: Vec<Resource>,
 
     /// The currently open Unix pipes for operations in this program.
     ///
@@ -16,7 +17,7 @@ struct Env {
 }
 
 impl Env {
-    fn new(rsrc: Vec<ir::Resource>) -> Self {
+    fn new(rsrc: Vec<Resource>) -> Self {
         let mut pipes = Vec::with_capacity(rsrc.len());
         pipes.resize_with(rsrc.len(), Default::default);
         Self { rsrc, pipes }
@@ -24,7 +25,7 @@ impl Env {
 
     fn read_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeReader> {
         let idx = rsrc.0;
-        debug_assert!(matches!(self.rsrc[idx], ir::Resource::Pipe));
+        debug_assert!(matches!(self.rsrc[idx], Resource::Pipe));
         if let Some(reader) = self.pipes[idx].0.take() {
             Ok(reader)
         } else {
@@ -36,7 +37,7 @@ impl Env {
 
     fn write_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeWriter> {
         let idx = rsrc.0;
-        debug_assert!(matches!(self.rsrc[idx], ir::Resource::Pipe));
+        debug_assert!(matches!(self.rsrc[idx], Resource::Pipe));
         if let Some(writer) = self.pipes[idx].1.take() {
             Ok(writer)
         } else {
@@ -47,19 +48,19 @@ impl Env {
     }
 
     /// Parse a (text) GFA file from a resource.
-    fn parse_gfa(&mut self, rsrc: ir::ResourceRef) -> HeapGFAStore {
+    fn parse_gfa(&mut self, rsrc: ResourceRef) -> HeapGFAStore {
         use flatgfa::parse::Parser;
         match &self.rsrc[rsrc.0] {
-            ir::Resource::File(name) => {
+            Resource::File(name) => {
                 let file = memfile::map_file(name);
                 Parser::for_heap().parse_mem(file.as_ref())
             }
-            ir::Resource::Stdin => {
+            Resource::Stdin => {
                 let stdin = std::io::stdin();
                 Parser::for_heap().parse_stream(stdin.lock())
             }
-            ir::Resource::Stdout => panic!("cannot read from stdout"),
-            ir::Resource::Pipe => {
+            Resource::Stdout => panic!("cannot read from stdout"),
+            Resource::Pipe => {
                 let read = self.read_pipe(rsrc).unwrap();
                 Parser::for_heap().parse_stream(BufReader::new(read))
             }
@@ -87,13 +88,25 @@ impl Eval for ir::NodeDepthInstr {
         let gfa = store.as_ref();
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
 
-        match env.rsrc[self.output.0] {
-            ir::Resource::Stdin => panic!("cannot write to stdin"),
-            ir::Resource::Stdout => {
-                ops::depth::write_seg_depth(&mut std::io::stdout(), &gfa, depths, uniq_depths)
-                    .unwrap()
+        match &env.rsrc[self.output.0] {
+            Resource::Stdin => panic!("cannot write to stdin"),
+            Resource::Stdout => {
+                ops::depth::write_seg_depth(&mut stdout(), &gfa, depths, uniq_depths).unwrap()
             }
-            _ => unimplemented!(),
+            Resource::File(name) => ops::depth::write_seg_depth(
+                &mut File::create(name).unwrap(),
+                &gfa,
+                depths,
+                uniq_depths,
+            )
+            .unwrap(),
+            Resource::Pipe => ops::depth::write_seg_depth(
+                &mut env.write_pipe(self.output).unwrap(),
+                &gfa,
+                depths,
+                uniq_depths,
+            )
+            .unwrap(),
         }
     }
 }
@@ -109,32 +122,62 @@ impl Eval for ir::PathDepthInstr {
                 .expect("no such path found");
             let (depths, uniq_depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
 
-            match env.rsrc[self.output.0] {
-                ir::Resource::Stdin => panic!("cannot write to stdin"),
-                ir::Resource::Stdout => ops::depth::write_path_depth(
-                    &mut std::io::stdout(),
+            match &env.rsrc[self.output.0] {
+                Resource::Stdin => panic!("cannot write to stdin"),
+                Resource::Stdout => ops::depth::write_path_depth(
+                    &mut stdout(),
                     &gfa,
                     depths,
                     uniq_depths,
                     std::iter::once(path_id),
                 )
                 .unwrap(),
-                _ => unimplemented!(),
+                Resource::File(name) => ops::depth::write_path_depth(
+                    &mut File::create(name).unwrap(),
+                    &gfa,
+                    depths,
+                    uniq_depths,
+                    std::iter::once(path_id),
+                )
+                .unwrap(),
+                Resource::Pipe => ops::depth::write_path_depth(
+                    &mut env.write_pipe(self.output).unwrap(),
+                    &gfa,
+                    depths,
+                    uniq_depths,
+                    std::iter::once(path_id),
+                )
+                .unwrap(),
             }
         } else {
             let (depths, uniq_depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
 
-            match env.rsrc[self.output.0] {
-                ir::Resource::Stdin => panic!("cannot write to stdin"),
-                ir::Resource::Stdout => ops::depth::write_path_depth(
-                    &mut std::io::stdout(),
+            match &env.rsrc[self.output.0] {
+                Resource::Stdin => panic!("cannot write to stdin"),
+                Resource::Stdout => ops::depth::write_path_depth(
+                    &mut stdout(),
                     &gfa,
                     depths,
                     uniq_depths,
                     gfa.paths.ids(),
                 )
                 .unwrap(),
-                _ => unimplemented!(),
+                Resource::File(name) => ops::depth::write_path_depth(
+                    &mut File::create(name).unwrap(),
+                    &gfa,
+                    depths,
+                    uniq_depths,
+                    gfa.paths.ids(),
+                )
+                .unwrap(),
+                Resource::Pipe => ops::depth::write_path_depth(
+                    &mut env.write_pipe(self.output).unwrap(),
+                    &gfa,
+                    depths,
+                    uniq_depths,
+                    gfa.paths.ids(),
+                )
+                .unwrap(),
             }
         }
     }
@@ -149,23 +192,23 @@ impl Eval for ir::ExecInstr {
         cmd.args(&self.args);
 
         match &env.rsrc[self.input.0] {
-            ir::Resource::Stdin => (),
-            ir::Resource::Stdout => panic!("cannot read from stdout"),
-            ir::Resource::File(name) => {
+            Resource::Stdin => (),
+            Resource::Stdout => panic!("cannot read from stdout"),
+            Resource::File(name) => {
                 cmd.stdin(File::open(name).unwrap());
             }
-            ir::Resource::Pipe => {
+            Resource::Pipe => {
                 cmd.stdin(env.read_pipe(self.input).unwrap());
             }
         }
 
         match &env.rsrc[self.output.0] {
-            ir::Resource::Stdin => panic!("cannot write to stdin"),
-            ir::Resource::Stdout => (),
-            ir::Resource::File(name) => {
+            Resource::Stdin => panic!("cannot write to stdin"),
+            Resource::Stdout => (),
+            Resource::File(name) => {
                 cmd.stdout(File::create(name).unwrap());
             }
-            ir::Resource::Pipe => {
+            Resource::Pipe => {
                 cmd.stdout(env.write_pipe(self.output).unwrap());
             }
         }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,7 +1,7 @@
 use crate::ir::{self, Resource, ResourceRef};
 use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops};
 use std::fs::File;
-use std::io::{self, BufReader, PipeReader, PipeWriter, stdout};
+use std::io::{self, BufReader, PipeReader, PipeWriter};
 
 struct Env {
     /// All the resource descriptions used in this program.
@@ -47,6 +47,24 @@ impl Env {
         }
     }
 
+    fn input(&mut self, rsrc: ResourceRef) -> Input {
+        match &self.rsrc[rsrc.0] {
+            Resource::Stdin => Input::Stdin(std::io::stdin()),
+            Resource::Stdout => panic!("cannot read from stdout"),
+            Resource::File(name) => Input::File(File::open(name).unwrap()),
+            Resource::Pipe => Input::Pipe(self.read_pipe(rsrc).unwrap()),
+        }
+    }
+
+    fn output(&mut self, rsrc: ResourceRef) -> Output {
+        match &self.rsrc[rsrc.0] {
+            Resource::Stdin => panic!("cannot write to stdin"),
+            Resource::Stdout => Output::Stdout(std::io::stdout()),
+            Resource::File(name) => Output::File(File::create(name).unwrap()),
+            Resource::Pipe => Output::Pipe(self.write_pipe(rsrc).unwrap()),
+        }
+    }
+
     /// Parse a (text) GFA file from a resource.
     fn parse_gfa(&mut self, rsrc: ResourceRef) -> HeapGFAStore {
         use flatgfa::parse::Parser;
@@ -66,6 +84,18 @@ impl Env {
             }
         }
     }
+}
+
+enum Input {
+    Stdin(std::io::Stdin),
+    File(File),
+    Pipe(PipeReader),
+}
+
+enum Output {
+    Stdout(std::io::Stdout),
+    File(File),
+    Pipe(PipeWriter),
 }
 
 trait Eval {
@@ -88,25 +118,16 @@ impl Eval for ir::NodeDepthInstr {
         let gfa = store.as_ref();
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
 
-        match &env.rsrc[self.output.0] {
-            Resource::Stdin => panic!("cannot write to stdin"),
-            Resource::Stdout => {
-                ops::depth::write_seg_depth(&mut stdout(), &gfa, depths, uniq_depths).unwrap()
+        match env.output(self.output) {
+            Output::Stdout(mut s) => {
+                ops::depth::write_seg_depth(&mut s, &gfa, depths, uniq_depths).unwrap()
             }
-            Resource::File(name) => ops::depth::write_seg_depth(
-                &mut File::create(name).unwrap(),
-                &gfa,
-                depths,
-                uniq_depths,
-            )
-            .unwrap(),
-            Resource::Pipe => ops::depth::write_seg_depth(
-                &mut env.write_pipe(self.output).unwrap(),
-                &gfa,
-                depths,
-                uniq_depths,
-            )
-            .unwrap(),
+            Output::File(mut s) => {
+                ops::depth::write_seg_depth(&mut s, &gfa, depths, uniq_depths).unwrap()
+            }
+            Output::Pipe(mut s) => {
+                ops::depth::write_seg_depth(&mut s, &gfa, depths, uniq_depths).unwrap()
+            }
         }
     }
 }
@@ -122,26 +143,25 @@ impl Eval for ir::PathDepthInstr {
                 .expect("no such path found");
             let (depths, uniq_depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
 
-            match &env.rsrc[self.output.0] {
-                Resource::Stdin => panic!("cannot write to stdin"),
-                Resource::Stdout => ops::depth::write_path_depth(
-                    &mut stdout(),
+            match env.output(self.output) {
+                Output::Stdout(mut s) => ops::depth::write_path_depth(
+                    &mut s,
                     &gfa,
                     depths,
                     uniq_depths,
                     std::iter::once(path_id),
                 )
                 .unwrap(),
-                Resource::File(name) => ops::depth::write_path_depth(
-                    &mut File::create(name).unwrap(),
+                Output::File(mut s) => ops::depth::write_path_depth(
+                    &mut s,
                     &gfa,
                     depths,
                     uniq_depths,
                     std::iter::once(path_id),
                 )
                 .unwrap(),
-                Resource::Pipe => ops::depth::write_path_depth(
-                    &mut env.write_pipe(self.output).unwrap(),
+                Output::Pipe(mut s) => ops::depth::write_path_depth(
+                    &mut s,
                     &gfa,
                     depths,
                     uniq_depths,
@@ -152,32 +172,19 @@ impl Eval for ir::PathDepthInstr {
         } else {
             let (depths, uniq_depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
 
-            match &env.rsrc[self.output.0] {
-                Resource::Stdin => panic!("cannot write to stdin"),
-                Resource::Stdout => ops::depth::write_path_depth(
-                    &mut stdout(),
-                    &gfa,
-                    depths,
-                    uniq_depths,
-                    gfa.paths.ids(),
-                )
-                .unwrap(),
-                Resource::File(name) => ops::depth::write_path_depth(
-                    &mut File::create(name).unwrap(),
-                    &gfa,
-                    depths,
-                    uniq_depths,
-                    gfa.paths.ids(),
-                )
-                .unwrap(),
-                Resource::Pipe => ops::depth::write_path_depth(
-                    &mut env.write_pipe(self.output).unwrap(),
-                    &gfa,
-                    depths,
-                    uniq_depths,
-                    gfa.paths.ids(),
-                )
-                .unwrap(),
+            match env.output(self.output) {
+                Output::Stdout(mut s) => {
+                    ops::depth::write_path_depth(&mut s, &gfa, depths, uniq_depths, gfa.paths.ids())
+                        .unwrap()
+                }
+                Output::File(mut s) => {
+                    ops::depth::write_path_depth(&mut s, &gfa, depths, uniq_depths, gfa.paths.ids())
+                        .unwrap()
+                }
+                Output::Pipe(mut s) => {
+                    ops::depth::write_path_depth(&mut s, &gfa, depths, uniq_depths, gfa.paths.ids())
+                        .unwrap()
+                }
             }
         }
     }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -100,6 +100,16 @@ enum Output {
     Pipe(BufWriter<PipeWriter>),
 }
 
+impl Output {
+    fn emit<T: Emit>(self, val: T) -> std::io::Result<()> {
+        match self {
+            Self::Stdout(mut s) => val.emit(&mut s),
+            Self::File(mut s) => val.emit(&mut s),
+            Self::Pipe(mut s) => val.emit(&mut s),
+        }
+    }
+}
+
 trait Eval {
     fn eval(&self, env: &mut Env);
 }
@@ -119,28 +129,13 @@ impl Eval for ir::NodeDepthInstr {
         let store = env.parse_gfa(self.input);
         let gfa = store.as_ref();
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
-
-        match env.output(self.output) {
-            Output::Stdout(mut s) => ops::depth::SegDepth {
+        env.output(self.output)
+            .emit(ops::depth::SegDepth {
                 gfa: &gfa,
                 depths,
                 uniq_depths,
-            }
-            .emit(&mut s),
-            Output::File(mut s) => ops::depth::SegDepth {
-                gfa: &gfa,
-                depths,
-                uniq_depths,
-            }
-            .emit(&mut s),
-            Output::Pipe(mut s) => ops::depth::SegDepth {
-                gfa: &gfa,
-                depths,
-                uniq_depths,
-            }
-            .emit(&mut s),
-        }
-        .unwrap();
+            })
+            .unwrap();
     }
 }
 
@@ -154,58 +149,24 @@ impl Eval for ir::PathDepthInstr {
                 .find_path(path_name.as_bytes().into())
                 .expect("no such path found");
             let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
-
-            match env.output(self.output) {
-                Output::Stdout(mut s) => ops::depth::PathDepth {
+            env.output(self.output)
+                .emit(ops::depth::PathDepth {
                     gfa: &gfa,
                     depths,
                     lengths,
                     paths: std::iter::once(path_id),
-                }
-                .emit(&mut s),
-                Output::File(mut s) => ops::depth::PathDepth {
-                    gfa: &gfa,
-                    depths,
-                    lengths,
-                    paths: std::iter::once(path_id),
-                }
-                .emit(&mut s),
-                Output::Pipe(mut s) => ops::depth::PathDepth {
-                    gfa: &gfa,
-                    depths,
-                    lengths,
-                    paths: std::iter::once(path_id),
-                }
-                .emit(&mut s),
-            }
-            .unwrap();
+                })
+                .unwrap();
         } else {
             let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
-
-            match env.output(self.output) {
-                Output::Stdout(mut s) => ops::depth::PathDepth {
+            env.output(self.output)
+                .emit(ops::depth::PathDepth {
                     gfa: &gfa,
                     depths,
                     lengths,
                     paths: gfa.paths.ids(),
-                }
-                .emit(&mut s),
-                Output::File(mut s) => ops::depth::PathDepth {
-                    gfa: &gfa,
-                    depths,
-                    lengths,
-                    paths: gfa.paths.ids(),
-                }
-                .emit(&mut s),
-                Output::Pipe(mut s) => ops::depth::PathDepth {
-                    gfa: &gfa,
-                    depths,
-                    lengths,
-                    paths: gfa.paths.ids(),
-                }
-                .emit(&mut s),
-            }
-            .unwrap();
+                })
+                .unwrap();
         }
     }
 }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -85,9 +85,16 @@ impl Eval for ir::NodeDepthInstr {
     fn eval(&self, env: &mut Env) {
         let store = env.parse_gfa(self.input);
         let gfa = store.as_ref();
-        // TODO Do something about the output resource...
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
-        ops::depth::print_seg_depth(&gfa, depths, uniq_depths);
+
+        match env.rsrc[self.output.0] {
+            ir::Resource::Stdin => panic!("cannot write to stdin"),
+            ir::Resource::Stdout => {
+                ops::depth::write_seg_depth(&mut std::io::stdout(), &gfa, depths, uniq_depths)
+                    .unwrap()
+            }
+            _ => unimplemented!(),
+        }
     }
 }
 
@@ -101,10 +108,34 @@ impl Eval for ir::PathDepthInstr {
                 .find_path(path_name.as_bytes().into())
                 .expect("no such path found");
             let (depths, uniq_depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
-            ops::depth::print_path_depth(&gfa, depths, uniq_depths, std::iter::once(path_id));
+
+            match env.rsrc[self.output.0] {
+                ir::Resource::Stdin => panic!("cannot write to stdin"),
+                ir::Resource::Stdout => ops::depth::write_path_depth(
+                    &mut std::io::stdout(),
+                    &gfa,
+                    depths,
+                    uniq_depths,
+                    std::iter::once(path_id),
+                )
+                .unwrap(),
+                _ => unimplemented!(),
+            }
         } else {
             let (depths, uniq_depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
-            ops::depth::print_path_depth(&gfa, depths, uniq_depths, gfa.paths.ids());
+
+            match env.rsrc[self.output.0] {
+                ir::Resource::Stdin => panic!("cannot write to stdin"),
+                ir::Resource::Stdout => ops::depth::write_path_depth(
+                    &mut std::io::stdout(),
+                    &gfa,
+                    depths,
+                    uniq_depths,
+                    gfa.paths.ids(),
+                )
+                .unwrap(),
+                _ => unimplemented!(),
+            }
         }
     }
 }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,6 +1,6 @@
 use crate::ir::{self, ResourceRef};
 use flatgfa::{self, flatgfa::HeapGFAStore, memfile, ops};
-use std::io::{self, PipeReader, PipeWriter};
+use std::io::{self, BufReader, PipeReader, PipeWriter};
 
 struct Env {
     /// All the resource descriptions used in this program.
@@ -45,6 +45,26 @@ impl Env {
             Ok(writer)
         }
     }
+
+    /// Parse a (text) GFA file from a resource.
+    fn parse_gfa(&mut self, rsrc: ir::ResourceRef) -> HeapGFAStore {
+        use flatgfa::parse::Parser;
+        match &self.rsrc[rsrc.0] {
+            ir::Resource::File(name) => {
+                let file = memfile::map_file(name);
+                Parser::for_heap().parse_mem(file.as_ref())
+            }
+            ir::Resource::Stdin => {
+                let stdin = std::io::stdin();
+                Parser::for_heap().parse_stream(stdin.lock())
+            }
+            ir::Resource::Stdout => panic!("cannot read from stdout"),
+            ir::Resource::Pipe => {
+                let read = self.read_pipe(rsrc).unwrap();
+                Parser::for_heap().parse_stream(BufReader::new(read))
+            }
+        }
+    }
 }
 
 trait Eval {
@@ -61,25 +81,9 @@ impl Eval for ir::Instr {
     }
 }
 
-/// Parse a (text) GFA file from a resource.
-fn parse_gfa(rsrc: &ir::Resource) -> HeapGFAStore {
-    use flatgfa::parse::Parser;
-    match rsrc {
-        ir::Resource::File(name) => {
-            let file = memfile::map_file(name);
-            Parser::for_heap().parse_mem(file.as_ref())
-        }
-        ir::Resource::Stdin => {
-            let stdin = std::io::stdin();
-            Parser::for_heap().parse_stream(stdin.lock())
-        }
-        _ => unimplemented!(),
-    }
-}
-
 impl Eval for ir::NodeDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = parse_gfa(&env.rsrc[self.input.0]);
+        let store = env.parse_gfa(self.input);
         let gfa = store.as_ref();
         // TODO Do something about the output resource...
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
@@ -89,7 +93,7 @@ impl Eval for ir::NodeDepthInstr {
 
 impl Eval for ir::PathDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = parse_gfa(&env.rsrc[self.input.0]);
+        let store = env.parse_gfa(self.input);
         let gfa = store.as_ref();
         if let Some(path_name) = &self.path {
             // TODO More elegantly handle missing paths.

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -5,6 +5,7 @@ pub enum Resource {
     File(String),
     Stdin,
     Stdout,
+    Pipe,
 }
 
 /// An instruction performs one imperative action.

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -101,10 +101,17 @@ impl Builder {
         }
     }
 
+    /// Create a new pipe resource.
+    pub fn pipe(&mut self) -> ResourceRef {
+        self.add_rsrc(Resource::Pipe)
+    }
+
+    /// Get the standard input resource.
     pub fn stdin(&self) -> ResourceRef {
         ResourceRef(0)
     }
 
+    /// Get the standard output resource.
     pub fn stdout(&self) -> ResourceRef {
         ResourceRef(1)
     }

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::ir::{self, Builder};
+use crate::ir::{self, Builder, ResourceRef};
 use flash::parser::{Node, Redirect, RedirectKind};
 use pico_args::Arguments;
 
@@ -11,10 +11,17 @@ pub fn parse_sh(input: &str) -> Node {
     parser.parse_script()
 }
 
-fn cmd_to_ir(builder: &mut Builder, name: String, args: Vec<String>, redirects: Vec<Redirect>) {
+fn cmd_to_ir(
+    builder: &mut Builder,
+    name: String,
+    args: Vec<String>,
+    redirects: Vec<Redirect>,
+    input: ResourceRef,
+    output: ResourceRef,
+) {
     // Do the input or output come from stream redirections?
-    let mut input = builder.stdin();
-    let mut output = builder.stdout();
+    let mut input = input;
+    let mut output = output;
     for redirect in redirects {
         match redirect.kind {
             RedirectKind::Input => input = builder.file(redirect.file),
@@ -59,22 +66,31 @@ fn cmd_to_ir(builder: &mut Builder, name: String, args: Vec<String>, redirects: 
     }
 }
 
-fn node_to_ir(builder: &mut Builder, node: Node) {
+fn node_to_ir(builder: &mut Builder, node: Node, input: ResourceRef, output: ResourceRef) {
     match node {
+        Node::Command {
+            name,
+            args,
+            redirects,
+        } => cmd_to_ir(builder, name, args, redirects, input, output),
+        Node::Comment(_) => (),
+        Node::Pipeline { commands } => {
+            // Step through the pipeline and construct a pipe
+            // between each consecutive pair.
+            let mut input = input;
+            let last = commands.len() - 1;
+            for (i, step) in commands.into_iter().enumerate() {
+                let output = if i == last { output } else { builder.pipe() };
+                node_to_ir(builder, step, input, output);
+                input = output; // Feed this pipe into the next step.
+            }
+        }
         Node::List {
             statements,
             operators: _,
         } => {
             for statement in statements {
-                match statement {
-                    Node::Command {
-                        name,
-                        args,
-                        redirects,
-                    } => cmd_to_ir(builder, name, args, redirects),
-                    Node::Comment(_) => (),
-                    _ => unimplemented!(),
-                }
+                node_to_ir(builder, statement, input, output);
             }
         }
         _ => unimplemented!(),
@@ -83,6 +99,8 @@ fn node_to_ir(builder: &mut Builder, node: Node) {
 
 pub fn sh_to_ir(shell: Node) -> ir::Program {
     let mut builder = ir::Builder::new();
-    node_to_ir(&mut builder, shell);
+    let stdin = builder.stdin();
+    let stdout = builder.stdout();
+    node_to_ir(&mut builder, shell, stdin, stdout);
     builder.build()
 }

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -30,8 +30,14 @@ impl Display for Wrapped<'_, ir::Instr> {
 
 impl Display for Wrapped<'_, ir::ResourceRef> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let rsrc = &self.rsrc[self.val.0];
-        rsrc.fmt(f)
+        let idx = self.val.0;
+        let rsrc = &self.rsrc[idx];
+        match rsrc {
+            ir::Resource::File(name) => write!(f, "\"{}\"", name),
+            ir::Resource::Stdin => write!(f, "stdin"),
+            ir::Resource::Stdout => write!(f, "stdout"),
+            ir::Resource::Pipe => write!(f, "pipe-{}", idx),
+        }
     }
 }
 
@@ -82,15 +88,5 @@ impl Display for ir::Program {
             )?;
         }
         Ok(())
-    }
-}
-
-impl Display for ir::Resource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            ir::Resource::File(name) => write!(f, "\"{}\"", name),
-            ir::Resource::Stdin => write!(f, "stdin"),
-            ir::Resource::Stdout => write!(f, "stdout"),
-        }
     }
 }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -1,3 +1,4 @@
+use crate::emit::Emit;
 use crate::flatbed::BEDParser;
 use crate::flatgfa::{self, Segment};
 use crate::memfile::{self, map_file};
@@ -227,7 +228,7 @@ pub struct Depth {
 }
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
-    use crate::ops::depth::{path_depth, seg_depth, Emit, PathDepth, SegDepth};
+    use crate::ops::depth::{path_depth, seg_depth, PathDepth, SegDepth};
     if args.seg_depth {
         // Segment depth table.
         let (depths, uniq_depths) = seg_depth(gfa);

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -227,16 +227,17 @@ pub struct Depth {
 }
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
+    let mut out = std::io::stdout();
     if args.seg_depth {
         // Segment depth table.
         let (depths, uniq_depths) = ops::depth::seg_depth(gfa);
-        ops::depth::print_seg_depth(gfa, depths, uniq_depths);
+        ops::depth::write_seg_depth(&mut out, gfa, depths, uniq_depths).unwrap();
     } else {
         // Path depth table.
         if args.path.is_empty() {
             // All paths.
             let (lengths, depths) = ops::depth::path_depth(gfa, gfa.paths.ids());
-            ops::depth::print_path_depth(gfa, lengths, depths, gfa.paths.ids());
+            ops::depth::write_path_depth(&mut out, gfa, lengths, depths, gfa.paths.ids()).unwrap();
         } else {
             // A subset of paths.
             let path_ids: Vec<_> = args
@@ -245,7 +246,8 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
                 .filter_map(|n| gfa.find_path(n.as_ref()))
                 .collect();
             let (lengths, depths) = ops::depth::path_depth(gfa, path_ids.iter().copied());
-            ops::depth::print_path_depth(gfa, lengths, depths, path_ids.iter().copied());
+            ops::depth::write_path_depth(&mut out, gfa, lengths, depths, path_ids.iter().copied())
+                .unwrap();
         }
     }
 }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -227,17 +227,28 @@ pub struct Depth {
 }
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
-    let mut out = std::io::stdout();
+    use crate::ops::depth::{path_depth, seg_depth, Emit, PathDepth, SegDepth};
     if args.seg_depth {
         // Segment depth table.
-        let (depths, uniq_depths) = ops::depth::seg_depth(gfa);
-        ops::depth::write_seg_depth(&mut out, gfa, depths, uniq_depths).unwrap();
+        let (depths, uniq_depths) = seg_depth(gfa);
+        SegDepth {
+            gfa,
+            depths,
+            uniq_depths,
+        }
+        .print();
     } else {
         // Path depth table.
         if args.path.is_empty() {
             // All paths.
-            let (lengths, depths) = ops::depth::path_depth(gfa, gfa.paths.ids());
-            ops::depth::write_path_depth(&mut out, gfa, lengths, depths, gfa.paths.ids()).unwrap();
+            let (lengths, depths) = path_depth(gfa, gfa.paths.ids());
+            PathDepth {
+                gfa,
+                lengths,
+                depths,
+                paths: gfa.paths.ids(),
+            }
+            .print();
         } else {
             // A subset of paths.
             let path_ids: Vec<_> = args
@@ -245,9 +256,14 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
                 .into_iter()
                 .filter_map(|n| gfa.find_path(n.as_ref()))
                 .collect();
-            let (lengths, depths) = ops::depth::path_depth(gfa, path_ids.iter().copied());
-            ops::depth::write_path_depth(&mut out, gfa, lengths, depths, path_ids.iter().copied())
-                .unwrap();
+            let (lengths, depths) = path_depth(gfa, path_ids.iter().copied());
+            PathDepth {
+                gfa,
+                lengths,
+                depths,
+                paths: path_ids.iter().copied(),
+            }
+            .print();
         }
     }
 }

--- a/flatgfa/src/emit.rs
+++ b/flatgfa/src/emit.rs
@@ -1,0 +1,19 @@
+use std::io::{Result, Write};
+
+/// Something that can be consumed and serialized as bytes.
+///
+/// This trait is sorta like `std::fmt::Display`, but it consumes the thing
+/// being printed. This can be useful for temporary structs that would be
+/// expensive to keep around beyond a single emission.
+pub trait Emit {
+    /// Write the value a stream.
+    fn emit(self, f: &mut impl Write) -> Result<()>;
+
+    /// Write the value to stdout.
+    fn print(self)
+    where
+        Self: Sized,
+    {
+        self.emit(&mut std::io::stdout().lock()).unwrap();
+    }
+}

--- a/flatgfa/src/lib.rs
+++ b/flatgfa/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod emit;
 pub mod file;
 pub mod flatbed;
 pub mod flatgfa;

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -38,17 +38,24 @@ pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
 /// Print a segment depth table.
 ///
 /// Format the result of `seg_depth` in an odgi-style TSV.
-pub fn print_seg_depth(gfa: &flatgfa::FlatGFA, depths: Vec<usize>, uniq_depths: Vec<usize>) {
-    println!("#node.id\tdepth\tdepth.uniq");
+pub fn write_seg_depth(
+    out: &mut impl std::io::Write,
+    gfa: &flatgfa::FlatGFA,
+    depths: Vec<usize>,
+    uniq_depths: Vec<usize>,
+) -> std::io::Result<()> {
+    writeln!(out, "#node.id\tdepth\tdepth.uniq")?;
     for (id, seg) in gfa.segs.items() {
         let name: u32 = seg.name as u32;
-        println!(
+        writeln!(
+            out,
             "{}\t{}\t{}",
             name,
             depths[id.index()],
             uniq_depths[id.index()],
-        );
+        )?;
     }
+    Ok(())
 }
 
 /// Compute the mean depth of each *path* in the variation graph.
@@ -103,19 +110,27 @@ fn measure_path(
 /// Print a path depth table.
 ///
 /// Format the result of `path_depth` in an odgi-style TSV.
-pub fn print_path_depth<I>(gfa: &flatgfa::FlatGFA, lengths: Vec<usize>, depths: Vec<f64>, paths: I)
+pub fn write_path_depth<I>(
+    out: &mut impl std::io::Write,
+    gfa: &flatgfa::FlatGFA,
+    lengths: Vec<usize>,
+    depths: Vec<f64>,
+    paths: I,
+) -> std::io::Result<()>
 where
     I: Iterator<Item = Id<flatgfa::Path>>,
 {
-    println!("#path\tstart\tend\tmean.depth");
+    writeln!(out, "#path\tstart\tend\tmean.depth")?;
     for (idx, id) in paths.enumerate() {
-        println!(
+        writeln!(
+            out,
             "{}\t0\t{}\t{}",
             gfa.get_path_name(&gfa.paths[id]),
             lengths[idx],
             format_float(depths[idx]),
-        );
+        )?;
     }
+    Ok(())
 }
 
 /// Format an `f64` in an odgi-like way, with limited decimal digits and without

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,3 +1,4 @@
+use crate::emit::Emit;
 use crate::flatgfa;
 use crate::pool::Id;
 use bit_vec::BitVec;
@@ -34,18 +35,6 @@ pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     }
 
     (depths, uniq_depths)
-}
-
-/// Sorta like `std::fmt::Display`, but consumes the thing being printed.
-pub trait Emit {
-    fn emit(self, f: &mut impl Write) -> std::io::Result<()>;
-
-    fn print(self)
-    where
-        Self: Sized,
-    {
-        self.emit(&mut std::io::stdout().lock()).unwrap();
-    }
 }
 
 /// A printable segment depth table.

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,6 +1,7 @@
 use crate::flatgfa;
 use crate::pool::Id;
 use bit_vec::BitVec;
+use std::io::Write;
 
 /// Compute the *depth* of each segment in the variation graph.
 ///
@@ -35,27 +36,42 @@ pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     (depths, uniq_depths)
 }
 
-/// Print a segment depth table.
-///
-/// Format the result of `seg_depth` in an odgi-style TSV.
-pub fn write_seg_depth(
-    out: &mut impl std::io::Write,
-    gfa: &flatgfa::FlatGFA,
-    depths: Vec<usize>,
-    uniq_depths: Vec<usize>,
-) -> std::io::Result<()> {
-    writeln!(out, "#node.id\tdepth\tdepth.uniq")?;
-    for (id, seg) in gfa.segs.items() {
-        let name: u32 = seg.name as u32;
-        writeln!(
-            out,
-            "{}\t{}\t{}",
-            name,
-            depths[id.index()],
-            uniq_depths[id.index()],
-        )?;
+/// Sorta like `std::fmt::Display`, but consumes the thing being printed.
+pub trait Emit {
+    fn emit(self, f: &mut impl Write) -> std::io::Result<()>;
+
+    fn print(self)
+    where
+        Self: Sized,
+    {
+        self.emit(&mut std::io::stdout().lock()).unwrap();
     }
-    Ok(())
+}
+
+/// A printable segment depth table.
+///
+/// Formats the result of `seg_depth` in an odgi-style TSV.
+pub struct SegDepth<'a> {
+    pub gfa: &'a flatgfa::FlatGFA<'a>,
+    pub depths: Vec<usize>,
+    pub uniq_depths: Vec<usize>,
+}
+
+impl<'a> Emit for SegDepth<'a> {
+    fn emit(self, f: &mut impl Write) -> std::io::Result<()> {
+        writeln!(f, "#node.id\tdepth\tdepth.uniq")?;
+        for (id, seg) in self.gfa.segs.items() {
+            let name: u32 = seg.name as u32;
+            writeln!(
+                f,
+                "{}\t{}\t{}",
+                name,
+                self.depths[id.index()],
+                self.uniq_depths[id.index()],
+            )?;
+        }
+        Ok(())
+    }
 }
 
 /// Compute the mean depth of each *path* in the variation graph.
@@ -107,30 +123,33 @@ fn measure_path(
     (length, avg_depth)
 }
 
-/// Print a path depth table.
+/// A printable path depth table.
 ///
-/// Format the result of `path_depth` in an odgi-style TSV.
-pub fn write_path_depth<I>(
-    out: &mut impl std::io::Write,
-    gfa: &flatgfa::FlatGFA,
-    lengths: Vec<usize>,
-    depths: Vec<f64>,
-    paths: I,
-) -> std::io::Result<()>
+/// Formats the result of `path_depth` in an odgi-style TSV.
+pub struct PathDepth<'a, I: Iterator<Item = Id<flatgfa::Path>>> {
+    pub gfa: &'a flatgfa::FlatGFA<'a>,
+    pub lengths: Vec<usize>,
+    pub depths: Vec<f64>,
+    pub paths: I,
+}
+
+impl<'a, I> Emit for PathDepth<'a, I>
 where
     I: Iterator<Item = Id<flatgfa::Path>>,
 {
-    writeln!(out, "#path\tstart\tend\tmean.depth")?;
-    for (idx, id) in paths.enumerate() {
-        writeln!(
-            out,
-            "{}\t0\t{}\t{}",
-            gfa.get_path_name(&gfa.paths[id]),
-            lengths[idx],
-            format_float(depths[idx]),
-        )?;
+    fn emit(self, f: &mut impl Write) -> std::io::Result<()> {
+        writeln!(f, "#path\tstart\tend\tmean.depth")?;
+        for (idx, id) in self.paths.enumerate() {
+            writeln!(
+                f,
+                "{}\t0\t{}\t{}",
+                self.gfa.get_path_name(&self.gfa.paths[id]),
+                self.lengths[idx],
+                format_float(self.depths[idx]),
+            )?;
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 /// Format an `f64` in an odgi-like way, with limited decimal digits and without


### PR DESCRIPTION
Now you can do stuff like `foo | bar > baz` in flash. This includes mixing and matching external commands and built-in (faked odgi) commands. So, as the README demonstrates, this works:

```
odgi depth -d -i ../tests/note5.gfa | tail -n1
```

This is an item in #254.