### PR TITLE
flash: Support FlatGFA input files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ version = "0.1.0"
 dependencies = [
  "flash",
  "flatgfa",
+ "memmap",
  "pico-args",
  "rustyline",
  "trycmd",

--- a/flatgfa-sh/Cargo.toml
+++ b/flatgfa-sh/Cargo.toml
@@ -12,6 +12,7 @@ flatgfa = { path = "../flatgfa" }
 flash = "0.0.6"
 pico-args = "0.5"
 rustyline = "18"
+memmap = { workspace = true }
 
 [dev-dependencies]
 trycmd = "1.2.0"

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -103,3 +103,13 @@ shell("bar", [], input=pipe-2) -> pipe-3
 shell("baz", [], input=pipe-3) -> "qux"
 
 ```
+
+Flash also detects FlatGFA files (by filename extension) everywhere that an
+input GFA is allowed:
+
+```console
+$ flash -p -c 'odgi depth -i chr8.flatgfa'
+map-file("chr8.flatgfa") -> mmap-3
+path-depth(mmap-3) -> stdout
+
+```

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -69,23 +69,23 @@ Here are some things that we currently parse:
 ```console
 $ flash -p -c 'odgi depth'
 parse-gfa(stdin) -> gfa-store-2
-path_depth(gfa-store-2) -> stdout
+path-depth(gfa-store-2) -> stdout
 
 $ flash -p -c 'odgi depth -d'
 parse-gfa(stdin) -> gfa-store-2
-node_depth(gfa-store-2) -> stdout
+node-depth(gfa-store-2) -> stdout
 
 $ flash -p -c 'odgi depth -i chr8.gfa'
 parse-gfa("chr8.gfa") -> gfa-store-3
-path_depth(gfa-store-3) -> stdout
+path-depth(gfa-store-3) -> stdout
 
 $ flash -p -c 'odgi depth -i chr8.gfa -r "chm13#chr8"'
 parse-gfa("chr8.gfa") -> gfa-store-3
-path_depth(gfa-store-3, path="chm13#chr8") -> stdout
+path-depth(gfa-store-3, path="chm13#chr8") -> stdout
 
 $ flash -p -c 'odgi depth < chr8.gfa > depth.tsv'
 parse-gfa("chr8.gfa") -> gfa-store-4
-path_depth(gfa-store-4) -> "depth.tsv"
+path-depth(gfa-store-4) -> "depth.tsv"
 
 ```
 

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -68,19 +68,24 @@ Here are some things that we currently parse:
 
 ```console
 $ flash -p -c 'odgi depth'
-path_depth(stdin) -> stdout
+parse-gfa(stdin) -> gfa-store-2
+path_depth(gfa-store-2) -> stdout
 
 $ flash -p -c 'odgi depth -d'
-node_depth(stdin) -> stdout
+parse-gfa(stdin) -> gfa-store-2
+node_depth(gfa-store-2) -> stdout
 
 $ flash -p -c 'odgi depth -i chr8.gfa'
-path_depth("chr8.gfa") -> stdout
+parse-gfa("chr8.gfa") -> gfa-store-3
+path_depth(gfa-store-3) -> stdout
 
 $ flash -p -c 'odgi depth -i chr8.gfa -r "chm13#chr8"'
-path_depth("chr8.gfa", path="chm13#chr8") -> stdout
+parse-gfa("chr8.gfa") -> gfa-store-3
+path_depth(gfa-store-3, path="chm13#chr8") -> stdout
 
 $ flash -p -c 'odgi depth < chr8.gfa > depth.tsv'
-path_depth("chr8.gfa") -> "depth.tsv"
+parse-gfa("chr8.gfa") -> gfa-store-4
+path_depth(gfa-store-4) -> "depth.tsv"
 
 ```
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -14,13 +14,25 @@ struct Env {
     /// these slots when the first instruction uses the pipe. The first use of
     /// either "side" of the pipe consumes it.
     pipes: Vec<(Option<PipeReader>, Option<PipeWriter>)>,
+
+    /// The currently available FlatGFA data stores.
+    ///
+    /// As with `pipes`, the length should be the same as for `rsrc`. This is
+    /// `Some` for every resource that is `GFAStore`.
+    gfa_stores: Vec<Option<HeapGFAStore>>,
 }
 
 impl Env {
     fn new(rsrc: Vec<Resource>) -> Self {
         let mut pipes = Vec::with_capacity(rsrc.len());
         pipes.resize_with(rsrc.len(), Default::default);
-        Self { rsrc, pipes }
+        let mut gfa_stores = Vec::with_capacity(rsrc.len());
+        gfa_stores.resize_with(rsrc.len(), Default::default);
+        Self {
+            rsrc,
+            pipes,
+            gfa_stores,
+        }
     }
 
     fn read_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeReader> {
@@ -54,6 +66,7 @@ impl Env {
             Resource::Stdout => panic!("cannot read from stdout"),
             Resource::File(name) => Input::File(BufReader::new(File::open(name).unwrap())),
             Resource::Pipe => Input::Pipe(BufReader::new(self.read_pipe(rsrc).unwrap())),
+            Resource::GFAStore => panic!("non-bytes input"),
         }
     }
 
@@ -63,27 +76,20 @@ impl Env {
             Resource::Stdout => Output::Stdout(std::io::stdout().lock()),
             Resource::File(name) => Output::File(BufWriter::new(File::create(name).unwrap())),
             Resource::Pipe => Output::Pipe(BufWriter::new(self.write_pipe(rsrc).unwrap())),
+            Resource::GFAStore => panic!("non-bytes output"),
         }
     }
 
-    /// Parse a (text) GFA file from a resource.
-    fn parse_gfa(&mut self, rsrc: ResourceRef) -> HeapGFAStore {
-        use flatgfa::parse::Parser;
-        match &self.rsrc[rsrc.0] {
-            Resource::File(name) => {
-                let file = memfile::map_file(name);
-                Parser::for_heap().parse_mem(file.as_ref())
-            }
-            Resource::Stdin => {
-                let stdin = std::io::stdin();
-                Parser::for_heap().parse_stream(stdin.lock())
-            }
-            Resource::Stdout => panic!("cannot read from stdout"),
-            Resource::Pipe => {
-                let read = self.read_pipe(rsrc).unwrap();
-                Parser::for_heap().parse_stream(BufReader::new(read))
-            }
-        }
+    fn get_store(&mut self, rsrc: ResourceRef) -> HeapGFAStore {
+        // TODO With some finer-grained structs, there's probably no need to
+        // take ownership here, which would let us reuse the resource.
+        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::GFAStore));
+        self.gfa_stores[rsrc.0].take().expect("store not populated")
+    }
+
+    fn set_store(&mut self, rsrc: ResourceRef, store: HeapGFAStore) {
+        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::GFAStore));
+        self.gfa_stores[rsrc.0] = Some(store);
     }
 }
 
@@ -120,13 +126,14 @@ impl Eval for ir::Instr {
             Self::NodeDepth(instr) => instr.eval(env),
             Self::PathDepth(instr) => instr.eval(env),
             Self::Exec(instr) => instr.eval(env),
+            Self::ParseGFA(instr) => instr.eval(env),
         }
     }
 }
 
 impl Eval for ir::NodeDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = env.parse_gfa(self.input);
+        let store = env.get_store(self.input);
         let gfa = store.as_ref();
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
         env.output(self.output)
@@ -141,7 +148,7 @@ impl Eval for ir::NodeDepthInstr {
 
 impl Eval for ir::PathDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = env.parse_gfa(self.input);
+        let store = env.get_store(self.input);
         let gfa = store.as_ref();
         if let Some(path_name) = &self.path {
             // TODO More elegantly handle missing paths.
@@ -188,6 +195,7 @@ impl Eval for ir::ExecInstr {
             Resource::Pipe => {
                 cmd.stdin(env.read_pipe(self.input).unwrap());
             }
+            Resource::GFAStore => panic!("non-bytes input"),
         }
 
         match &env.rsrc[self.output.0] {
@@ -199,10 +207,36 @@ impl Eval for ir::ExecInstr {
             Resource::Pipe => {
                 cmd.stdout(env.write_pipe(self.output).unwrap());
             }
+            Resource::GFAStore => panic!("non-bytes output"),
         }
 
         // TODO: Do anything with the status?
         cmd.status().unwrap();
+    }
+}
+
+impl Eval for ir::ParseGFAInstr {
+    fn eval(&self, env: &mut Env) {
+        use flatgfa::parse::Parser;
+
+        let store = match &env.rsrc[self.input.0] {
+            Resource::File(name) => {
+                let file = memfile::map_file(name);
+                Parser::for_heap().parse_mem(file.as_ref())
+            }
+            Resource::Stdin => {
+                let stdin = std::io::stdin();
+                Parser::for_heap().parse_stream(stdin.lock())
+            }
+            Resource::Stdout => panic!("cannot read from stdout"),
+            Resource::Pipe => {
+                let read = env.read_pipe(self.input).unwrap();
+                Parser::for_heap().parse_stream(BufReader::new(read))
+            }
+            Resource::GFAStore => panic!("non-bytes input"),
+        };
+
+        env.set_store(self.output, store);
     }
 }
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,5 +1,6 @@
 use crate::ir::{self, Resource, ResourceRef};
 use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile, ops};
+use memmap::Mmap;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter};
 
@@ -26,6 +27,12 @@ struct Env {
     /// This is a heap vector (indexed by `idx`) for each resource that is a
     /// `GFAStore`.
     gfa_stores: Vec<Option<HeapGFAStore>>,
+
+    /// The currently memory-mapped files.
+    ///
+    /// This is a heap vector (indexed by `idx`) for each resource that is a
+    /// `Mmap`.
+    mmaps: Vec<Option<Mmap>>,
 }
 
 impl Env {
@@ -34,6 +41,7 @@ impl Env {
         let mut idx: Vec<u16> = Vec::with_capacity(rsrc.len());
         let mut pipes: Vec<(Option<PipeReader>, Option<PipeWriter>)> =
             Vec::with_capacity(rsrc.len());
+        let mut mmaps: Vec<Option<Mmap>> = Vec::with_capacity(rsrc.len());
         let mut gfa_stores: Vec<Option<HeapGFAStore>> = Vec::with_capacity(rsrc.len());
         for r in &rsrc {
             let i = match r {
@@ -45,6 +53,10 @@ impl Env {
                     gfa_stores.push(None);
                     (gfa_stores.len() - 1).try_into().unwrap()
                 }
+                Resource::Mmap => {
+                    mmaps.push(None);
+                    (mmaps.len() - 1).try_into().unwrap()
+                }
                 _ => u16::MAX,
             };
             idx.push(i);
@@ -55,6 +67,7 @@ impl Env {
             idx,
             pipes,
             gfa_stores,
+            mmaps,
         }
     }
 
@@ -66,6 +79,11 @@ impl Env {
     fn get_gfa_store(&mut self, rsrc: ResourceRef) -> &mut Option<HeapGFAStore> {
         debug_assert!(matches!(self.rsrc[rsrc.0], Resource::GFAStore));
         &mut self.gfa_stores[self.idx[rsrc.0] as usize]
+    }
+
+    fn get_mmap(&mut self, rsrc: ResourceRef) -> &mut Option<Mmap> {
+        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::Mmap));
+        &mut self.mmaps[self.idx[rsrc.0] as usize]
     }
 
     fn read_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeReader> {
@@ -97,7 +115,7 @@ impl Env {
             Resource::Stdout => panic!("cannot read from stdout"),
             Resource::File(name) => Input::File(BufReader::new(File::open(name).unwrap())),
             Resource::Pipe => Input::Pipe(BufReader::new(self.read_pipe(rsrc).unwrap())),
-            Resource::GFAStore => panic!("non-bytes input"),
+            _ => panic!("non-bytes input"),
         }
     }
 
@@ -107,7 +125,7 @@ impl Env {
             Resource::Stdout => Output::Stdout(std::io::stdout().lock()),
             Resource::File(name) => Output::File(BufWriter::new(File::create(name).unwrap())),
             Resource::Pipe => Output::Pipe(BufWriter::new(self.write_pipe(rsrc).unwrap())),
-            Resource::GFAStore => panic!("non-bytes output"),
+            _ => panic!("non-bytes output"),
         }
     }
 
@@ -158,7 +176,7 @@ impl Eval for ir::Instr {
             Self::PathDepth(instr) => instr.eval(env),
             Self::Exec(instr) => instr.eval(env),
             Self::ParseGFA(instr) => instr.eval(env),
-            Self::LoadFlatGFA(instr) => instr.eval(env),
+            Self::MapFile(instr) => instr.eval(env),
         }
     }
 }
@@ -227,7 +245,7 @@ impl Eval for ir::ExecInstr {
             Resource::Pipe => {
                 cmd.stdin(env.read_pipe(self.input).unwrap());
             }
-            Resource::GFAStore => panic!("non-bytes input"),
+            _ => panic!("non-bytes input"),
         }
 
         match &env.rsrc[self.output.0] {
@@ -239,7 +257,7 @@ impl Eval for ir::ExecInstr {
             Resource::Pipe => {
                 cmd.stdout(env.write_pipe(self.output).unwrap());
             }
-            Resource::GFAStore => panic!("non-bytes output"),
+            _ => panic!("non-bytes output"),
         }
 
         // TODO: Do anything with the status?
@@ -265,21 +283,20 @@ impl Eval for ir::ParseGFAInstr {
                 let read = env.read_pipe(self.input).unwrap();
                 Parser::for_heap().parse_stream(BufReader::new(read))
             }
-            Resource::GFAStore => panic!("non-bytes input"),
+            _ => panic!("non-bytes input"),
         };
 
         env.set_store(self.output, store);
     }
 }
 
-impl Eval for ir::LoadFlatGFAInstr {
+impl Eval for ir::MapFileInstr {
     fn eval(&self, env: &mut Env) {
         if let Resource::File(name) = &env.rsrc[self.input.0] {
             let mmap = memfile::map_file(&name);
-            let gfa = flatgfa::file::view(&mmap);
-            env.set_store(self.output, todo!());
+            *env.get_mmap(self.output) = Some(mmap);
         } else {
-            panic!("FlatGFAs can only come from files");
+            panic!("can only map actual files");
         }
     }
 }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -7,54 +7,85 @@ struct Env {
     /// All the resource descriptions used in this program.
     rsrc: Vec<Resource>,
 
+    /// Indices into the heap vectors for resources that have them.
+    ///
+    /// This has the same length as `rsrc`. For each resource type that comes
+    /// with an associated run-time value, this contains the index into the
+    /// appropriate heap vector in this environment. For others, it's MAX.
+    idx: Vec<u16>,
+
     /// The currently open Unix pipes for operations in this program.
     ///
-    /// This has the same length as `rsrc`. For every resource index that is a
-    /// `Pipe`, this may contain the currently open pipe. We lazily populate
-    /// these slots when the first instruction uses the pipe. The first use of
-    /// either "side" of the pipe consumes it.
+    /// This is a heap vector (indexed via `idx`) for each resource that is a
+    /// `Pipe`. We lazily populate these slots when the first instruction uses
+    /// the pipe. The first use of either "side" of the pipe consumes it.
     pipes: Vec<(Option<PipeReader>, Option<PipeWriter>)>,
 
     /// The currently available FlatGFA data stores.
     ///
-    /// As with `pipes`, the length should be the same as for `rsrc`. This is
-    /// `Some` for every resource that is `GFAStore`.
+    /// This is a heap vector (indexed by `idx`) for each resource that is a
+    /// `GFAStore`.
     gfa_stores: Vec<Option<HeapGFAStore>>,
 }
 
 impl Env {
     fn new(rsrc: Vec<Resource>) -> Self {
-        let mut pipes = Vec::with_capacity(rsrc.len());
-        pipes.resize_with(rsrc.len(), Default::default);
-        let mut gfa_stores = Vec::with_capacity(rsrc.len());
-        gfa_stores.resize_with(rsrc.len(), Default::default);
+        // Initialize the heap vectors and their indices.
+        let mut idx: Vec<u16> = Vec::with_capacity(rsrc.len());
+        let mut pipes: Vec<(Option<PipeReader>, Option<PipeWriter>)> =
+            Vec::with_capacity(rsrc.len());
+        let mut gfa_stores: Vec<Option<HeapGFAStore>> = Vec::with_capacity(rsrc.len());
+        for r in &rsrc {
+            let i = match r {
+                Resource::Pipe => {
+                    pipes.push((None, None));
+                    (pipes.len() - 1).try_into().unwrap()
+                }
+                Resource::GFAStore => {
+                    gfa_stores.push(None);
+                    (gfa_stores.len() - 1).try_into().unwrap()
+                }
+                _ => u16::MAX,
+            };
+            idx.push(i);
+        }
+
         Self {
             rsrc,
+            idx,
             pipes,
             gfa_stores,
         }
     }
 
+    fn get_pipe(&mut self, rsrc: ResourceRef) -> &mut (Option<PipeReader>, Option<PipeWriter>) {
+        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::Pipe));
+        &mut self.pipes[self.idx[rsrc.0] as usize]
+    }
+
+    fn get_gfa_store(&mut self, rsrc: ResourceRef) -> &mut Option<HeapGFAStore> {
+        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::GFAStore));
+        &mut self.gfa_stores[self.idx[rsrc.0] as usize]
+    }
+
     fn read_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeReader> {
-        let idx = rsrc.0;
-        debug_assert!(matches!(self.rsrc[idx], Resource::Pipe));
-        if let Some(reader) = self.pipes[idx].0.take() {
+        let pair = self.get_pipe(rsrc);
+        if let Some(reader) = pair.0.take() {
             Ok(reader)
         } else {
             let (reader, writer) = io::pipe()?;
-            self.pipes[idx].1 = Some(writer);
+            pair.1 = Some(writer);
             Ok(reader)
         }
     }
 
     fn write_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeWriter> {
-        let idx = rsrc.0;
-        debug_assert!(matches!(self.rsrc[idx], Resource::Pipe));
-        if let Some(writer) = self.pipes[idx].1.take() {
+        let pair = self.get_pipe(rsrc);
+        if let Some(writer) = pair.1.take() {
             Ok(writer)
         } else {
             let (reader, writer) = io::pipe()?;
-            self.pipes[idx].0 = Some(reader);
+            pair.0 = Some(reader);
             Ok(writer)
         }
     }
@@ -83,13 +114,13 @@ impl Env {
     fn get_store(&mut self, rsrc: ResourceRef) -> HeapGFAStore {
         // TODO With some finer-grained structs, there's probably no need to
         // take ownership here, which would let us reuse the resource.
-        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::GFAStore));
-        self.gfa_stores[rsrc.0].take().expect("store not populated")
+        let loc = self.get_gfa_store(rsrc);
+        loc.take().expect("store not populated")
     }
 
     fn set_store(&mut self, rsrc: ResourceRef, store: HeapGFAStore) {
-        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::GFAStore));
-        self.gfa_stores[rsrc.0] = Some(store);
+        let loc = self.get_gfa_store(rsrc);
+        *loc = Some(store);
     }
 }
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,4 +1,5 @@
 use crate::ir::{self, Resource, ResourceRef};
+use flatgfa::FlatGFA;
 use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile, ops};
 use memmap::Mmap;
 use std::fs::File;
@@ -128,6 +129,28 @@ impl Env {
             _ => panic!("non-bytes output"),
         }
     }
+
+    /// Get a FlatGFA data structure from the heap.
+    ///
+    /// The resource must be either a memory-mapped file or an in-memory
+    /// FlatGFA store.
+    fn flatgfa<'a>(&'a self, rsrc: ResourceRef) -> FlatGFA<'a> {
+        match &self.rsrc[rsrc.0] {
+            Resource::GFAStore => {
+                let store = self.gfa_stores[self.idx[rsrc.0] as usize]
+                    .as_ref()
+                    .expect("store not populated");
+                store.as_ref()
+            }
+            Resource::Mmap => {
+                let mmap = self.mmaps[self.idx[rsrc.0] as usize]
+                    .as_ref()
+                    .expect("mmap not populated");
+                flatgfa::file::view(mmap.as_ref())
+            }
+            _ => panic!("resource must be FlatGFA data"),
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -171,53 +194,44 @@ impl Eval for ir::Instr {
 
 impl Eval for ir::NodeDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = env
-            .get_gfa_store(self.input)
-            .take()
-            .expect("store not populated");
-        let gfa = store.as_ref();
+        let out = env.output(self.output);
+        let gfa = env.flatgfa(self.input);
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
-        env.output(self.output)
-            .emit(ops::depth::SegDepth {
-                gfa: &gfa,
-                depths,
-                uniq_depths,
-            })
-            .unwrap();
+        out.emit(ops::depth::SegDepth {
+            gfa: &gfa,
+            depths,
+            uniq_depths,
+        })
+        .unwrap();
     }
 }
 
 impl Eval for ir::PathDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = env
-            .get_gfa_store(self.input)
-            .take()
-            .expect("store not populated");
-        let gfa = store.as_ref();
+        let out = env.output(self.output);
+        let gfa = env.flatgfa(self.input);
         if let Some(path_name) = &self.path {
             // TODO More elegantly handle missing paths.
             let path_id = gfa
                 .find_path(path_name.as_bytes().into())
                 .expect("no such path found");
             let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
-            env.output(self.output)
-                .emit(ops::depth::PathDepth {
-                    gfa: &gfa,
-                    depths,
-                    lengths,
-                    paths: std::iter::once(path_id),
-                })
-                .unwrap();
+            out.emit(ops::depth::PathDepth {
+                gfa: &gfa,
+                depths,
+                lengths,
+                paths: std::iter::once(path_id),
+            })
+            .unwrap();
         } else {
             let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
-            env.output(self.output)
-                .emit(ops::depth::PathDepth {
-                    gfa: &gfa,
-                    depths,
-                    lengths,
-                    paths: gfa.paths.ids(),
-                })
-                .unwrap();
+            out.emit(ops::depth::PathDepth {
+                gfa: &gfa,
+                depths,
+                lengths,
+                paths: gfa.paths.ids(),
+            })
+            .unwrap();
         }
     }
 }

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -127,6 +127,7 @@ impl Eval for ir::Instr {
             Self::PathDepth(instr) => instr.eval(env),
             Self::Exec(instr) => instr.eval(env),
             Self::ParseGFA(instr) => instr.eval(env),
+            Self::LoadFlatGFA(instr) => instr.eval(env),
         }
     }
 }
@@ -237,6 +238,18 @@ impl Eval for ir::ParseGFAInstr {
         };
 
         env.set_store(self.output, store);
+    }
+}
+
+impl Eval for ir::LoadFlatGFAInstr {
+    fn eval(&self, env: &mut Env) {
+        if let Resource::File(name) = &env.rsrc[self.input.0] {
+            let mmap = memfile::map_file(&name);
+            let gfa = flatgfa::file::view(&mmap);
+            env.set_store(self.output, todo!());
+        } else {
+            panic!("FlatGFAs can only come from files");
+        }
     }
 }
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -128,18 +128,6 @@ impl Env {
             _ => panic!("non-bytes output"),
         }
     }
-
-    fn get_store(&mut self, rsrc: ResourceRef) -> HeapGFAStore {
-        // TODO With some finer-grained structs, there's probably no need to
-        // take ownership here, which would let us reuse the resource.
-        let loc = self.get_gfa_store(rsrc);
-        loc.take().expect("store not populated")
-    }
-
-    fn set_store(&mut self, rsrc: ResourceRef, store: HeapGFAStore) {
-        let loc = self.get_gfa_store(rsrc);
-        *loc = Some(store);
-    }
 }
 
 #[allow(dead_code)]
@@ -183,7 +171,10 @@ impl Eval for ir::Instr {
 
 impl Eval for ir::NodeDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = env.get_store(self.input);
+        let store = env
+            .get_gfa_store(self.input)
+            .take()
+            .expect("store not populated");
         let gfa = store.as_ref();
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
         env.output(self.output)
@@ -198,7 +189,10 @@ impl Eval for ir::NodeDepthInstr {
 
 impl Eval for ir::PathDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let store = env.get_store(self.input);
+        let store = env
+            .get_gfa_store(self.input)
+            .take()
+            .expect("store not populated");
         let gfa = store.as_ref();
         if let Some(path_name) = &self.path {
             // TODO More elegantly handle missing paths.
@@ -286,7 +280,7 @@ impl Eval for ir::ParseGFAInstr {
             _ => panic!("non-bytes input"),
         };
 
-        env.set_store(self.output, store);
+        *env.get_gfa_store(self.output) = Some(store);
     }
 }
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -287,7 +287,7 @@ impl Eval for ir::ParseGFAInstr {
 impl Eval for ir::MapFileInstr {
     fn eval(&self, env: &mut Env) {
         if let Resource::File(name) = &env.rsrc[self.input.0] {
-            let mmap = memfile::map_file(&name);
+            let mmap = memfile::map_file(name);
             *env.get_mmap(self.output) = Some(mmap);
         } else {
             panic!("can only map actual files");

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -6,6 +6,7 @@ pub enum Resource {
     Stdin,
     Stdout,
     Pipe,
+    GFAStore,
 }
 
 /// An instruction performs one imperative action.
@@ -14,6 +15,7 @@ pub enum Instr {
     NodeDepth(NodeDepthInstr),
     PathDepth(PathDepthInstr),
     Exec(ExecInstr),
+    ParseGFA(ParseGFAInstr),
 }
 
 #[derive(Debug)]
@@ -53,6 +55,19 @@ pub struct ExecInstr {
 impl From<ExecInstr> for Instr {
     fn from(value: ExecInstr) -> Self {
         Self::Exec(value)
+    }
+}
+
+/// Parse a GFA file or stream  in text foramt.
+#[derive(Debug)]
+pub struct ParseGFAInstr {
+    pub input: ResourceRef,
+    pub output: ResourceRef,
+}
+
+impl From<ParseGFAInstr> for Instr {
+    fn from(value: ParseGFAInstr) -> Self {
+        Self::ParseGFA(value)
     }
 }
 
@@ -106,6 +121,11 @@ impl Builder {
         self.add_rsrc(Resource::Pipe)
     }
 
+    /// Create a new FlatGFA data store resource.
+    pub fn gfa_store(&mut self) -> ResourceRef {
+        self.add_rsrc(Resource::GFAStore)
+    }
+
     /// Get the standard input resource.
     pub fn stdin(&self) -> ResourceRef {
         ResourceRef(0)
@@ -114,6 +134,16 @@ impl Builder {
     /// Get the standard output resource.
     pub fn stdout(&self) -> ResourceRef {
         ResourceRef(1)
+    }
+
+    /// Create an instruction to parse GFA text into a FlatGFA store.
+    ///
+    /// The input should be a plain-bytes resource. We return the output, which
+    /// is a FlatGFA store resource.
+    pub fn parse_gfa(&mut self, input: ResourceRef) -> ResourceRef {
+        let output = self.gfa_store();
+        self.add_instr(Instr::ParseGFA(ParseGFAInstr { input, output }));
+        output
     }
 
     pub fn build(self) -> Program {

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -7,6 +7,7 @@ pub enum Resource {
     Stdout,
     Pipe,
     GFAStore,
+    Mmap,
 }
 
 /// An instruction performs one imperative action.
@@ -16,7 +17,7 @@ pub enum Instr {
     PathDepth(PathDepthInstr),
     Exec(ExecInstr),
     ParseGFA(ParseGFAInstr),
-    LoadFlatGFA(LoadFlatGFAInstr),
+    MapFile(MapFileInstr),
 }
 
 #[derive(Debug)]
@@ -72,16 +73,16 @@ impl From<ParseGFAInstr> for Instr {
     }
 }
 
-/// Load an on-disk FlatGFA from a binary file.
+/// Memory-map a file: for instance, a FlatGFA binary file.
 #[derive(Debug)]
-pub struct LoadFlatGFAInstr {
+pub struct MapFileInstr {
     pub input: ResourceRef,
     pub output: ResourceRef,
 }
 
-impl From<LoadFlatGFAInstr> for Instr {
-    fn from(value: LoadFlatGFAInstr) -> Self {
-        Self::LoadFlatGFA(value)
+impl From<MapFileInstr> for Instr {
+    fn from(value: MapFileInstr) -> Self {
+        Self::MapFile(value)
     }
 }
 

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -141,6 +141,11 @@ impl Builder {
         self.add_rsrc(Resource::GFAStore)
     }
 
+    /// Create a new memory-mapped file resource.
+    pub fn mmap(&mut self) -> ResourceRef {
+        self.add_rsrc(Resource::Mmap)
+    }
+
     /// Get the standard input resource.
     pub fn stdin(&self) -> ResourceRef {
         ResourceRef(0)
@@ -151,14 +156,27 @@ impl Builder {
         ResourceRef(1)
     }
 
-    /// Create an instruction to parse GFA text into a FlatGFA store.
+    /// Create an instruction to load a FlatGFA data structure as a resource.
     ///
-    /// The input should be a plain-bytes resource. We return the output, which
-    /// is a FlatGFA store resource.
-    pub fn parse_gfa(&mut self, input: ResourceRef) -> ResourceRef {
-        let output = self.gfa_store();
-        self.add_instr(Instr::ParseGFA(ParseGFAInstr { input, output }));
-        output
+    /// Either parse GFA text or memory-map a FlatGFA binary file. If `input` is
+    /// a byte stream, we treat it as GFA text. If it's a file, we use the
+    /// filename to decide whether to treat it as GFA text or FlatGFA binary.
+    pub fn load_gfa(&mut self, input: ResourceRef) -> ResourceRef {
+        match &self.rsrc[input.0] {
+            Resource::File(name) if name.ends_with(".flatgfa") => {
+                // Memory-map the FlatGFA binary file.
+                let output = self.mmap();
+                self.add_instr(Instr::MapFile(MapFileInstr { input, output }));
+                output
+            }
+            Resource::Pipe | Resource::Stdin | Resource::File(_) => {
+                // Parse as GFA text.
+                let output = self.gfa_store();
+                self.add_instr(Instr::ParseGFA(ParseGFAInstr { input, output }));
+                output
+            }
+            _ => panic!("cannot parse this resource as GFA text"),
+        }
     }
 
     pub fn build(self) -> Program {

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -16,6 +16,7 @@ pub enum Instr {
     PathDepth(PathDepthInstr),
     Exec(ExecInstr),
     ParseGFA(ParseGFAInstr),
+    LoadFlatGFA(LoadFlatGFAInstr),
 }
 
 #[derive(Debug)]
@@ -68,6 +69,19 @@ pub struct ParseGFAInstr {
 impl From<ParseGFAInstr> for Instr {
     fn from(value: ParseGFAInstr) -> Self {
         Self::ParseGFA(value)
+    }
+}
+
+/// Load an on-disk FlatGFA from a binary file.
+#[derive(Debug)]
+pub struct LoadFlatGFAInstr {
+    pub input: ResourceRef,
+    pub output: ResourceRef,
+}
+
+impl From<LoadFlatGFAInstr> for Instr {
+    fn from(value: LoadFlatGFAInstr) -> Self {
+        Self::LoadFlatGFA(value)
     }
 }
 

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -40,8 +40,9 @@ fn cmd_to_ir(
                     input = builder.file(filename);
                 }
 
-                // Parse the GFA text to a FlatGFA store.
-                let input = builder.parse_gfa(input);
+                // Get a FlatGFA data structure, either by parsing GFA text or
+                // by memory-mapping a FlatGFA binary file.
+                let input = builder.load_gfa(input);
 
                 // In the `odgi depth` command line, the default is a per-path
                 // table, and `-d` switches to a per-node table. (There are

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -40,6 +40,9 @@ fn cmd_to_ir(
                     input = builder.file(filename);
                 }
 
+                // Parse the GFA text to a FlatGFA store.
+                let input = builder.parse_gfa(input);
+
                 // In the `odgi depth` command line, the default is a per-path
                 // table, and `-d` switches to a per-node table. (There are
                 // other modes, such as `-D`, to support...)

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -25,7 +25,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Instr::PathDepth(instr) => self.wrap(instr).fmt(f),
             ir::Instr::Exec(instr) => self.wrap(instr).fmt(f),
             ir::Instr::ParseGFA(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::LoadFlatGFA(instr) => self.wrap(instr).fmt(f),
+            ir::Instr::MapFile(instr) => self.wrap(instr).fmt(f),
         }
     }
 }
@@ -40,6 +40,7 @@ impl Display for Wrapped<'_, ir::ResourceRef> {
             ir::Resource::Stdout => write!(f, "stdout"),
             ir::Resource::Pipe => write!(f, "pipe-{}", idx),
             ir::Resource::GFAStore => write!(f, "gfa-store-{}", idx),
+            ir::Resource::Mmap => write!(f, "mmap-{}", idx),
         }
     }
 }
@@ -89,11 +90,11 @@ impl Display for Wrapped<'_, ir::ParseGFAInstr> {
     }
 }
 
-impl Display for Wrapped<'_, ir::LoadFlatGFAInstr> {
+impl Display for Wrapped<'_, ir::MapFileInstr> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "load-flat-gfa({}) -> {}",
+            "map-file({}) -> {}",
             self.wrap(&self.val.input),
             self.wrap(&self.val.output),
         )

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -25,6 +25,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Instr::PathDepth(instr) => self.wrap(instr).fmt(f),
             ir::Instr::Exec(instr) => self.wrap(instr).fmt(f),
             ir::Instr::ParseGFA(instr) => self.wrap(instr).fmt(f),
+            ir::Instr::LoadFlatGFA(instr) => self.wrap(instr).fmt(f),
         }
     }
 }
@@ -82,6 +83,17 @@ impl Display for Wrapped<'_, ir::ParseGFAInstr> {
         write!(
             f,
             "parse-gfa({}) -> {}",
+            self.wrap(&self.val.input),
+            self.wrap(&self.val.output),
+        )
+    }
+}
+
+impl Display for Wrapped<'_, ir::LoadFlatGFAInstr> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "load-flat-gfa({}) -> {}",
             self.wrap(&self.val.input),
             self.wrap(&self.val.output),
         )

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -24,6 +24,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Instr::NodeDepth(instr) => self.wrap(instr).fmt(f),
             ir::Instr::PathDepth(instr) => self.wrap(instr).fmt(f),
             ir::Instr::Exec(instr) => self.wrap(instr).fmt(f),
+            ir::Instr::ParseGFA(instr) => self.wrap(instr).fmt(f),
         }
     }
 }
@@ -37,6 +38,7 @@ impl Display for Wrapped<'_, ir::ResourceRef> {
             ir::Resource::Stdin => write!(f, "stdin"),
             ir::Resource::Stdout => write!(f, "stdout"),
             ir::Resource::Pipe => write!(f, "pipe-{}", idx),
+            ir::Resource::GFAStore => write!(f, "gfa-store-{}", idx),
         }
     }
 }
@@ -69,6 +71,17 @@ impl Display for Wrapped<'_, ir::ExecInstr> {
             "shell({:?}, {:?}, input={}) -> {}",
             self.val.command,
             self.val.args,
+            self.wrap(&self.val.input),
+            self.wrap(&self.val.output),
+        )
+    }
+}
+
+impl Display for Wrapped<'_, ir::ParseGFAInstr> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "parse-gfa({}) -> {}",
             self.wrap(&self.val.input),
             self.wrap(&self.val.output),
         )

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -47,7 +47,7 @@ impl Display for Wrapped<'_, ir::NodeDepthInstr> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "node_depth({}) -> {}",
+            "node-depth({}) -> {}",
             self.wrap(&self.val.input),
             self.wrap(&self.val.output),
         )
@@ -56,7 +56,7 @@ impl Display for Wrapped<'_, ir::NodeDepthInstr> {
 
 impl Display for Wrapped<'_, ir::PathDepthInstr> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "path_depth({}", self.wrap(&self.val.input))?;
+        write!(f, "path-depth({}", self.wrap(&self.val.input))?;
         if let Some(path) = &self.val.path {
             write!(f, ", path=\"{}\"", path)?;
         }


### PR DESCRIPTION
Our faked odgi commands can now transparently read (binary) FlatGFA files as well as they can text GFA files. We just use the filename extension to detect which to do. There is hopefully enough scaffolding here that other operators should have no trouble following the same pattern.

Architecturally, this required:
* Adding a separate "parse GFA text" instruction, instead of merging the parsing in with the actual operator.
* Also adding a separate "memory-map on-disk file" instruction.
* Adding two new resource types to track the results of the aforementioned instructions.

The upshot is that, assuming you've already done the conversion, these two commands should do the same thing:

```
flash -c 'odgi depth -i ../tests/note5.gfa'
flash -c 'odgi depth -i ../tests/note5.flatgfa'
```

Part of #254.