### PR TITLE
flash: Add `bedtools makewindows` faked command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
 name = "flatgfa-sh"
 version = "0.1.0"
 dependencies = [
+ "bstr",
  "flash",
  "flatgfa",
  "memmap",

--- a/flatgfa-sh/Cargo.toml
+++ b/flatgfa-sh/Cargo.toml
@@ -13,6 +13,7 @@ flash = "0.0.6"
 pico-args = "0.5"
 rustyline = "18"
 memmap = { workspace = true }
+bstr = { workspace = true }
 
 [dev-dependencies]
 trycmd = "1.2.0"

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -113,3 +113,16 @@ map-file("chr8.flatgfa") -> mmap-3
 path-depth(mmap-3) -> stdout
 
 ```
+
+
+Complicated Example
+-------------------
+
+Here's a shell script that uses a pipeline to combine `odgi depth` and
+`bedtools makewindows`.
+
+```console
+$ flash windows.sh
+5	0	4
+
+```

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,4 +1,5 @@
 use crate::ir::{self, Resource, ResourceRef};
+use bstr::BStr;
 use flatgfa::FlatGFA;
 use flatgfa::flatbed::HeapBEDStore;
 use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile, ops};
@@ -177,11 +178,11 @@ enum Output {
 }
 
 impl Output {
-    fn emit<T: Emit>(self, val: T) -> std::io::Result<()> {
-        match self {
-            Self::Stdout(mut s) => val.emit(&mut s),
-            Self::File(mut s) => val.emit(&mut s),
-            Self::Pipe(mut s) => val.emit(&mut s),
+    fn emit<T: Emit>(&mut self, val: T) -> std::io::Result<()> {
+        match *self {
+            Self::Stdout(ref mut s) => val.emit(s),
+            Self::File(ref mut s) => val.emit(s),
+            Self::Pipe(ref mut s) => val.emit(s),
         }
     }
 }
@@ -199,13 +200,14 @@ impl Eval for ir::Instr {
             Self::ParseGFA(instr) => instr.eval(env),
             Self::MapFile(instr) => instr.eval(env),
             Self::ParseBED(instr) => instr.eval(env),
+            Self::MakeWindows(instr) => instr.eval(env),
         }
     }
 }
 
 impl Eval for ir::NodeDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let out = env.output(self.output);
+        let mut out = env.output(self.output);
         let gfa = env.flatgfa(self.input);
         let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
         out.emit(ops::depth::SegDepth {
@@ -219,7 +221,7 @@ impl Eval for ir::NodeDepthInstr {
 
 impl Eval for ir::PathDepthInstr {
     fn eval(&self, env: &mut Env) {
-        let out = env.output(self.output);
+        let mut out = env.output(self.output);
         let gfa = env.flatgfa(self.input);
         if let Some(path_name) = &self.path {
             // TODO More elegantly handle missing paths.
@@ -342,6 +344,42 @@ impl Eval for ir::ParseBEDInstr {
         };
 
         *env.get_bed_store(self.output) = Some(store);
+    }
+}
+
+struct WindowsBed<'a> {
+    name: &'a BStr,
+    start: u64,
+    end: u64,
+    size: u64,
+}
+
+impl<'a> Emit for WindowsBed<'a> {
+    fn emit(self, f: &mut impl std::io::Write) -> io::Result<()> {
+        let mut pos = self.start;
+        while pos < self.end {
+            let end = (pos + self.size).min(self.end);
+            writeln!(f, "{}\t{}\t{}", self.name, pos, end)?;
+            pos = end;
+        }
+        Ok(())
+    }
+}
+
+impl Eval for ir::MakeWindowsInstr {
+    fn eval(&self, env: &mut Env) {
+        let store = env.get_bed_store(self.input).take().unwrap();
+        let bed = store.as_ref();
+        let mut out = env.output(self.output);
+        for entry in bed.entries.all() {
+            out.emit(WindowsBed {
+                name: bed.get_name_of_entry(entry),
+                start: entry.start,
+                end: entry.end,
+                size: self.size.try_into().unwrap(),
+            })
+            .unwrap();
+        }
     }
 }
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,5 +1,6 @@
 use crate::ir::{self, Resource, ResourceRef};
 use flatgfa::FlatGFA;
+use flatgfa::flatbed::HeapBEDStore;
 use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile, ops};
 use memmap::Mmap;
 use std::fs::File;
@@ -23,27 +24,26 @@ struct Env {
     /// the pipe. The first use of either "side" of the pipe consumes it.
     pipes: Vec<(Option<PipeReader>, Option<PipeWriter>)>,
 
-    /// The currently available FlatGFA data stores.
-    ///
-    /// This is a heap vector (indexed by `idx`) for each resource that is a
-    /// `GFAStore`.
+    /// A heap vector of currently available FlatGFA data stores.
     gfa_stores: Vec<Option<HeapGFAStore>>,
 
-    /// The currently memory-mapped files.
-    ///
-    /// This is a heap vector (indexed by `idx`) for each resource that is a
-    /// `Mmap`.
+    /// A heap vector of currently memory-mapped files.
     mmaps: Vec<Option<Mmap>>,
+
+    /// A heap vector of FlatBED stores.
+    bed_stores: Vec<Option<HeapBEDStore>>,
 }
 
 impl Env {
     fn new(rsrc: Vec<Resource>) -> Self {
         // Initialize the heap vectors and their indices.
+        // TODO Reduce some duplication here...
         let mut idx: Vec<u16> = Vec::with_capacity(rsrc.len());
         let mut pipes: Vec<(Option<PipeReader>, Option<PipeWriter>)> =
             Vec::with_capacity(rsrc.len());
         let mut mmaps: Vec<Option<Mmap>> = Vec::with_capacity(rsrc.len());
         let mut gfa_stores: Vec<Option<HeapGFAStore>> = Vec::with_capacity(rsrc.len());
+        let mut bed_stores: Vec<Option<HeapBEDStore>> = Vec::with_capacity(rsrc.len());
         for r in &rsrc {
             let i = match r {
                 Resource::Pipe => {
@@ -58,6 +58,10 @@ impl Env {
                     mmaps.push(None);
                     (mmaps.len() - 1).try_into().unwrap()
                 }
+                Resource::BEDStore => {
+                    bed_stores.push(None);
+                    (bed_stores.len() - 1).try_into().unwrap()
+                }
                 _ => u16::MAX,
             };
             idx.push(i);
@@ -69,6 +73,7 @@ impl Env {
             pipes,
             gfa_stores,
             mmaps,
+            bed_stores,
         }
     }
 
@@ -85,6 +90,11 @@ impl Env {
     fn get_mmap(&mut self, rsrc: ResourceRef) -> &mut Option<Mmap> {
         debug_assert!(matches!(self.rsrc[rsrc.0], Resource::Mmap));
         &mut self.mmaps[self.idx[rsrc.0] as usize]
+    }
+
+    fn get_bed_store(&mut self, rsrc: ResourceRef) -> &mut Option<HeapBEDStore> {
+        debug_assert!(matches!(self.rsrc[rsrc.0], Resource::BEDStore));
+        &mut self.bed_stores[self.idx[rsrc.0] as usize]
     }
 
     fn read_pipe(&mut self, rsrc: ResourceRef) -> io::Result<PipeReader> {
@@ -188,6 +198,7 @@ impl Eval for ir::Instr {
             Self::Exec(instr) => instr.eval(env),
             Self::ParseGFA(instr) => instr.eval(env),
             Self::MapFile(instr) => instr.eval(env),
+            Self::ParseBED(instr) => instr.eval(env),
         }
     }
 }
@@ -306,6 +317,31 @@ impl Eval for ir::MapFileInstr {
         } else {
             panic!("can only map actual files");
         }
+    }
+}
+
+impl Eval for ir::ParseBEDInstr {
+    fn eval(&self, env: &mut Env) {
+        use flatgfa::flatbed::BEDParser;
+
+        let store = match &env.rsrc[self.input.0] {
+            Resource::File(name) => {
+                let file = memfile::map_file(name);
+                BEDParser::for_heap().parse_mem(file.as_ref())
+            }
+            Resource::Stdin => {
+                let stdin = std::io::stdin();
+                BEDParser::for_heap().parse_stream(stdin.lock())
+            }
+            Resource::Stdout => panic!("cannot read from stdout"),
+            Resource::Pipe => {
+                let read = env.read_pipe(self.input).unwrap();
+                BEDParser::for_heap().parse_stream(BufReader::new(read))
+            }
+            _ => panic!("non-bytes input"),
+        };
+
+        *env.get_bed_store(self.output) = Some(store);
     }
 }
 

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -8,6 +8,7 @@ pub enum Resource {
     Pipe,
     GFAStore,
     Mmap,
+    BEDStore,
 }
 
 /// An instruction performs one imperative action.
@@ -18,6 +19,7 @@ pub enum Instr {
     Exec(ExecInstr),
     ParseGFA(ParseGFAInstr),
     MapFile(MapFileInstr),
+    ParseBED(ParseBEDInstr),
 }
 
 #[derive(Debug)]
@@ -60,7 +62,7 @@ impl From<ExecInstr> for Instr {
     }
 }
 
-/// Parse a GFA file or stream  in text foramt.
+/// Parse a GFA file or stream in text foramt.
 #[derive(Debug)]
 pub struct ParseGFAInstr {
     pub input: ResourceRef,
@@ -83,6 +85,19 @@ pub struct MapFileInstr {
 impl From<MapFileInstr> for Instr {
     fn from(value: MapFileInstr) -> Self {
         Self::MapFile(value)
+    }
+}
+
+/// Parse a text BED file or stream.
+#[derive(Debug)]
+pub struct ParseBEDInstr {
+    pub input: ResourceRef,
+    pub output: ResourceRef,
+}
+
+impl From<ParseBEDInstr> for Instr {
+    fn from(value: ParseBEDInstr) -> Self {
+        Self::ParseBED(value)
     }
 }
 

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -20,6 +20,7 @@ pub enum Instr {
     ParseGFA(ParseGFAInstr),
     MapFile(MapFileInstr),
     ParseBED(ParseBEDInstr),
+    MakeWindows(MakeWindowsInstr),
 }
 
 #[derive(Debug)]
@@ -101,6 +102,23 @@ impl From<ParseBEDInstr> for Instr {
     }
 }
 
+/// Create strided windows within chromosome spans.
+///
+/// Behaves like `bedtools makewindows`. Takes in a BED file with chromosome
+/// sizes, and generates widows of the given `size` as a BED output.
+#[derive(Debug)]
+pub struct MakeWindowsInstr {
+    pub input: ResourceRef,
+    pub output: ResourceRef,
+    pub size: usize,
+}
+
+impl From<MakeWindowsInstr> for Instr {
+    fn from(value: MakeWindowsInstr) -> Self {
+        Self::MakeWindows(value)
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
 pub struct ResourceRef(pub usize);
@@ -156,6 +174,11 @@ impl Builder {
         self.add_rsrc(Resource::GFAStore)
     }
 
+    /// Create a new FlatBED data store resource.
+    pub fn bed_store(&mut self) -> ResourceRef {
+        self.add_rsrc(Resource::BEDStore)
+    }
+
     /// Create a new memory-mapped file resource.
     pub fn mmap(&mut self) -> ResourceRef {
         self.add_rsrc(Resource::Mmap)
@@ -187,10 +210,22 @@ impl Builder {
             Resource::Pipe | Resource::Stdin | Resource::File(_) => {
                 // Parse as GFA text.
                 let output = self.gfa_store();
-                self.add_instr(Instr::ParseGFA(ParseGFAInstr { input, output }));
+                self.add_instr(ParseGFAInstr { input, output });
                 output
             }
             _ => panic!("cannot parse this resource as GFA text"),
+        }
+    }
+
+    /// Create an instruction to parse a BED file to a FlatBED resource.
+    pub fn load_bed(&mut self, input: ResourceRef) -> ResourceRef {
+        match &self.rsrc[input.0] {
+            Resource::Pipe | Resource::Stdin | Resource::File(_) => {
+                let output = self.bed_store();
+                self.add_instr(ParseBEDInstr { input, output });
+                output
+            }
+            _ => panic!("cannot parse this resource as BED text"),
         }
     }
 

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -59,6 +59,28 @@ fn cmd_to_ir(
             }
             _ => unimplemented!("unsupported odgi subcommand"),
         }
+    } else if name == "bedtools" {
+        let mut argp = Arguments::from_vec(args.into_iter().map(|s| s.into()).collect());
+        match argp.subcommand().unwrap().as_deref() {
+            Some("makewindows") => {
+                // The input comes from the `-b` argument, which may be
+                // literally `/dev/stdin`.
+                let filename: String = argp.value_from_str("-b").unwrap();
+                if filename != "/dev/stdin" {
+                    input = builder.file(filename);
+                }
+
+                // Use an instruction to parse the BED file.
+                let input = builder.load_bed(input);
+
+                builder.add_instr(ir::MakeWindowsInstr {
+                    input,
+                    output,
+                    size: argp.value_from_str("-w").unwrap(),
+                });
+            }
+            _ => unimplemented!("unsupported bedtools subcommand"),
+        }
     } else {
         // Any non-odgi command is a "passthrough" shell command.
         builder.add_instr(ir::ExecInstr {

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -26,6 +26,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Instr::Exec(instr) => self.wrap(instr).fmt(f),
             ir::Instr::ParseGFA(instr) => self.wrap(instr).fmt(f),
             ir::Instr::MapFile(instr) => self.wrap(instr).fmt(f),
+            ir::Instr::ParseBED(instr) => self.wrap(instr).fmt(f),
         }
     }
 }
@@ -41,6 +42,7 @@ impl Display for Wrapped<'_, ir::ResourceRef> {
             ir::Resource::Pipe => write!(f, "pipe-{}", idx),
             ir::Resource::GFAStore => write!(f, "gfa-store-{}", idx),
             ir::Resource::Mmap => write!(f, "mmap-{}", idx),
+            ir::Resource::BEDStore => write!(f, "bed-store-{}", idx),
         }
     }
 }
@@ -95,6 +97,17 @@ impl Display for Wrapped<'_, ir::MapFileInstr> {
         write!(
             f,
             "map-file({}) -> {}",
+            self.wrap(&self.val.input),
+            self.wrap(&self.val.output),
+        )
+    }
+}
+
+impl Display for Wrapped<'_, ir::ParseBEDInstr> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "parse-bed({}) -> {}",
             self.wrap(&self.val.input),
             self.wrap(&self.val.output),
         )

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -27,6 +27,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Instr::ParseGFA(instr) => self.wrap(instr).fmt(f),
             ir::Instr::MapFile(instr) => self.wrap(instr).fmt(f),
             ir::Instr::ParseBED(instr) => self.wrap(instr).fmt(f),
+            ir::Instr::MakeWindows(instr) => self.wrap(instr).fmt(f),
         }
     }
 }
@@ -109,6 +110,18 @@ impl Display for Wrapped<'_, ir::ParseBEDInstr> {
             f,
             "parse-bed({}) -> {}",
             self.wrap(&self.val.input),
+            self.wrap(&self.val.output),
+        )
+    }
+}
+
+impl Display for Wrapped<'_, ir::MakeWindowsInstr> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "make-windows({}, {}) -> {}",
+            self.wrap(&self.val.input),
+            self.val.size,
             self.wrap(&self.val.output),
         )
     }

--- a/flatgfa-sh/windows.sh
+++ b/flatgfa-sh/windows.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+odgi depth -i ../tests/note5.gfa -r 5 | bedtools makewindows -b /dev/stdin -w 4 > note5.w4.bed
+head -n1 note5.w4.bed
+rm -f note5.w4.bed

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -3,6 +3,7 @@ use crate::memfile::MemchrSplit;
 use crate::pool::{FixedStore, HeapStore, Id, Pool, Span, Store};
 use atoi::FromRadix10;
 use bstr::BStr;
+use std::io::BufRead;
 use zerocopy::{FromBytes, IntoBytes};
 
 /// A single interval from a BED file.
@@ -128,14 +129,26 @@ impl<'a, P: StoreFamily<'a>> BEDParser<'a, P> {
     /// Parse a BED text file from an in-memory buffer.
     pub fn parse_mem(mut self, buf: &[u8]) -> BEDStore<'a, P> {
         for line in MemchrSplit::new(b'\n', buf) {
-            let (name_slice, rest) = parse_field(line).unwrap();
-            let (start_num, rest) = parse_num(rest).unwrap();
-            let (end_num, _) = parse_num(&rest[1..]).unwrap();
-
-            self.flat.add_entry(name_slice, start_num, end_num);
+            self.parse_line(line)
         }
-
         self.flat
+    }
+
+    /// Parse a BED text file from an I/O stream.
+    pub fn parse_stream<R: BufRead>(mut self, stream: R) -> BEDStore<'a, P> {
+        for line in stream.split(b'\n') {
+            self.parse_line(&line.unwrap())
+        }
+        self.flat
+    }
+
+    /// Parse a single line from a BED file and add it to the store.
+    fn parse_line(&mut self, line: &[u8]) {
+        let (name_slice, rest) = parse_field(line).unwrap();
+        let (start_num, rest) = parse_num(rest).unwrap();
+        let (end_num, _) = parse_num(&rest[1..]).unwrap();
+
+        self.flat.add_entry(name_slice, start_num, end_num);
     }
 }
 

--- a/flatgfa/src/flatbed.rs
+++ b/flatgfa/src/flatbed.rs
@@ -144,6 +144,11 @@ impl<'a, P: StoreFamily<'a>> BEDParser<'a, P> {
 
     /// Parse a single line from a BED file and add it to the store.
     fn parse_line(&mut self, line: &[u8]) {
+        // Ignore comments (which are also used as header lines).
+        if line.starts_with(b"#") {
+            return;
+        }
+
         let (name_slice, rest) = parse_field(line).unwrap();
         let (start_num, rest) = parse_num(rest).unwrap();
         let (end_num, _) = parse_num(&rest[1..]).unwrap();


### PR DESCRIPTION
This adds a "faked" version of `bedtools makewindows` to flash (see #254). Because this command also reads a BED as input to tell it which paths to follow, I also added support for representing FlatBED resources in flash.

This now makes it possible to run the first line in our target shell script.