### PR TITLE
flash: A first optimization, to bypass `.og` files

### DIFF
--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -104,6 +104,10 @@ shell("baz", [], input=pipe-1) -> "qux"
 
 ```
 
+
+Input GFA File Types
+--------------------
+
 Flash also detects FlatGFA files and odgi files (by filename extension)
 everywhere that an input GFA is allowed:
 
@@ -116,6 +120,21 @@ $ flash -p -c 'odgi depth -i chr8.og'
 odgi-view("chr8.og") -> pipe-0
 parse-gfa(pipe-0) -> gfa-store-0
 path-depth(gfa-store-0) -> stdout
+
+```
+
+With optimizations enabled via `-O`, flash will detect when an `.og` file can be
+bypassed in favor of an existing FlatGFA equivalent:
+
+```console
+$ flash -p -c 'odgi depth -i ../tests/note5.og'
+odgi-view("../tests/note5.og") -> pipe-0
+parse-gfa(pipe-0) -> gfa-store-0
+path-depth(gfa-store-0) -> stdout
+
+$ flash -p -O -c 'odgi depth -i ../tests/note5.og'
+map-file("../tests/note5.flatgfa") -> mmap-0
+path-depth(mmap-0) -> stdout
 
 ```
 

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -124,7 +124,7 @@ path-depth(gfa-store-0) -> stdout
 ```
 
 With optimizations enabled via `-O`, flash will detect when an `.og` file can be
-bypassed in favor of an existing FlatGFA equivalent:
+bypassed in favor of an existing FlatGFA or text GFA equivalent:
 
 ```console
 $ flash -p -c 'odgi depth -i ../tests/note5.og'

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -123,8 +123,22 @@ path-depth(gfa-store-0) -> stdout
 
 ```
 
-With optimizations enabled via `-O`, flash will detect when an `.og` file can be
-bypassed in favor of an existing FlatGFA or text GFA equivalent:
+With optimizations enabled via `-O`, flash will detect when you're reading a
+plain-text GFA file but have a FlatGFA file you can use directly instead:
+
+```console
+$ flash -p -c 'odgi depth -i ../tests/note5.gfa'
+parse-gfa("../tests/note5.gfa") -> gfa-store-0
+path-depth(gfa-store-0) -> stdout
+
+$ flash -p -O -c 'odgi depth -i ../tests/note5.gfa'
+map-file("../tests/note5.flatgfa") -> mmap-0
+path-depth(mmap-0) -> stdout
+
+```
+
+Similarly, when you use an odgi-native `.og` file, an optimization can rewrite
+this to use a plain-text GFA file directly or a FlatGFA binary file:
 
 ```console
 $ flash -p -c 'odgi depth -i ../tests/note5.og'

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -104,13 +104,18 @@ shell("baz", [], input=pipe-1) -> "qux"
 
 ```
 
-Flash also detects FlatGFA files (by filename extension) everywhere that an
-input GFA is allowed:
+Flash also detects FlatGFA files and odgi files (by filename extension)
+everywhere that an input GFA is allowed:
 
 ```console
 $ flash -p -c 'odgi depth -i chr8.flatgfa'
 map-file("chr8.flatgfa") -> mmap-0
 path-depth(mmap-0) -> stdout
+
+$ flash -p -c 'odgi depth -i chr8.og'
+shell("odgi", ["view", "-g", "-i", "chr8.og"], input=stdin) -> pipe-0
+parse-gfa(pipe-0) -> gfa-store-0
+path-depth(gfa-store-0) -> stdout
 
 ```
 

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -113,7 +113,7 @@ map-file("chr8.flatgfa") -> mmap-0
 path-depth(mmap-0) -> stdout
 
 $ flash -p -c 'odgi depth -i chr8.og'
-shell("odgi", ["view", "-g", "-i", "chr8.og"], input=stdin) -> pipe-0
+odgi-view("chr8.og") -> pipe-0
 parse-gfa(pipe-0) -> gfa-store-0
 path-depth(gfa-store-0) -> stdout
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -5,6 +5,7 @@ use flatgfa::FlatGFA;
 use flatgfa::flatbed::HeapBEDStore;
 use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile, ops};
 use memmap::Mmap;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter};
 use std::ops::{Index, IndexMut};
@@ -106,6 +107,47 @@ impl Env {
             _ => panic!("resource must be FlatGFA data"),
         }
     }
+
+    /// Execute a subprocess hooked up to the given resources as the stdin & stdout streams.
+    fn run_cmd(
+        &mut self,
+        command: impl AsRef<OsStr>,
+        args: &[impl AsRef<OsStr>],
+        stdin: Resource,
+        stdout: Resource,
+    ) {
+        use std::process::Command;
+
+        let mut cmd = Command::new(command);
+        cmd.args(args);
+
+        match stdin.kind {
+            ResourceKind::Stdin => (),
+            ResourceKind::Stdout => panic!("cannot read from stdout"),
+            ResourceKind::File => {
+                cmd.stdin(File::open(self.file_name(stdin)).unwrap());
+            }
+            ResourceKind::Pipe => {
+                cmd.stdin(self.read_pipe(stdin).unwrap());
+            }
+            _ => panic!("non-bytes input"),
+        }
+
+        match stdout.kind {
+            ResourceKind::Stdin => panic!("cannot write to stdin"),
+            ResourceKind::Stdout => (),
+            ResourceKind::File => {
+                cmd.stdout(File::create(self.file_name(stdout)).unwrap());
+            }
+            ResourceKind::Pipe => {
+                cmd.stdout(self.write_pipe(stdout).unwrap());
+            }
+            _ => panic!("non-bytes output"),
+        }
+
+        // TODO: Do anything with the status?
+        cmd.status().unwrap();
+    }
 }
 
 /// The data storage for heap values of a given resource kind.
@@ -176,6 +218,7 @@ impl Eval for ir::Instr {
             Self::MapFile(instr) => instr.eval(env),
             Self::ParseBED(instr) => instr.eval(env),
             Self::MakeWindows(instr) => instr.eval(env),
+            Self::OdgiView(instr) => instr.eval(env),
         }
     }
 }
@@ -226,38 +269,7 @@ impl Eval for ir::PathDepthInstr {
 
 impl Eval for ir::ExecInstr {
     fn eval(&self, env: &mut Env) {
-        use std::fs::File;
-        use std::process::Command;
-
-        let mut cmd = Command::new(&self.command);
-        cmd.args(&self.args);
-
-        match self.input.kind {
-            ResourceKind::Stdin => (),
-            ResourceKind::Stdout => panic!("cannot read from stdout"),
-            ResourceKind::File => {
-                cmd.stdin(File::open(env.file_name(self.input)).unwrap());
-            }
-            ResourceKind::Pipe => {
-                cmd.stdin(env.read_pipe(self.input).unwrap());
-            }
-            _ => panic!("non-bytes input"),
-        }
-
-        match self.output.kind {
-            ResourceKind::Stdin => panic!("cannot write to stdin"),
-            ResourceKind::Stdout => (),
-            ResourceKind::File => {
-                cmd.stdout(File::create(env.file_name(self.output)).unwrap());
-            }
-            ResourceKind::Pipe => {
-                cmd.stdout(env.write_pipe(self.output).unwrap());
-            }
-            _ => panic!("non-bytes output"),
-        }
-
-        // TODO: Do anything with the status?
-        cmd.status().unwrap();
+        env.run_cmd(&self.command, &self.args, self.input, self.output)
     }
 }
 
@@ -333,6 +345,21 @@ impl Eval for ir::MakeWindowsInstr {
             })
             .unwrap();
         }
+    }
+}
+
+impl Eval for ir::OdgiViewInstr {
+    fn eval(&self, env: &mut Env) {
+        let og_file = env.file_name(self.input).to_string();
+        env.run_cmd(
+            "odgi",
+            &["view", "-g", "-i", &og_file],
+            Resource {
+                kind: ResourceKind::Stdin,
+                index: 0,
+            },
+            self.output,
+        )
     }
 }
 

--- a/flatgfa-sh/src/eval.rs
+++ b/flatgfa-sh/src/eval.rs
@@ -1,4 +1,4 @@
-use crate::ir::{self, Resource, ResourceKind};
+use crate::ir::{self, Op, Resource, ResourceKind};
 use bstr::BStr;
 use enum_map::EnumMap;
 use flatgfa::FlatGFA;
@@ -210,106 +210,94 @@ trait Eval {
 
 impl Eval for ir::Instr {
     fn eval(&self, env: &mut Env) {
-        match self {
-            Self::NodeDepth(instr) => instr.eval(env),
-            Self::PathDepth(instr) => instr.eval(env),
-            Self::Exec(instr) => instr.eval(env),
-            Self::ParseGFA(instr) => instr.eval(env),
-            Self::MapFile(instr) => instr.eval(env),
-            Self::ParseBED(instr) => instr.eval(env),
-            Self::MakeWindows(instr) => instr.eval(env),
-            Self::OdgiView(instr) => instr.eval(env),
+        match &self.op {
+            Op::NodeDepth => node_depth(env, self.input, self.output),
+            Op::PathDepth { path } => path_depth(env, self.input, self.output, path),
+            Op::Exec { command, args } => exec(env, self.input, self.output, command, args),
+            Op::ParseGFA => parse_gfa(env, self.input, self.output),
+            Op::MapFile => map_file(env, self.input, self.output),
+            Op::ParseBED => parse_bed(env, self.input, self.output),
+            Op::MakeWindows { size } => make_windows(env, self.input, self.output, *size),
+            Op::OdgiView => odgi_view(env, self.input, self.output),
         }
     }
 }
 
-impl Eval for ir::NodeDepthInstr {
-    fn eval(&self, env: &mut Env) {
-        let mut out = env.output(self.output);
-        let gfa = env.flatgfa(self.input);
-        let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
-        out.emit(ops::depth::SegDepth {
+fn node_depth(env: &mut Env, input: Resource, output: Resource) {
+    let mut out = env.output(output);
+    let gfa = env.flatgfa(input);
+    let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
+    out.emit(ops::depth::SegDepth {
+        gfa: &gfa,
+        depths,
+        uniq_depths,
+    })
+    .unwrap();
+}
+
+fn path_depth(env: &mut Env, input: Resource, output: Resource, path: &Option<String>) {
+    let mut out = env.output(output);
+    let gfa = env.flatgfa(input);
+    if let Some(path_name) = &path {
+        // TODO More elegantly handle missing paths.
+        let path_id = gfa
+            .find_path(path_name.as_bytes().into())
+            .expect("no such path found");
+        let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
+        out.emit(ops::depth::PathDepth {
             gfa: &gfa,
             depths,
-            uniq_depths,
+            lengths,
+            paths: std::iter::once(path_id),
+        })
+        .unwrap();
+    } else {
+        let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
+        out.emit(ops::depth::PathDepth {
+            gfa: &gfa,
+            depths,
+            lengths,
+            paths: gfa.paths.ids(),
         })
         .unwrap();
     }
 }
 
-impl Eval for ir::PathDepthInstr {
-    fn eval(&self, env: &mut Env) {
-        let mut out = env.output(self.output);
-        let gfa = env.flatgfa(self.input);
-        if let Some(path_name) = &self.path {
-            // TODO More elegantly handle missing paths.
-            let path_id = gfa
-                .find_path(path_name.as_bytes().into())
-                .expect("no such path found");
-            let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
-            out.emit(ops::depth::PathDepth {
-                gfa: &gfa,
-                depths,
-                lengths,
-                paths: std::iter::once(path_id),
-            })
-            .unwrap();
-        } else {
-            let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
-            out.emit(ops::depth::PathDepth {
-                gfa: &gfa,
-                depths,
-                lengths,
-                paths: gfa.paths.ids(),
-            })
-            .unwrap();
-        }
+fn exec(env: &mut Env, input: Resource, output: Resource, command: &String, args: &[String]) {
+    env.run_cmd(&command, &args, input, output);
+}
+
+fn parse_gfa(env: &mut Env, input: Resource, output: Resource) {
+    use flatgfa::parse::Parser;
+
+    let store = match env.input(input) {
+        Input::File(file) => Parser::for_heap().parse_mem(file.as_ref()),
+        Input::Stdin(stream) => Parser::for_heap().parse_stream(stream),
+        Input::Pipe(stream) => Parser::for_heap().parse_stream(stream),
+    };
+
+    env.gfa_stores[output] = Some(store);
+}
+
+fn map_file(env: &mut Env, input: Resource, output: Resource) {
+    if let ResourceKind::File = input.kind {
+        let mmap = memfile::map_file(env.file_name(input));
+        env.mmaps[output] = Some(mmap);
+    } else {
+        panic!("can only map actual files");
     }
 }
 
-impl Eval for ir::ExecInstr {
-    fn eval(&self, env: &mut Env) {
-        env.run_cmd(&self.command, &self.args, self.input, self.output)
-    }
-}
+fn parse_bed(env: &mut Env, input: Resource, output: Resource) {
+    use flatgfa::flatbed::BEDParser;
 
-impl Eval for ir::ParseGFAInstr {
-    fn eval(&self, env: &mut Env) {
-        use flatgfa::parse::Parser;
+    let store = match env.input(input) {
+        Input::File(file) => BEDParser::for_heap().parse_mem(file.as_ref()),
+        Input::Stdin(stream) => BEDParser::for_heap().parse_stream(stream),
+        Input::Pipe(stream) => BEDParser::for_heap().parse_stream(stream),
+    };
 
-        let store = match env.input(self.input) {
-            Input::File(file) => Parser::for_heap().parse_mem(file.as_ref()),
-            Input::Stdin(stream) => Parser::for_heap().parse_stream(stream),
-            Input::Pipe(stream) => Parser::for_heap().parse_stream(stream),
-        };
-
-        env.gfa_stores[self.output] = Some(store);
-    }
-}
-
-impl Eval for ir::MapFileInstr {
-    fn eval(&self, env: &mut Env) {
-        if let ResourceKind::File = self.input.kind {
-            let mmap = memfile::map_file(env.file_name(self.input));
-            env.mmaps[self.output] = Some(mmap);
-        } else {
-            panic!("can only map actual files");
-        }
-    }
-}
-
-impl Eval for ir::ParseBEDInstr {
-    fn eval(&self, env: &mut Env) {
-        use flatgfa::flatbed::BEDParser;
-
-        let store = match env.input(self.input) {
-            Input::File(file) => BEDParser::for_heap().parse_mem(file.as_ref()),
-            Input::Stdin(stream) => BEDParser::for_heap().parse_stream(stream),
-            Input::Pipe(stream) => BEDParser::for_heap().parse_stream(stream),
-        };
-
-        env.bed_stores[self.output] = Some(store);
-    }
+    env.bed_stores[output] = Some(store);
 }
 
 struct WindowsBed<'a> {
@@ -331,36 +319,32 @@ impl<'a> Emit for WindowsBed<'a> {
     }
 }
 
-impl Eval for ir::MakeWindowsInstr {
-    fn eval(&self, env: &mut Env) {
-        let store = env.bed_stores[self.input].take().unwrap();
-        let bed = store.as_ref();
-        let mut out = env.output(self.output);
-        for entry in bed.entries.all() {
-            out.emit(WindowsBed {
-                name: bed.get_name_of_entry(entry),
-                start: entry.start,
-                end: entry.end,
-                size: self.size.try_into().unwrap(),
-            })
-            .unwrap();
-        }
+fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
+    let store = env.bed_stores[input].take().unwrap();
+    let bed = store.as_ref();
+    let mut out = env.output(output);
+    for entry in bed.entries.all() {
+        out.emit(WindowsBed {
+            name: bed.get_name_of_entry(entry),
+            start: entry.start,
+            end: entry.end,
+            size: size.try_into().unwrap(),
+        })
+        .unwrap();
     }
 }
 
-impl Eval for ir::OdgiViewInstr {
-    fn eval(&self, env: &mut Env) {
-        let og_file = env.file_name(self.input).to_string();
-        env.run_cmd(
-            "odgi",
-            &["view", "-g", "-i", &og_file],
-            Resource {
-                kind: ResourceKind::Stdin,
-                index: 0,
-            },
-            self.output,
-        )
-    }
+fn odgi_view(env: &mut Env, input: Resource, output: Resource) {
+    let og_file = env.file_name(input).to_string();
+    env.run_cmd(
+        "odgi",
+        &["view", "-g", "-i", &og_file],
+        Resource {
+            kind: ResourceKind::Stdin,
+            index: 0,
+        },
+        output,
+    )
 }
 
 pub fn run(prog: ir::Program) {

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -1,0 +1,143 @@
+use super::{Env, Input};
+use crate::ir::{Instr, Op, Resource, ResourceKind};
+use bstr::BStr;
+use flatgfa::{self, emit::Emit, memfile, ops};
+use std::io;
+
+/// Execute a single instruction.
+pub fn eval(env: &mut Env, instr: &Instr) {
+    match &instr.op {
+        Op::NodeDepth => node_depth(env, instr.input, instr.output),
+        Op::PathDepth { path } => path_depth(env, instr.input, instr.output, path),
+        Op::Exec { command, args } => exec(env, instr.input, instr.output, command, args),
+        Op::ParseGFA => parse_gfa(env, instr.input, instr.output),
+        Op::MapFile => map_file(env, instr.input, instr.output),
+        Op::ParseBED => parse_bed(env, instr.input, instr.output),
+        Op::MakeWindows { size } => make_windows(env, instr.input, instr.output, *size),
+        Op::OdgiView => odgi_view(env, instr.input, instr.output),
+    }
+}
+
+fn node_depth(env: &mut Env, input: Resource, output: Resource) {
+    let mut out = env.output(output);
+    let gfa = env.flatgfa(input);
+    let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
+    out.emit(ops::depth::SegDepth {
+        gfa: &gfa,
+        depths,
+        uniq_depths,
+    })
+    .unwrap();
+}
+
+fn path_depth(env: &mut Env, input: Resource, output: Resource, path: &Option<String>) {
+    let mut out = env.output(output);
+    let gfa = env.flatgfa(input);
+    if let Some(path_name) = &path {
+        // TODO More elegantly handle missing paths.
+        let path_id = gfa
+            .find_path(path_name.as_bytes().into())
+            .expect("no such path found");
+        let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
+        out.emit(ops::depth::PathDepth {
+            gfa: &gfa,
+            depths,
+            lengths,
+            paths: std::iter::once(path_id),
+        })
+        .unwrap();
+    } else {
+        let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
+        out.emit(ops::depth::PathDepth {
+            gfa: &gfa,
+            depths,
+            lengths,
+            paths: gfa.paths.ids(),
+        })
+        .unwrap();
+    }
+}
+
+fn exec(env: &mut Env, input: Resource, output: Resource, command: &String, args: &[String]) {
+    env.run_cmd(command, args, input, output);
+}
+
+fn parse_gfa(env: &mut Env, input: Resource, output: Resource) {
+    use flatgfa::parse::Parser;
+
+    let store = match env.input(input) {
+        Input::File(file) => Parser::for_heap().parse_mem(file.as_ref()),
+        Input::Stdin(stream) => Parser::for_heap().parse_stream(stream),
+        Input::Pipe(stream) => Parser::for_heap().parse_stream(stream),
+    };
+
+    env.gfa_stores[output] = Some(store);
+}
+
+fn map_file(env: &mut Env, input: Resource, output: Resource) {
+    if let ResourceKind::File = input.kind {
+        let mmap = memfile::map_file(env.file_name(input));
+        env.mmaps[output] = Some(mmap);
+    } else {
+        panic!("can only map actual files");
+    }
+}
+
+fn parse_bed(env: &mut Env, input: Resource, output: Resource) {
+    use flatgfa::flatbed::BEDParser;
+
+    let store = match env.input(input) {
+        Input::File(file) => BEDParser::for_heap().parse_mem(file.as_ref()),
+        Input::Stdin(stream) => BEDParser::for_heap().parse_stream(stream),
+        Input::Pipe(stream) => BEDParser::for_heap().parse_stream(stream),
+    };
+
+    env.bed_stores[output] = Some(store);
+}
+
+struct WindowsBed<'a> {
+    name: &'a BStr,
+    start: u64,
+    end: u64,
+    size: u64,
+}
+
+impl<'a> Emit for WindowsBed<'a> {
+    fn emit(self, f: &mut impl std::io::Write) -> io::Result<()> {
+        let mut pos = self.start;
+        while pos < self.end {
+            let end = (pos + self.size).min(self.end);
+            writeln!(f, "{}\t{}\t{}", self.name, pos, end)?;
+            pos = end;
+        }
+        Ok(())
+    }
+}
+
+fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
+    let store = env.bed_stores[input].take().unwrap();
+    let bed = store.as_ref();
+    let mut out = env.output(output);
+    for entry in bed.entries.all() {
+        out.emit(WindowsBed {
+            name: bed.get_name_of_entry(entry),
+            start: entry.start,
+            end: entry.end,
+            size: size.try_into().unwrap(),
+        })
+        .unwrap();
+    }
+}
+
+fn odgi_view(env: &mut Env, input: Resource, output: Resource) {
+    let og_file = env.file_name(input).to_string();
+    env.run_cmd(
+        "odgi",
+        &["view", "-g", "-i", &og_file],
+        Resource {
+            kind: ResourceKind::Stdin,
+            index: 0,
+        },
+        output,
+    )
+}

--- a/flatgfa-sh/src/eval/mod.rs
+++ b/flatgfa-sh/src/eval/mod.rs
@@ -1,9 +1,10 @@
-use crate::ir::{self, Op, Resource, ResourceKind};
-use bstr::BStr;
+mod instr;
+
+use crate::ir::{self, Resource, ResourceKind};
 use enum_map::EnumMap;
 use flatgfa::FlatGFA;
 use flatgfa::flatbed::HeapBEDStore;
-use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile, ops};
+use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile};
 use memmap::Mmap;
 use std::ffi::OsStr;
 use std::fs::File;
@@ -204,152 +205,9 @@ impl Output {
     }
 }
 
-trait Eval {
-    fn eval(&self, env: &mut Env);
-}
-
-impl Eval for ir::Instr {
-    fn eval(&self, env: &mut Env) {
-        match &self.op {
-            Op::NodeDepth => node_depth(env, self.input, self.output),
-            Op::PathDepth { path } => path_depth(env, self.input, self.output, path),
-            Op::Exec { command, args } => exec(env, self.input, self.output, command, args),
-            Op::ParseGFA => parse_gfa(env, self.input, self.output),
-            Op::MapFile => map_file(env, self.input, self.output),
-            Op::ParseBED => parse_bed(env, self.input, self.output),
-            Op::MakeWindows { size } => make_windows(env, self.input, self.output, *size),
-            Op::OdgiView => odgi_view(env, self.input, self.output),
-        }
-    }
-}
-
-fn node_depth(env: &mut Env, input: Resource, output: Resource) {
-    let mut out = env.output(output);
-    let gfa = env.flatgfa(input);
-    let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
-    out.emit(ops::depth::SegDepth {
-        gfa: &gfa,
-        depths,
-        uniq_depths,
-    })
-    .unwrap();
-}
-
-fn path_depth(env: &mut Env, input: Resource, output: Resource, path: &Option<String>) {
-    let mut out = env.output(output);
-    let gfa = env.flatgfa(input);
-    if let Some(path_name) = &path {
-        // TODO More elegantly handle missing paths.
-        let path_id = gfa
-            .find_path(path_name.as_bytes().into())
-            .expect("no such path found");
-        let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
-        out.emit(ops::depth::PathDepth {
-            gfa: &gfa,
-            depths,
-            lengths,
-            paths: std::iter::once(path_id),
-        })
-        .unwrap();
-    } else {
-        let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
-        out.emit(ops::depth::PathDepth {
-            gfa: &gfa,
-            depths,
-            lengths,
-            paths: gfa.paths.ids(),
-        })
-        .unwrap();
-    }
-}
-
-fn exec(env: &mut Env, input: Resource, output: Resource, command: &String, args: &[String]) {
-    env.run_cmd(&command, &args, input, output);
-}
-
-fn parse_gfa(env: &mut Env, input: Resource, output: Resource) {
-    use flatgfa::parse::Parser;
-
-    let store = match env.input(input) {
-        Input::File(file) => Parser::for_heap().parse_mem(file.as_ref()),
-        Input::Stdin(stream) => Parser::for_heap().parse_stream(stream),
-        Input::Pipe(stream) => Parser::for_heap().parse_stream(stream),
-    };
-
-    env.gfa_stores[output] = Some(store);
-}
-
-fn map_file(env: &mut Env, input: Resource, output: Resource) {
-    if let ResourceKind::File = input.kind {
-        let mmap = memfile::map_file(env.file_name(input));
-        env.mmaps[output] = Some(mmap);
-    } else {
-        panic!("can only map actual files");
-    }
-}
-
-fn parse_bed(env: &mut Env, input: Resource, output: Resource) {
-    use flatgfa::flatbed::BEDParser;
-
-    let store = match env.input(input) {
-        Input::File(file) => BEDParser::for_heap().parse_mem(file.as_ref()),
-        Input::Stdin(stream) => BEDParser::for_heap().parse_stream(stream),
-        Input::Pipe(stream) => BEDParser::for_heap().parse_stream(stream),
-    };
-
-    env.bed_stores[output] = Some(store);
-}
-
-struct WindowsBed<'a> {
-    name: &'a BStr,
-    start: u64,
-    end: u64,
-    size: u64,
-}
-
-impl<'a> Emit for WindowsBed<'a> {
-    fn emit(self, f: &mut impl std::io::Write) -> io::Result<()> {
-        let mut pos = self.start;
-        while pos < self.end {
-            let end = (pos + self.size).min(self.end);
-            writeln!(f, "{}\t{}\t{}", self.name, pos, end)?;
-            pos = end;
-        }
-        Ok(())
-    }
-}
-
-fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
-    let store = env.bed_stores[input].take().unwrap();
-    let bed = store.as_ref();
-    let mut out = env.output(output);
-    for entry in bed.entries.all() {
-        out.emit(WindowsBed {
-            name: bed.get_name_of_entry(entry),
-            start: entry.start,
-            end: entry.end,
-            size: size.try_into().unwrap(),
-        })
-        .unwrap();
-    }
-}
-
-fn odgi_view(env: &mut Env, input: Resource, output: Resource) {
-    let og_file = env.file_name(input).to_string();
-    env.run_cmd(
-        "odgi",
-        &["view", "-g", "-i", &og_file],
-        Resource {
-            kind: ResourceKind::Stdin,
-            index: 0,
-        },
-        output,
-    )
-}
-
 pub fn run(prog: ir::Program) {
     let mut env = Env::new(prog.file_names, prog.rsrc_counts);
-    for op in prog.instrs {
-        op.eval(&mut env);
+    for i in prog.instrs {
+        instr::eval(&mut env, &i);
     }
 }

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -199,9 +199,10 @@ impl Builder {
 
     /// Create an instruction to load a FlatGFA data structure as a resource.
     ///
-    /// Either parse GFA text or memory-map a FlatGFA binary file. If `input` is
-    /// a byte stream, we treat it as GFA text. If it's a file, we use the
-    /// filename to decide whether to treat it as GFA text or FlatGFA binary.
+    /// Either parse GFA text, memory-map a FlatGFA binary file, or convert an
+    /// odgi native file. If `input` is a byte stream, we treat it as GFA text.
+    /// If it's a file, we use the filename to decide whether to treat it as GFA
+    /// text or FlatGFA binary.
     pub fn load_gfa(&mut self, input: Resource) -> Resource {
         match input.kind {
             ResourceKind::File if self.file_name(input).ends_with(".flatgfa") => {
@@ -209,6 +210,22 @@ impl Builder {
                 let output = self.add_rsrc(ResourceKind::Mmap);
                 self.add_instr(Instr::MapFile(MapFileInstr { input, output }));
                 output
+            }
+            ResourceKind::File if self.file_name(input).ends_with(".og") => {
+                // Use `odgi view -g -i <file>` to dump as GFA text and then parse that.
+                let pipe = self.add_rsrc(ResourceKind::Pipe);
+                self.add_instr(ExecInstr {
+                    input: self.stdin(),
+                    output: pipe,
+                    command: "odgi".into(),
+                    args: vec![
+                        "view".into(),
+                        "-g".into(),
+                        "-i".into(),
+                        self.file_name(input).into(),
+                    ],
+                });
+                self.load_gfa(pipe)
             }
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
                 // Parse as GFA text.

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -114,7 +114,7 @@ impl Builder {
     }
 
     /// Create a new "normal" resource (not a file, stdin, or stdout).
-    pub fn add_rsrc(&mut self, kind: ResourceKind) -> Resource {
+    pub fn rsrc(&mut self, kind: ResourceKind) -> Resource {
         let index = self.rsrc_counts[kind];
         self.rsrc_counts[kind] += 1;
         Resource { kind, index }
@@ -146,19 +146,19 @@ impl Builder {
         match input.kind {
             ResourceKind::File if self.file_name(input).ends_with(".flatgfa") => {
                 // Memory-map the FlatGFA binary file.
-                let output = self.add_rsrc(ResourceKind::Mmap);
+                let output = self.rsrc(ResourceKind::Mmap);
                 self.instr(input, output, Op::MapFile);
                 output
             }
             ResourceKind::File if self.file_name(input).ends_with(".og") => {
                 // Use `odgi view` to dump as GFA text and then parse that.
-                let pipe = self.add_rsrc(ResourceKind::Pipe);
+                let pipe = self.rsrc(ResourceKind::Pipe);
                 self.instr(input, pipe, Op::OdgiView);
                 self.load_gfa(pipe)
             }
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
                 // Parse as GFA text.
-                let output = self.add_rsrc(ResourceKind::GFAStore);
+                let output = self.rsrc(ResourceKind::GFAStore);
                 self.instr(input, output, Op::ParseGFA);
                 output
             }
@@ -170,11 +170,23 @@ impl Builder {
     pub fn load_bed(&mut self, input: Resource) -> Resource {
         match input.kind {
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
-                let output = self.add_rsrc(ResourceKind::BEDStore);
+                let output = self.rsrc(ResourceKind::BEDStore);
                 self.instr(input, output, Op::ParseBED);
                 output
             }
             _ => panic!("cannot parse this resource as BED text"),
+        }
+    }
+
+    /// Replace all uses of one resource with another.
+    pub fn replace_rsrc(&mut self, old: Resource, new: Resource) {
+        for instr in self.instrs.iter_mut() {
+            if instr.input == old {
+                instr.input = new;
+            }
+            if instr.output == old {
+                instr.output = new;
+            }
         }
     }
 

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -148,10 +148,10 @@ pub struct Program {
 }
 
 pub struct Builder {
-    instrs: Vec<Instr>,
-    files: HashMap<String, Resource>,
-    file_names: Vec<String>,
-    rsrc_counts: EnumMap<ResourceKind, u16>,
+    pub instrs: Vec<Instr>,
+    pub files: HashMap<String, Resource>,
+    pub file_names: Vec<String>,
+    pub rsrc_counts: EnumMap<ResourceKind, u16>,
 }
 
 impl Builder {

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -20,124 +20,23 @@ pub struct Resource {
 
 /// An instruction performs one imperative action.
 #[derive(Debug)]
-pub enum Instr {
-    NodeDepth(NodeDepthInstr),
-    PathDepth(PathDepthInstr),
-    Exec(ExecInstr),
-    ParseGFA(ParseGFAInstr),
-    MapFile(MapFileInstr),
-    ParseBED(ParseBEDInstr),
-    MakeWindows(MakeWindowsInstr),
-    OdgiView(OdgiViewInstr),
-}
-
-#[derive(Debug)]
-pub struct NodeDepthInstr {
+pub struct Instr {
     pub input: Resource,
     pub output: Resource,
+    pub op: Op,
 }
 
-impl From<NodeDepthInstr> for Instr {
-    fn from(value: NodeDepthInstr) -> Self {
-        Self::NodeDepth(value)
-    }
-}
-
+/// The operation that an instruction may perform.
 #[derive(Debug)]
-pub struct PathDepthInstr {
-    pub input: Resource,
-    pub output: Resource,
-    pub path: Option<String>,
-}
-
-impl From<PathDepthInstr> for Instr {
-    fn from(value: PathDepthInstr) -> Self {
-        Self::PathDepth(value)
-    }
-}
-
-/// An instruction that just runs an external shell command.
-#[derive(Debug)]
-pub struct ExecInstr {
-    pub input: Resource,
-    pub output: Resource,
-    pub command: String,
-    pub args: Vec<String>,
-}
-
-impl From<ExecInstr> for Instr {
-    fn from(value: ExecInstr) -> Self {
-        Self::Exec(value)
-    }
-}
-
-/// Parse a GFA file or stream in text foramt.
-#[derive(Debug)]
-pub struct ParseGFAInstr {
-    pub input: Resource,
-    pub output: Resource,
-}
-
-impl From<ParseGFAInstr> for Instr {
-    fn from(value: ParseGFAInstr) -> Self {
-        Self::ParseGFA(value)
-    }
-}
-
-/// Memory-map a file: for instance, a FlatGFA binary file.
-#[derive(Debug)]
-pub struct MapFileInstr {
-    pub input: Resource,
-    pub output: Resource,
-}
-
-impl From<MapFileInstr> for Instr {
-    fn from(value: MapFileInstr) -> Self {
-        Self::MapFile(value)
-    }
-}
-
-/// Parse a text BED file or stream.
-#[derive(Debug)]
-pub struct ParseBEDInstr {
-    pub input: Resource,
-    pub output: Resource,
-}
-
-impl From<ParseBEDInstr> for Instr {
-    fn from(value: ParseBEDInstr) -> Self {
-        Self::ParseBED(value)
-    }
-}
-
-/// Create strided windows within chromosome spans.
-///
-/// Behaves like `bedtools makewindows`. Takes in a BED file with chromosome
-/// sizes, and generates widows of the given `size` as a BED output.
-#[derive(Debug)]
-pub struct MakeWindowsInstr {
-    pub input: Resource,
-    pub output: Resource,
-    pub size: usize,
-}
-
-impl From<MakeWindowsInstr> for Instr {
-    fn from(value: MakeWindowsInstr) -> Self {
-        Self::MakeWindows(value)
-    }
-}
-
-/// Convert an odgi native file (.og) to GFA text.
-#[derive(Debug)]
-pub struct OdgiViewInstr {
-    pub input: Resource,
-    pub output: Resource,
-}
-
-impl From<OdgiViewInstr> for Instr {
-    fn from(value: OdgiViewInstr) -> Self {
-        Self::OdgiView(value)
-    }
+pub enum Op {
+    NodeDepth,
+    PathDepth { path: Option<String> },
+    Exec { command: String, args: Vec<String> },
+    ParseGFA,
+    MapFile,
+    ParseBED,
+    MakeWindows { size: usize },
+    OdgiView,
 }
 
 #[derive(Debug)]
@@ -190,8 +89,8 @@ impl Builder {
     }
 
     /// Add an instruction to the end of the program.
-    pub fn add_instr<I: Into<Instr>>(&mut self, instr: I) {
-        self.instrs.push(instr.into());
+    pub fn instr(&mut self, input: Resource, output: Resource, op: Op) {
+        self.instrs.push(Instr { input, output, op })
     }
 
     /// Add a file resource, or get an existing one if we've already added it.
@@ -248,22 +147,19 @@ impl Builder {
             ResourceKind::File if self.file_name(input).ends_with(".flatgfa") => {
                 // Memory-map the FlatGFA binary file.
                 let output = self.add_rsrc(ResourceKind::Mmap);
-                self.add_instr(Instr::MapFile(MapFileInstr { input, output }));
+                self.instr(input, output, Op::MapFile);
                 output
             }
             ResourceKind::File if self.file_name(input).ends_with(".og") => {
                 // Use `odgi view` to dump as GFA text and then parse that.
                 let pipe = self.add_rsrc(ResourceKind::Pipe);
-                self.add_instr(OdgiViewInstr {
-                    input,
-                    output: pipe,
-                });
+                self.instr(input, pipe, Op::OdgiView);
                 self.load_gfa(pipe)
             }
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
                 // Parse as GFA text.
                 let output = self.add_rsrc(ResourceKind::GFAStore);
-                self.add_instr(ParseGFAInstr { input, output });
+                self.instr(input, output, Op::ParseGFA);
                 output
             }
             _ => panic!("cannot parse this resource as GFA text"),
@@ -275,7 +171,7 @@ impl Builder {
         match input.kind {
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
                 let output = self.add_rsrc(ResourceKind::BEDStore);
-                self.add_instr(ParseBEDInstr { input, output });
+                self.instr(input, output, Op::ParseBED);
                 output
             }
             _ => panic!("cannot parse this resource as BED text"),

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -155,6 +155,7 @@ pub struct Builder {
 }
 
 impl Builder {
+    /// Start building a fresh, empty program.
     pub fn new() -> Self {
         Self {
             instrs: Vec::new(),
@@ -164,6 +165,31 @@ impl Builder {
         }
     }
 
+    /// Start with an existing program.
+    pub fn rebuild(prog: Program) -> Self {
+        let files: HashMap<_, _> = prog
+            .file_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                (
+                    name.clone(),
+                    Resource {
+                        kind: ResourceKind::File,
+                        index: i.try_into().unwrap(),
+                    },
+                )
+            })
+            .collect();
+        Self {
+            instrs: prog.instrs,
+            files,
+            file_names: prog.file_names,
+            rsrc_counts: prog.rsrc_counts,
+        }
+    }
+
+    /// Add an instruction to the end of the program.
     pub fn add_instr<I: Into<Instr>>(&mut self, instr: I) {
         self.instrs.push(instr.into());
     }

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -28,6 +28,7 @@ pub enum Instr {
     MapFile(MapFileInstr),
     ParseBED(ParseBEDInstr),
     MakeWindows(MakeWindowsInstr),
+    OdgiView(OdgiViewInstr),
 }
 
 #[derive(Debug)]
@@ -126,6 +127,19 @@ impl From<MakeWindowsInstr> for Instr {
     }
 }
 
+/// Convert an odgi native file (.og) to GFA text.
+#[derive(Debug)]
+pub struct OdgiViewInstr {
+    pub input: Resource,
+    pub output: Resource,
+}
+
+impl From<OdgiViewInstr> for Instr {
+    fn from(value: OdgiViewInstr) -> Self {
+        Self::OdgiView(value)
+    }
+}
+
 #[derive(Debug)]
 pub struct Program {
     pub instrs: Vec<Instr>,
@@ -212,18 +226,11 @@ impl Builder {
                 output
             }
             ResourceKind::File if self.file_name(input).ends_with(".og") => {
-                // Use `odgi view -g -i <file>` to dump as GFA text and then parse that.
+                // Use `odgi view` to dump as GFA text and then parse that.
                 let pipe = self.add_rsrc(ResourceKind::Pipe);
-                self.add_instr(ExecInstr {
-                    input: self.stdin(),
+                self.add_instr(OdgiViewInstr {
+                    input,
                     output: pipe,
-                    command: "odgi".into(),
-                    args: vec![
-                        "view".into(),
-                        "-g".into(),
-                        "-i".into(),
-                        self.file_name(input).into(),
-                    ],
                 });
                 self.load_gfa(pipe)
             }

--- a/flatgfa-sh/src/main.rs
+++ b/flatgfa-sh/src/main.rs
@@ -1,14 +1,16 @@
 mod eval;
 mod ir;
+mod opt;
 mod parse;
 mod pretty;
 
 use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
 
-fn run_shell(line: &str, pretend: bool) {
+fn run_shell(line: &str, pretend: bool, optimize: bool) {
     let shell = parse::parse_sh(line);
     let prog = parse::sh_to_ir(shell);
+    let prog = if optimize { opt::optimize(prog) } else { prog };
     if pretend {
         print!("{}", prog);
     } else {
@@ -16,11 +18,11 @@ fn run_shell(line: &str, pretend: bool) {
     }
 }
 
-fn repl(pretend: bool) -> rustyline::Result<()> {
+fn repl(pretend: bool, optimize: bool) -> rustyline::Result<()> {
     let mut rl = DefaultEditor::new()?;
     loop {
         match rl.readline("$ ") {
-            Ok(line) => run_shell(&line, pretend),
+            Ok(line) => run_shell(&line, pretend, optimize),
             Err(ReadlineError::Interrupted) => break,
             Err(ReadlineError::Eof) => break,
             Err(err) => {
@@ -35,16 +37,17 @@ fn repl(pretend: bool) -> rustyline::Result<()> {
 fn main() {
     let mut args = pico_args::Arguments::from_env();
     let pretend = args.contains(["-p", "--pretend"]);
+    let optimize = args.contains(["-O", "--optimize"]);
     let cmd: Option<String> = args.opt_value_from_str("-c").unwrap();
     let script_filename: Option<String> = args.opt_free_from_str().unwrap();
 
     if let Some(cmd) = cmd {
-        run_shell(&cmd, pretend);
+        run_shell(&cmd, pretend, optimize);
     } else if let Some(filename) = script_filename {
         let script = std::fs::read_to_string(filename).unwrap();
-        run_shell(&script, pretend);
+        run_shell(&script, pretend, optimize);
     } else {
-        repl(pretend).unwrap();
+        repl(pretend, optimize).unwrap();
     }
 }
 

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,0 +1,7 @@
+use crate::ir::{Builder, Program};
+
+pub fn optimize(prog: Program) -> Program {
+    let builder = Builder::rebuild(prog);
+    dbg!("optimize!");
+    builder.build()
+}

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -3,19 +3,18 @@ use std::fs;
 
 fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
     // Search for a `parse-gfa` instruction.
-    for (parse_idx, instr) in instrs.iter().enumerate() {
-        if let Op::ParseGFA = instr.op {
-            // Search for an `odgi-view` instruction that produces the GFA.
-            let gfa = instr.input;
-            if let Some(view_idx) = instrs.iter().position(|instr| match instr.op {
-                Op::OdgiView => instr.output == gfa,
-                _ => false,
-            }) {
-                return Some((view_idx, parse_idx));
-            }
-        }
-    }
-    None
+    let (parse_idx, parse_instr) = instrs
+        .iter()
+        .enumerate()
+        .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))?;
+
+    // Search for an `odgi-view` instruction that produces the GFA.
+    let gfa = parse_instr.input;
+    let view_idx = instrs
+        .iter()
+        .position(|instr| matches!(instr.op, Op::OdgiView) && instr.output == gfa)?;
+
+    Some((view_idx, parse_idx))
 }
 
 fn opt_og_pair(builder: &mut Builder, view_idx: usize, parse_idx: usize) {

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,7 +1,60 @@
-use crate::ir::{Builder, Program};
+use crate::ir::{Builder, Instr, MapFileInstr, Program};
+use std::fs;
+
+fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
+    // Search for a `parse-gfa` instruction.
+    for (parse_idx, instr) in instrs.iter().enumerate() {
+        if let Instr::ParseGFA(parse) = instr {
+            // Search for an `odgi-view` instruction that produces the GFA.
+            let gfa = parse.input;
+            if let Some((view_idx, Instr::OdgiView(view))) =
+                instrs.iter().enumerate().find(|(_, instr)| match instr {
+                    Instr::OdgiView(view) => view.output == gfa,
+                    _ => false,
+                })
+            {
+                dbg!(parse_idx, parse, view_idx, view);
+                return Some((view_idx, parse_idx));
+            }
+        }
+    }
+    None
+}
 
 pub fn optimize(prog: Program) -> Program {
-    let builder = Builder::rebuild(prog);
-    dbg!("optimize!");
+    let mut builder = Builder::rebuild(prog);
+
+    if let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) {
+        dbg!(view_idx, parse_idx);
+
+        // Get the input `.og` file to this pair.
+        let og_filename = if let Instr::OdgiView(view) = &builder.instrs[view_idx] {
+            builder.file_name(view.input)
+        } else {
+            panic!()
+        };
+        let stem = og_filename
+            .strip_suffix(".og")
+            .expect("odgi-view inputs must end in .og");
+
+        // Get the final FlatGFA output resource.
+        let gfa_rsrc = if let Instr::ParseGFA(parse) = &builder.instrs[parse_idx] {
+            parse.output
+        } else {
+            panic!()
+        };
+
+        // Does the FlatGFA exist?
+        let flat_filename = format!("{stem}.flatgfa");
+        if fs::exists(&flat_filename).unwrap() {
+            // Make a new instruction to load the FlatGFA.
+            let flat_file = builder.file(flat_filename);
+            builder.add_instr(Instr::MapFile(MapFileInstr {
+                input: flat_file,
+                output: gfa_rsrc,
+            }));
+        }
+    }
+
     builder.build()
 }

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,4 +1,4 @@
-use crate::ir::{Builder, Instr, MapFileInstr, Program};
+use crate::ir::{Builder, Instr, MapFileInstr, Program, ResourceKind};
 use std::fs;
 
 fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
@@ -7,13 +7,10 @@ fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
         if let Instr::ParseGFA(parse) = instr {
             // Search for an `odgi-view` instruction that produces the GFA.
             let gfa = parse.input;
-            if let Some((view_idx, Instr::OdgiView(view))) =
-                instrs.iter().enumerate().find(|(_, instr)| match instr {
-                    Instr::OdgiView(view) => view.output == gfa,
-                    _ => false,
-                })
-            {
-                dbg!(parse_idx, parse, view_idx, view);
+            if let Some(view_idx) = instrs.iter().position(|instr| match instr {
+                Instr::OdgiView(view) => view.output == gfa,
+                _ => false,
+            }) {
                 return Some((view_idx, parse_idx));
             }
         }
@@ -25,8 +22,6 @@ pub fn optimize(prog: Program) -> Program {
     let mut builder = Builder::rebuild(prog);
 
     if let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) {
-        dbg!(view_idx, parse_idx);
-
         // Get the input `.og` file to this pair.
         let og_filename = if let Instr::OdgiView(view) = &builder.instrs[view_idx] {
             builder.file_name(view.input)
@@ -37,8 +32,8 @@ pub fn optimize(prog: Program) -> Program {
             .strip_suffix(".og")
             .expect("odgi-view inputs must end in .og");
 
-        // Get the final FlatGFA output resource.
-        let gfa_rsrc = if let Instr::ParseGFA(parse) = &builder.instrs[parse_idx] {
+        // Get the parsed FlatGFA output resource.
+        let old_gfa = if let Instr::ParseGFA(parse) = &builder.instrs[parse_idx] {
             parse.output
         } else {
             panic!()
@@ -48,11 +43,19 @@ pub fn optimize(prog: Program) -> Program {
         let flat_filename = format!("{stem}.flatgfa");
         if fs::exists(&flat_filename).unwrap() {
             // Make a new instruction to load the FlatGFA.
-            let flat_file = builder.file(flat_filename);
-            builder.add_instr(Instr::MapFile(MapFileInstr {
-                input: flat_file,
-                output: gfa_rsrc,
-            }));
+            let new_gfa = builder.add_rsrc(ResourceKind::Mmap);
+            let new_instr = MapFileInstr {
+                input: builder.file(flat_filename),
+                output: new_gfa,
+            };
+
+            // Swap it in where the old `parse-gfa` used to be, and remove the
+            // `odgi-view`.
+            builder.instrs[parse_idx] = new_instr;
+            builder.instrs.remove(view_idx);
+
+            // Replace all uses of `old_gfa` with `new_gfa`.
+            // TODO
         }
     }
 

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,14 +1,14 @@
-use crate::ir::{Builder, Instr, MapFileInstr, Program, ResourceKind};
+use crate::ir::{Builder, Instr, Op, Program, ResourceKind};
 use std::fs;
 
 fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
     // Search for a `parse-gfa` instruction.
     for (parse_idx, instr) in instrs.iter().enumerate() {
-        if let Instr::ParseGFA(parse) = instr {
+        if let Op::ParseGFA = instr.op {
             // Search for an `odgi-view` instruction that produces the GFA.
-            let gfa = parse.input;
-            if let Some(view_idx) = instrs.iter().position(|instr| match instr {
-                Instr::OdgiView(view) => view.output == gfa,
+            let gfa = instr.input;
+            if let Some(view_idx) = instrs.iter().position(|instr| match instr.op {
+                Op::OdgiView => instr.output == gfa,
                 _ => false,
             }) {
                 return Some((view_idx, parse_idx));
@@ -23,30 +23,23 @@ pub fn optimize(prog: Program) -> Program {
 
     if let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) {
         // Get the input `.og` file to this pair.
-        let og_filename = if let Instr::OdgiView(view) = &builder.instrs[view_idx] {
-            builder.file_name(view.input)
-        } else {
-            panic!()
-        };
+        let og_filename = builder.file_name(builder.instrs[view_idx].input);
         let stem = og_filename
             .strip_suffix(".og")
             .expect("odgi-view inputs must end in .og");
 
         // Get the parsed FlatGFA output resource.
-        let old_gfa = if let Instr::ParseGFA(parse) = &builder.instrs[parse_idx] {
-            parse.output
-        } else {
-            panic!()
-        };
+        let old_gfa = builder.instrs[parse_idx].output;
 
         // Does the FlatGFA exist?
         let flat_filename = format!("{stem}.flatgfa");
         if fs::exists(&flat_filename).unwrap() {
             // Make a new instruction to load the FlatGFA.
             let new_gfa = builder.add_rsrc(ResourceKind::Mmap);
-            let new_instr = MapFileInstr {
+            let new_instr = Instr {
                 input: builder.file(flat_filename),
                 output: new_gfa,
+                op: Op::MapFile,
             };
 
             // Swap it in where the old `parse-gfa` used to be, and remove the

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -18,42 +18,42 @@ fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
     None
 }
 
+fn opt_og_pair(builder: &mut Builder, view_idx: usize, parse_idx: usize) {
+    // Get the input `.og` file to this pair.
+    let og_filename = builder.file_name(builder.instrs[view_idx].input);
+    let stem = og_filename
+        .strip_suffix(".og")
+        .expect("odgi-view inputs must end in .og");
+
+    // Get the parsed FlatGFA output resource.
+    let old_gfa = builder.instrs[parse_idx].output;
+
+    // Does the FlatGFA exist?
+    let flat_filename = format!("{stem}.flatgfa");
+    if fs::exists(&flat_filename).unwrap() {
+        // Make a new instruction to load the FlatGFA.
+        let new_gfa = builder.rsrc(ResourceKind::Mmap);
+        let new_instr = Instr {
+            input: builder.file(flat_filename),
+            output: new_gfa,
+            op: Op::MapFile,
+        };
+
+        // Swap it in where the old `parse-gfa` used to be, and remove the
+        // `odgi-view`.
+        builder.instrs[parse_idx] = new_instr;
+        builder.instrs.remove(view_idx);
+
+        // Use the new resource in the rest of the program.
+        builder.replace_rsrc(old_gfa, new_gfa);
+    }
+}
+
 pub fn optimize(prog: Program) -> Program {
     let mut builder = Builder::rebuild(prog);
 
     if let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) {
-        // Get the input `.og` file to this pair.
-        let og_filename = builder.file_name(builder.instrs[view_idx].input);
-        let stem = og_filename
-            .strip_suffix(".og")
-            .expect("odgi-view inputs must end in .og");
-
-        // Get the parsed FlatGFA output resource.
-        let old_gfa = builder.instrs[parse_idx].output;
-
-        // Does the FlatGFA exist?
-        let flat_filename = format!("{stem}.flatgfa");
-        if fs::exists(&flat_filename).unwrap() {
-            // Make a new instruction to load the FlatGFA.
-            let new_gfa = builder.add_rsrc(ResourceKind::Mmap);
-            let new_instr = Instr {
-                input: builder.file(flat_filename),
-                output: new_gfa,
-                op: Op::MapFile,
-            };
-
-            // Swap it in where the old `parse-gfa` used to be, and remove the
-            // `odgi-view`.
-            builder.instrs[parse_idx] = new_instr;
-            builder.instrs.remove(view_idx);
-
-            // Replace all uses of `old_gfa` with `new_gfa`.
-            for instr in builder.instrs.iter_mut() {
-                if instr.input == old_gfa {
-                    instr.input = new_gfa;
-                }
-            }
-        }
+        opt_og_pair(&mut builder, view_idx, parse_idx);
     }
 
     builder.build()

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -48,7 +48,11 @@ pub fn optimize(prog: Program) -> Program {
             builder.instrs.remove(view_idx);
 
             // Replace all uses of `old_gfa` with `new_gfa`.
-            // TODO
+            for instr in builder.instrs.iter_mut() {
+                if instr.input == old_gfa {
+                    instr.input = new_gfa;
+                }
+            }
         }
     }
 

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,23 +1,29 @@
 use crate::ir::{Builder, Instr, Op, Program, ResourceKind};
 use std::fs;
 
-fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
-    // Search for a `parse-gfa` instruction.
-    let (parse_idx, parse_instr) = instrs
-        .iter()
-        .enumerate()
-        .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))?;
+/// Apply all our optimizations to a program.
+pub fn optimize(prog: Program) -> Program {
+    let mut builder = Builder::rebuild(prog);
 
-    // Search for an `odgi-view` instruction that produces the GFA.
-    let gfa = parse_instr.input;
-    let view_idx = instrs
-        .iter()
-        .position(|instr| matches!(instr.op, Op::OdgiView) && instr.output == gfa)?;
+    // Optimize `odgi-view` or `parse-gfa` into `map-file` when a FlatGFA file
+    // is available.
+    opt_gfa_parse(&mut builder);
+    opt_og_parse(&mut builder);
 
-    Some((view_idx, parse_idx))
+    builder.build()
 }
 
-fn opt_og_pair(builder: &mut Builder, view_idx: usize, parse_idx: usize) {
+/// Try to replace odgi inputs with FlatGFA binary inputs.
+///
+/// Search for an `odgi-view` instruction that reads an `.og` file and feeds
+/// into a `gfa-parse` instruction, and (if found) replace that pair with a
+/// `map-file` of a similarly-named `.fgfa` file that exists on the filesystem.
+fn opt_og_parse(builder: &mut Builder) {
+    // Find an `odgi-view` -> `gfa-parse` pair.
+    let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) else {
+        return;
+    };
+
     // Get the stem of the input `.og` file to this pair.
     let stem = builder
         .file_name(builder.instrs[view_idx].input)
@@ -41,6 +47,27 @@ fn opt_og_pair(builder: &mut Builder, view_idx: usize, parse_idx: usize) {
     }
 }
 
+fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
+    // Search for a `parse-gfa` instruction.
+    let (parse_idx, parse_instr) = instrs
+        .iter()
+        .enumerate()
+        .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))?;
+
+    // Search for an `odgi-view` instruction that produces the GFA.
+    let gfa = parse_instr.input;
+    let view_idx = instrs
+        .iter()
+        .position(|instr| matches!(instr.op, Op::OdgiView) && instr.output == gfa)?;
+
+    Some((view_idx, parse_idx))
+}
+
+/// Optimize GFA file input to FlatGFA input.
+///
+/// Search for a `parse-gfa` instruction for a `.gfa` file and, when the
+/// relevant file exists, replace it with a `map-file` of an equivalent
+/// `.flatgfa` file.
 fn opt_gfa_parse(builder: &mut Builder) {
     // Search for a `parse-gfa` instruction.
     if let Some((parse_idx, parse_instr)) = builder
@@ -64,6 +91,11 @@ fn opt_gfa_parse(builder: &mut Builder) {
     }
 }
 
+/// Replace an instruction with a `map-file` to open a FlatGFA binary file.
+///
+/// If the file `{stem}.flatgfa` exists, replace the instruction at `instr_idx`
+/// with a new instruction that maps that file. Update all consuming
+/// instructions to use the resulting resource instead of the parsed GFA.
 fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> bool {
     // Does the FlatGFA exist?
     let flat_filename = format!("{stem}.flatgfa");
@@ -88,18 +120,4 @@ fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> boo
     builder.replace_rsrc(old_gfa, new_gfa);
 
     true
-}
-
-pub fn optimize(prog: Program) -> Program {
-    let mut builder = Builder::rebuild(prog);
-
-    // Optimize `parse-gfa` when we have a FlatGFA file.
-    opt_gfa_parse(&mut builder);
-
-    // Optimize `odgi-view` when we have a FlatGFA file.
-    if let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) {
-        opt_og_pair(&mut builder, view_idx, parse_idx);
-    }
-
-    builder.build()
 }

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -18,37 +18,21 @@ fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
 }
 
 fn opt_og_pair(builder: &mut Builder, view_idx: usize, parse_idx: usize) {
-    // Get the input `.og` file to this pair.
-    let og_filename = builder.file_name(builder.instrs[view_idx].input);
-    let stem = og_filename
+    // Get the stem of the input `.og` file to this pair.
+    let stem = builder
+        .file_name(builder.instrs[view_idx].input)
         .strip_suffix(".og")
-        .expect("odgi-view inputs must end in .og");
+        .expect("odgi-view inputs must end in .og")
+        .to_string();
 
-    // Get the parsed FlatGFA output resource.
-    let old_gfa = builder.instrs[parse_idx].output;
-
-    // Does the FlatGFA exist?
-    let flat_filename = format!("{stem}.flatgfa");
-    if fs::exists(&flat_filename).unwrap() {
-        // Make a new instruction to load the FlatGFA.
-        let new_gfa = builder.rsrc(ResourceKind::Mmap);
-        let new_instr = Instr {
-            input: builder.file(flat_filename),
-            output: new_gfa,
-            op: Op::MapFile,
-        };
-
-        // Swap it in where the old `parse-gfa` used to be, and remove the
-        // `odgi-view`.
-        builder.instrs[parse_idx] = new_instr;
+    // Try replacing this with a FlatGFA load.
+    if replace_with_flat(builder, &stem, parse_idx) {
+        // Remove the `odgi-view` too.
         builder.instrs.remove(view_idx);
-
-        // Use the new resource in the rest of the program.
-        builder.replace_rsrc(old_gfa, new_gfa);
         return;
     }
 
-    // Otherwise, does the text GFA exist?
+    // Otherwise, try replacing this with a direct text GFA parse.
     let text_filename = format!("{stem}.gfa");
     if fs::exists(&text_filename).unwrap() {
         // Make the `parse-gfa` read from this file, and remove the `odgi-view`.
@@ -57,9 +41,62 @@ fn opt_og_pair(builder: &mut Builder, view_idx: usize, parse_idx: usize) {
     }
 }
 
+fn opt_gfa_parse(builder: &mut Builder) {
+    // Search for a `parse-gfa` instruction.
+    if let Some((parse_idx, parse_instr)) = builder
+        .instrs
+        .iter()
+        .enumerate()
+        .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))
+    {
+        // Get the stem of the input `.gfa` file, if it's a file.
+        if parse_instr.input.kind != ResourceKind::File {
+            return;
+        }
+        let stem = builder
+            .file_name(parse_instr.input)
+            .strip_suffix(".gfa")
+            .expect("parse-gfa inputs must end in .gfa")
+            .to_string();
+
+        // Try replacing it with a FlatGFA load.
+        replace_with_flat(builder, &stem, parse_idx);
+    }
+}
+
+fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> bool {
+    // Does the FlatGFA exist?
+    let flat_filename = format!("{stem}.flatgfa");
+    if !fs::exists(&flat_filename).unwrap() {
+        return false;
+    }
+
+    // Make a new instruction to load the FlatGFA.
+    let new_gfa = builder.rsrc(ResourceKind::Mmap);
+    let new_instr = Instr {
+        input: builder.file(flat_filename),
+        output: new_gfa,
+        op: Op::MapFile,
+    };
+
+    // Swap it in where the old producer instruction used to be.
+    let old_gfa = builder.instrs[instr_idx].output;
+    builder.instrs[instr_idx] = new_instr;
+
+    // Use the new resource in the rest of the program, replacing the producer
+    // instruction's old result.
+    builder.replace_rsrc(old_gfa, new_gfa);
+
+    true
+}
+
 pub fn optimize(prog: Program) -> Program {
     let mut builder = Builder::rebuild(prog);
 
+    // Optimize `parse-gfa` when we have a FlatGFA file.
+    opt_gfa_parse(&mut builder);
+
+    // Optimize `odgi-view` when we have a FlatGFA file.
     if let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) {
         opt_og_pair(&mut builder, view_idx, parse_idx);
     }

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -45,6 +45,15 @@ fn opt_og_pair(builder: &mut Builder, view_idx: usize, parse_idx: usize) {
 
         // Use the new resource in the rest of the program.
         builder.replace_rsrc(old_gfa, new_gfa);
+        return;
+    }
+
+    // Otherwise, does the text GFA exist?
+    let text_filename = format!("{stem}.gfa");
+    if fs::exists(&text_filename).unwrap() {
+        // Make the `parse-gfa` read from this file, and remove the `odgi-view`.
+        builder.instrs[parse_idx].input = builder.file(text_filename);
+        builder.instrs.remove(view_idx);
     }
 }
 

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -115,7 +115,7 @@ fn node_to_ir(builder: &mut Builder, node: Node, input: Resource, output: Resour
                 let output = if i == last {
                     output
                 } else {
-                    builder.add_rsrc(ir::ResourceKind::Pipe)
+                    builder.rsrc(ir::ResourceKind::Pipe)
                 };
                 node_to_ir(builder, step, input, output);
                 input = output; // Feed this pipe into the next step.

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::ir::{self, Builder, Resource};
+use crate::ir::{self, Builder, Op, Resource};
 use flash::parser::{Node, Redirect, RedirectKind};
 use pico_args::Arguments;
 
@@ -48,13 +48,15 @@ fn cmd_to_ir(
                 // table, and `-d` switches to a per-node table. (There are
                 // other modes, such as `-D`, to support...)
                 if argp.contains("-d") {
-                    builder.add_instr(ir::NodeDepthInstr { input, output });
+                    builder.instr(input, output, Op::NodeDepth);
                 } else {
-                    builder.add_instr(ir::PathDepthInstr {
+                    builder.instr(
                         input,
                         output,
-                        path: argp.opt_value_from_str("-r").unwrap(),
-                    });
+                        Op::PathDepth {
+                            path: argp.opt_value_from_str("-r").unwrap(),
+                        },
+                    );
                 };
             }
             _ => unimplemented!("unsupported odgi subcommand"),
@@ -73,22 +75,26 @@ fn cmd_to_ir(
                 // Use an instruction to parse the BED file.
                 let input = builder.load_bed(input);
 
-                builder.add_instr(ir::MakeWindowsInstr {
+                builder.instr(
                     input,
                     output,
-                    size: argp.value_from_str("-w").unwrap(),
-                });
+                    Op::MakeWindows {
+                        size: argp.value_from_str("-w").unwrap(),
+                    },
+                );
             }
             _ => unimplemented!("unsupported bedtools subcommand"),
         }
     } else {
         // Any non-odgi command is a "passthrough" shell command.
-        builder.add_instr(ir::ExecInstr {
+        builder.instr(
             input,
             output,
-            command: name,
-            args,
-        });
+            Op::Exec {
+                command: name,
+                args,
+            },
+        );
     }
 }
 

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -20,16 +20,43 @@ impl<'a, T> Wrapped<'a, T> {
 
 impl Display for Wrapped<'_, ir::Instr> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match &self.val {
-            ir::Instr::NodeDepth(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::PathDepth(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::Exec(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::ParseGFA(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::MapFile(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::ParseBED(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::MakeWindows(instr) => self.wrap(instr).fmt(f),
-            ir::Instr::OdgiView(instr) => self.wrap(instr).fmt(f),
+        // Exec instructions get formatted in a special way.
+        if let ir::Op::Exec { command, args } = &self.val.op {
+            write!(
+                f,
+                "shell({:?}, {:?}, input={}) -> {}",
+                command,
+                args,
+                self.wrap(&self.val.input),
+                self.wrap(&self.val.output)
+            )?;
+            return Ok(());
         }
+
+        // Other instructions follow a `name(input, args) -> output` pattern.
+        let name = match &self.val.op {
+            ir::Op::NodeDepth => "node-depth",
+            ir::Op::PathDepth { path: _ } => "path-depth",
+            ir::Op::Exec {
+                command: _,
+                args: _,
+            } => "exec",
+            ir::Op::ParseGFA => "parse-gfa",
+            ir::Op::MapFile => "map-file",
+            ir::Op::ParseBED => "parse-bed",
+            ir::Op::MakeWindows { size: _ } => "make-windows",
+            ir::Op::OdgiView => "odgi-view",
+        };
+        write!(f, "{}({}", name, self.wrap(&self.val.input))?;
+        match &self.val.op {
+            ir::Op::PathDepth { path: Some(path) } => write!(f, ", path={:?}", path)?,
+            ir::Op::Exec { command, args } => {
+                write!(f, ", command={:?}, args={:?}", command, args)?
+            }
+            ir::Op::MakeWindows { size } => write!(f, ", size={}", size)?,
+            _ => (),
+        };
+        write!(f, ") -> {}", self.wrap(&self.val.output))
     }
 }
 
@@ -45,96 +72,6 @@ impl Display for Wrapped<'_, ir::Resource> {
             ir::ResourceKind::Mmap => write!(f, "mmap-{}", index),
             ir::ResourceKind::BEDStore => write!(f, "bed-store-{}", index),
         }
-    }
-}
-
-impl Display for Wrapped<'_, ir::NodeDepthInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "node-depth({}) -> {}",
-            self.wrap(&self.val.input),
-            self.wrap(&self.val.output),
-        )
-    }
-}
-
-impl Display for Wrapped<'_, ir::PathDepthInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "path-depth({}", self.wrap(&self.val.input))?;
-        if let Some(path) = &self.val.path {
-            write!(f, ", path=\"{}\"", path)?;
-        }
-        write!(f, ") -> {}", self.wrap(&self.val.output))
-    }
-}
-
-impl Display for Wrapped<'_, ir::ExecInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "shell({:?}, {:?}, input={}) -> {}",
-            self.val.command,
-            self.val.args,
-            self.wrap(&self.val.input),
-            self.wrap(&self.val.output),
-        )
-    }
-}
-
-impl Display for Wrapped<'_, ir::ParseGFAInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "parse-gfa({}) -> {}",
-            self.wrap(&self.val.input),
-            self.wrap(&self.val.output),
-        )
-    }
-}
-
-impl Display for Wrapped<'_, ir::MapFileInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "map-file({}) -> {}",
-            self.wrap(&self.val.input),
-            self.wrap(&self.val.output),
-        )
-    }
-}
-
-impl Display for Wrapped<'_, ir::ParseBEDInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "parse-bed({}) -> {}",
-            self.wrap(&self.val.input),
-            self.wrap(&self.val.output),
-        )
-    }
-}
-
-impl Display for Wrapped<'_, ir::MakeWindowsInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "make-windows({}, {}) -> {}",
-            self.wrap(&self.val.input),
-            self.val.size,
-            self.wrap(&self.val.output),
-        )
-    }
-}
-
-impl Display for Wrapped<'_, ir::OdgiViewInstr> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "odgi-view({}) -> {}",
-            self.wrap(&self.val.input),
-            self.wrap(&self.val.output),
-        )
     }
 }
 

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -28,6 +28,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Instr::MapFile(instr) => self.wrap(instr).fmt(f),
             ir::Instr::ParseBED(instr) => self.wrap(instr).fmt(f),
             ir::Instr::MakeWindows(instr) => self.wrap(instr).fmt(f),
+            ir::Instr::OdgiView(instr) => self.wrap(instr).fmt(f),
         }
     }
 }
@@ -121,6 +122,17 @@ impl Display for Wrapped<'_, ir::MakeWindowsInstr> {
             "make-windows({}, {}) -> {}",
             self.wrap(&self.val.input),
             self.val.size,
+            self.wrap(&self.val.output),
+        )
+    }
+}
+
+impl Display for Wrapped<'_, ir::OdgiViewInstr> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "odgi-view({}) -> {}",
+            self.wrap(&self.val.input),
             self.wrap(&self.val.output),
         )
     }


### PR DESCRIPTION
First, I added the ability to take `.og` files as input. We just execute `odgi view -g` in a subprocess to get the GFA and then parse that.

Next, I introduced an optimization that removes this when possible. It detects when you're using an `.og` file where an identically-named `.flatgfa` file is also available and changes the program to use that instead. The shell has an `-O` flag to enable optimizations. You can see the difference in "pretend" mode:

```
$ flash -p -c 'odgi depth -i ../tests/note5.og'
odgi-view("../tests/note5.og") -> pipe-0
parse-gfa(pipe-0) -> gfa-store-0
path-depth(gfa-store-0) -> stdout

$ flash -p -O -c 'odgi depth -i ../tests/note5.og'
map-file("../tests/note5.flatgfa") -> mmap-0
path-depth(mmap-0) -> stdout
```