### PR TITLE
Support separate `odgi depth -b` for arbitrary interval depth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "memmap",
  "pico-args",
  "rustyline",
+ "smallvec",
  "trycmd",
 ]
 

--- a/flatgfa-sh/Cargo.toml
+++ b/flatgfa-sh/Cargo.toml
@@ -14,7 +14,8 @@ pico-args = "0.5"
 rustyline = "18"
 memmap = { workspace = true }
 bstr = { workspace = true }
-enum-map = "2.7.3"
+enum-map = "2"
+smallvec = "1"
 
 [dev-dependencies]
 trycmd = "1.2.0"

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -161,6 +161,10 @@ Here's a shell script that uses a pipeline to combine `odgi depth` and
 
 ```console
 $ flash windows.sh
-5	0	4
+#path	start	end	mean.depth
+5	0	4	2
+5	4	8	2
+5	8	12	2
+5	12	13	2
 
 ```

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -7,14 +7,14 @@ use std::io;
 /// Execute a single instruction.
 pub fn eval(env: &mut Env, instr: &Instr) {
     match &instr.op {
-        Op::NodeDepth => node_depth(env, instr.input, instr.output),
-        Op::PathDepth { path } => path_depth(env, instr.input, instr.output, path),
-        Op::Exec { command, args } => exec(env, instr.input, instr.output, command, args),
-        Op::ParseGFA => parse_gfa(env, instr.input, instr.output),
-        Op::MapFile => map_file(env, instr.input, instr.output),
-        Op::ParseBED => parse_bed(env, instr.input, instr.output),
-        Op::MakeWindows { size } => make_windows(env, instr.input, instr.output, *size),
-        Op::OdgiView => odgi_view(env, instr.input, instr.output),
+        Op::NodeDepth => node_depth(env, instr.inputs[0], instr.output),
+        Op::PathDepth { path } => path_depth(env, instr.inputs[0], instr.output, path),
+        Op::Exec { command, args } => exec(env, instr.inputs[0], instr.output, command, args),
+        Op::ParseGFA => parse_gfa(env, instr.inputs[0], instr.output),
+        Op::MapFile => map_file(env, instr.inputs[0], instr.output),
+        Op::ParseBED => parse_bed(env, instr.inputs[0], instr.output),
+        Op::MakeWindows { size } => make_windows(env, instr.inputs[0], instr.output, *size),
+        Op::OdgiView => odgi_view(env, instr.inputs[0], instr.output),
     }
 }
 

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -15,6 +15,7 @@ pub fn eval(env: &mut Env, instr: &Instr) {
         Op::ParseBED => parse_bed(env, instr.inputs[0], instr.output),
         Op::MakeWindows { size } => make_windows(env, instr.inputs[0], instr.output, *size),
         Op::OdgiView => odgi_view(env, instr.inputs[0], instr.output),
+        Op::IntervalDepth => interval_depth(env, instr.inputs[0], instr.inputs[1], instr.output),
     }
 }
 
@@ -140,4 +141,19 @@ fn odgi_view(env: &mut Env, input: Resource, output: Resource) {
         },
         output,
     )
+}
+
+fn interval_depth(env: &mut Env, gfa_rsrc: Resource, bed_rsrc: Resource, output: Resource) {
+    let bed_store = env.bed_stores[bed_rsrc].take().unwrap();
+    let gfa = env.flatgfa(gfa_rsrc);
+
+    let depths = ops::window_depth::bed_depth(&gfa, &bed_store.as_ref());
+
+    let mut out = env.output(output);
+    out.write("#path\tstart\tend\tmean.depth\n").unwrap();
+    out.emit(ops::window_depth::IntervalDepth {
+        intervals: bed_store.as_ref(),
+        depths,
+    })
+    .unwrap();
 }

--- a/flatgfa-sh/src/eval/mod.rs
+++ b/flatgfa-sh/src/eval/mod.rs
@@ -8,7 +8,7 @@ use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile};
 use memmap::Mmap;
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter};
+use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter, Write};
 use std::ops::{Index, IndexMut};
 
 struct Env {
@@ -201,6 +201,14 @@ impl Output {
             Self::Stdout(ref mut s) => val.emit(s),
             Self::File(ref mut s) => val.emit(s),
             Self::Pipe(ref mut s) => val.emit(s),
+        }
+    }
+
+    fn write<T: std::fmt::Display>(&mut self, val: T) -> std::io::Result<()> {
+        match *self {
+            Self::Stdout(ref mut s) => write!(s, "{}", val),
+            Self::File(ref mut s) => write!(s, "{}", val),
+            Self::Pipe(ref mut s) => write!(s, "{}", val),
         }
     }
 }

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -45,6 +45,7 @@ pub enum Op {
         size: usize,
     },
     OdgiView,
+    IntervalDepth,
 }
 
 #[derive(Debug)]

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -21,7 +21,7 @@ pub struct Resource {
 /// An instruction performs one imperative action.
 #[derive(Debug)]
 pub struct Instr {
-    pub input: Resource,
+    pub inputs: Vec<Resource>,
     pub output: Resource,
     pub op: Op,
 }
@@ -89,8 +89,12 @@ impl Builder {
     }
 
     /// Add an instruction to the end of the program.
-    pub fn instr(&mut self, input: Resource, output: Resource, op: Op) {
-        self.instrs.push(Instr { input, output, op })
+    pub fn instr(&mut self, inputs: &[Resource], output: Resource, op: Op) {
+        self.instrs.push(Instr {
+            inputs: inputs.to_vec(),
+            output,
+            op,
+        })
     }
 
     /// Add a file resource, or get an existing one if we've already added it.
@@ -147,19 +151,19 @@ impl Builder {
             ResourceKind::File if self.file_name(input).ends_with(".flatgfa") => {
                 // Memory-map the FlatGFA binary file.
                 let output = self.rsrc(ResourceKind::Mmap);
-                self.instr(input, output, Op::MapFile);
+                self.instr(&[input], output, Op::MapFile);
                 output
             }
             ResourceKind::File if self.file_name(input).ends_with(".og") => {
                 // Use `odgi view` to dump as GFA text and then parse that.
                 let pipe = self.rsrc(ResourceKind::Pipe);
-                self.instr(input, pipe, Op::OdgiView);
+                self.instr(&[input], pipe, Op::OdgiView);
                 self.load_gfa(pipe)
             }
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
                 // Parse as GFA text.
                 let output = self.rsrc(ResourceKind::GFAStore);
-                self.instr(input, output, Op::ParseGFA);
+                self.instr(&[input], output, Op::ParseGFA);
                 output
             }
             _ => panic!("cannot parse this resource as GFA text"),
@@ -171,7 +175,7 @@ impl Builder {
         match input.kind {
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
                 let output = self.rsrc(ResourceKind::BEDStore);
-                self.instr(input, output, Op::ParseBED);
+                self.instr(&[input], output, Op::ParseBED);
                 output
             }
             _ => panic!("cannot parse this resource as BED text"),
@@ -181,8 +185,10 @@ impl Builder {
     /// Replace all uses of one resource with another.
     pub fn replace_rsrc(&mut self, old: Resource, new: Resource) {
         for instr in self.instrs.iter_mut() {
-            if instr.input == old {
-                instr.input = new;
+            for input in instr.inputs.iter_mut() {
+                if *input == old {
+                    *input = new;
+                }
             }
             if instr.output == old {
                 instr.output = new;

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -1,4 +1,5 @@
 use enum_map::{Enum, EnumMap};
+use smallvec::SmallVec;
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Enum)]
@@ -21,7 +22,7 @@ pub struct Resource {
 /// An instruction performs one imperative action.
 #[derive(Debug)]
 pub struct Instr {
-    pub inputs: Vec<Resource>,
+    pub inputs: SmallVec<[Resource; 2]>,
     pub output: Resource,
     pub op: Op,
 }
@@ -30,12 +31,19 @@ pub struct Instr {
 #[derive(Debug)]
 pub enum Op {
     NodeDepth,
-    PathDepth { path: Option<String> },
-    Exec { command: String, args: Vec<String> },
+    PathDepth {
+        path: Option<String>,
+    },
+    Exec {
+        command: String,
+        args: SmallVec<[String; 4]>,
+    },
     ParseGFA,
     MapFile,
     ParseBED,
-    MakeWindows { size: usize },
+    MakeWindows {
+        size: usize,
+    },
     OdgiView,
 }
 
@@ -91,7 +99,7 @@ impl Builder {
     /// Add an instruction to the end of the program.
     pub fn instr(&mut self, inputs: &[Resource], output: Resource, op: Op) {
         self.instrs.push(Instr {
-            inputs: inputs.to_vec(),
+            inputs: inputs.into(),
             output,
             op,
         })

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,4 +1,5 @@
 use crate::ir::{Builder, Instr, Op, Program, ResourceKind};
+use smallvec::SmallVec;
 use std::fs;
 
 /// Apply all our optimizations to a program.
@@ -106,7 +107,7 @@ fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> boo
     // Make a new instruction to load the FlatGFA.
     let new_gfa = builder.rsrc(ResourceKind::Mmap);
     let new_instr = Instr {
-        inputs: vec![builder.file(flat_filename)],
+        inputs: SmallVec::from_slice(&[builder.file(flat_filename)]),
         output: new_gfa,
         op: Op::MapFile,
     };

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -26,7 +26,7 @@ fn opt_og_parse(builder: &mut Builder) {
 
     // Get the stem of the input `.og` file to this pair.
     let stem = builder
-        .file_name(builder.instrs[view_idx].input)
+        .file_name(builder.instrs[view_idx].inputs[0])
         .strip_suffix(".og")
         .expect("odgi-view inputs must end in .og")
         .to_string();
@@ -42,7 +42,7 @@ fn opt_og_parse(builder: &mut Builder) {
     let text_filename = format!("{stem}.gfa");
     if fs::exists(&text_filename).unwrap() {
         // Make the `parse-gfa` read from this file, and remove the `odgi-view`.
-        builder.instrs[parse_idx].input = builder.file(text_filename);
+        builder.instrs[parse_idx].inputs[0] = builder.file(text_filename);
         builder.instrs.remove(view_idx);
     }
 }
@@ -55,7 +55,7 @@ fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
         .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))?;
 
     // Search for an `odgi-view` instruction that produces the GFA.
-    let gfa = parse_instr.input;
+    let gfa = parse_instr.inputs[0];
     let view_idx = instrs
         .iter()
         .position(|instr| matches!(instr.op, Op::OdgiView) && instr.output == gfa)?;
@@ -77,11 +77,11 @@ fn opt_gfa_parse(builder: &mut Builder) {
         .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))
     {
         // Get the stem of the input `.gfa` file, if it's a file.
-        if parse_instr.input.kind != ResourceKind::File {
+        if parse_instr.inputs[0].kind != ResourceKind::File {
             return;
         }
         let stem = builder
-            .file_name(parse_instr.input)
+            .file_name(parse_instr.inputs[0])
             .strip_suffix(".gfa")
             .expect("parse-gfa inputs must end in .gfa")
             .to_string();
@@ -106,7 +106,7 @@ fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> boo
     // Make a new instruction to load the FlatGFA.
     let new_gfa = builder.rsrc(ResourceKind::Mmap);
     let new_instr = Instr {
-        input: builder.file(flat_filename),
+        inputs: vec![builder.file(flat_filename)],
         output: new_gfa,
         op: Op::MapFile,
     };

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -92,7 +92,7 @@ fn cmd_to_ir(
             output,
             Op::Exec {
                 command: name,
-                args,
+                args: args.into(),
             },
         );
     }

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -45,10 +45,14 @@ fn cmd_to_ir(
                 let input = builder.load_gfa(input);
 
                 // In the `odgi depth` command line, the default is a per-path
-                // table, and `-d` switches to a per-node table. (There are
-                // other modes, such as `-D`, to support...)
+                // table. `-d` switches to a per-node table, and `-b` takes a
+                // BED file and switches to an interval table.
                 if argp.contains("-d") {
                     builder.instr(&[input], output, Op::NodeDepth);
+                } else if let Some(bed_file) = argp.opt_value_from_str("-b").unwrap() {
+                    let bed_file = builder.file(bed_file);
+                    let bed_rsrc = builder.load_bed(bed_file);
+                    builder.instr(&[input, bed_rsrc], output, Op::IntervalDepth)
                 } else {
                     builder.instr(
                         &[input],

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -48,10 +48,10 @@ fn cmd_to_ir(
                 // table, and `-d` switches to a per-node table. (There are
                 // other modes, such as `-D`, to support...)
                 if argp.contains("-d") {
-                    builder.instr(input, output, Op::NodeDepth);
+                    builder.instr(&[input], output, Op::NodeDepth);
                 } else {
                     builder.instr(
-                        input,
+                        &[input],
                         output,
                         Op::PathDepth {
                             path: argp.opt_value_from_str("-r").unwrap(),
@@ -76,7 +76,7 @@ fn cmd_to_ir(
                 let input = builder.load_bed(input);
 
                 builder.instr(
-                    input,
+                    &[input],
                     output,
                     Op::MakeWindows {
                         size: argp.value_from_str("-w").unwrap(),
@@ -88,7 +88,7 @@ fn cmd_to_ir(
     } else {
         // Any non-odgi command is a "passthrough" shell command.
         builder.instr(
-            input,
+            &[input],
             output,
             Op::Exec {
                 command: name,

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -46,6 +46,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Op::ParseBED => "parse-bed",
             ir::Op::MakeWindows { size: _ } => "make-windows",
             ir::Op::OdgiView => "odgi-view",
+            ir::Op::IntervalDepth => "interval-depth",
         };
         write!(f, "{}({}", name, self.wrap(&self.val.inputs[0]))?;
         for input in &self.val.inputs[1..] {

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -27,7 +27,7 @@ impl Display for Wrapped<'_, ir::Instr> {
                 "shell({:?}, {:?}, input={}) -> {}",
                 command,
                 args,
-                self.wrap(&self.val.input),
+                self.wrap(&self.val.inputs[0]),
                 self.wrap(&self.val.output)
             )?;
             return Ok(());
@@ -47,7 +47,10 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Op::MakeWindows { size: _ } => "make-windows",
             ir::Op::OdgiView => "odgi-view",
         };
-        write!(f, "{}({}", name, self.wrap(&self.val.input))?;
+        write!(f, "{}({}", name, self.wrap(&self.val.inputs[0]))?;
+        for input in &self.val.inputs[1..] {
+            write!(f, ", {}", self.wrap(input))?;
+        }
         match &self.val.op {
             ir::Op::PathDepth { path: Some(path) } => write!(f, ", path={:?}", path)?,
             ir::Op::Exec { command, args } => {

--- a/flatgfa-sh/windows.sh
+++ b/flatgfa-sh/windows.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 odgi depth -i ../tests/note5.gfa -r 5 | bedtools makewindows -b /dev/stdin -w 4 > note5.w4.bed
-head -n1 note5.w4.bed
+odgi depth -i ../tests/note5.gfa -b note5.w4.bed
 rm -f note5.w4.bed

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -222,13 +222,18 @@ pub struct Depth {
     #[argh(switch, long = "graph-depth-table", short = 'd')]
     seg_depth: bool,
 
-    /// in path mode, show only the namedpath
+    /// in path mode, show only the named path
     #[argh(option, short = 'r')]
     path: Vec<bstr::BString>,
+
+    /// show depth for intervals from a BED file
+    #[argh(option, long = "bed-input", short = 'b')]
+    bed: Option<String>,
 }
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
     use crate::ops::depth::{path_depth, seg_depth, PathDepth, SegDepth};
+    use crate::ops::window_depth::interval_depth_bed;
     if args.seg_depth {
         // Segment depth table.
         let (depths, uniq_depths) = seg_depth(gfa);
@@ -238,6 +243,11 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
             uniq_depths,
         }
         .print();
+    } else if let Some(bed) = args.bed {
+        // Interval depth table.
+        let file = memfile::map_file(&bed);
+        let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
+        interval_depth_bed(gfa, &bed_store.as_ref());
     } else {
         // Path depth table.
         if args.path.is_empty() {

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -233,7 +233,7 @@ pub struct Depth {
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
     use crate::ops::depth::{path_depth, seg_depth, PathDepth, SegDepth};
-    use crate::ops::window_depth::{interval_depth, IntervalDepth};
+    use crate::ops::window_depth::{bed_depth, IntervalDepth};
     if args.seg_depth {
         // Segment depth table.
         let (depths, uniq_depths) = seg_depth(gfa);
@@ -247,7 +247,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
         // Interval depth table.
         let file = memfile::map_file(&bed);
         let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
-        let depths = interval_depth(gfa, &bed_store.as_ref());
+        let depths = bed_depth(gfa, &bed_store.as_ref());
         IntervalDepth {
             intervals: bed_store.as_ref(),
             depths,

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -233,7 +233,7 @@ pub struct Depth {
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
     use crate::ops::depth::{path_depth, seg_depth, PathDepth, SegDepth};
-    use crate::ops::window_depth::interval_depth;
+    use crate::ops::window_depth::{interval_depth, IntervalDepth};
     if args.seg_depth {
         // Segment depth table.
         let (depths, uniq_depths) = seg_depth(gfa);
@@ -247,7 +247,12 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
         // Interval depth table.
         let file = memfile::map_file(&bed);
         let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
-        interval_depth(gfa, &bed_store.as_ref()).print();
+        let depths = interval_depth(gfa, &bed_store.as_ref());
+        IntervalDepth {
+            intervals: bed_store.as_ref(),
+            depths,
+        }
+        .print()
     } else {
         // Path depth table.
         if args.path.is_empty() {
@@ -482,5 +487,10 @@ pub struct WindowDepth {
 
 pub fn window_depth(gfa: &flatgfa::FlatGFA, args: WindowDepth) {
     let path = gfa.find_path(args.path.as_ref()).expect("path not found");
-    ops::window_depth::window_depth(gfa, path, args.window).print();
+    let (intervals, depths) = ops::window_depth::window_depth(gfa, path, args.window);
+    ops::window_depth::IntervalDepth {
+        intervals: intervals.as_ref(),
+        depths,
+    }
+    .print()
 }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -233,7 +233,7 @@ pub struct Depth {
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
     use crate::ops::depth::{path_depth, seg_depth, PathDepth, SegDepth};
-    use crate::ops::window_depth::interval_depth_bed;
+    use crate::ops::window_depth::interval_depth;
     if args.seg_depth {
         // Segment depth table.
         let (depths, uniq_depths) = seg_depth(gfa);
@@ -247,7 +247,7 @@ pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
         // Interval depth table.
         let file = memfile::map_file(&bed);
         let bed_store = BEDParser::for_heap().parse_mem(file.as_ref());
-        interval_depth_bed(gfa, &bed_store.as_ref());
+        interval_depth(gfa, &bed_store.as_ref()).print();
     } else {
         // Path depth table.
         if args.path.is_empty() {
@@ -482,5 +482,5 @@ pub struct WindowDepth {
 
 pub fn window_depth(gfa: &flatgfa::FlatGFA, args: WindowDepth) {
     let path = gfa.find_path(args.path.as_ref()).expect("path not found");
-    ops::window_depth::window_depth_bed(gfa, path, args.window);
+    ops::window_depth::window_depth(gfa, path, args.window).print();
 }

--- a/flatgfa/src/ops/window_depth.rs
+++ b/flatgfa/src/ops/window_depth.rs
@@ -1,3 +1,4 @@
+use crate::flatbed::FlatBED;
 use crate::flatgfa::{self, Path};
 use crate::ops::depth::{format_float, seg_depth};
 use crate::pool::Id;
@@ -104,7 +105,8 @@ fn assign_depths(
     depths
 }
 
-/// Compute the depth for windows along a path and print a BED file.
+/// Compute the depth for equally-sized windows along a given path and print a
+/// BED file.
 pub fn window_depth_bed(gfa: &flatgfa::FlatGFA, path: Id<Path>, window_size: usize) {
     // The actual depth computation.
     let depth = seg_depth(gfa).0;
@@ -113,6 +115,41 @@ pub fn window_depth_bed(gfa: &flatgfa::FlatGFA, path: Id<Path>, window_size: usi
     let window_depths = assign_depths(seg_depths, &windows);
 
     // Print a BED table with these weights.
+    let name = gfa.get_path_name(&gfa.paths[path]);
+    for i in 0..windows.len() {
+        let start = windows[i].0;
+        let end = windows[i].1;
+        let depth_str = format_float(window_depths[i], 4);
+        println!("{name}\t{start}\t{end}\t{depth_str}");
+    }
+}
+
+/// Compute the depth for arbitrary intervals and print a BED file.
+///
+/// The intervals must be (1) along a single path and (2) sorted in increasing
+/// order along that path.
+pub fn interval_depth_bed(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) {
+    // We assume that this BED interval file contains only intervals from a
+    // single path. (Relaxing this assumption without sacrificing performance is
+    // interesting future work.)
+    let path_name = intervals.get_name_of_entry(&intervals.entries.all()[0]);
+    let path = gfa.find_path(path_name).expect("path not found in graph");
+
+    // TODO Avoid this conversion cost!
+    let windows: Vec<_> = intervals
+        .entries
+        .all()
+        .iter()
+        .map(|entry| (entry.start as usize, entry.end as usize))
+        .collect();
+
+    // TODO Share this stuff with `window_depth_bed`!
+    let depth = seg_depth(gfa).0;
+    let seg_depths = weighted_depths(gfa, &depth, path);
+    let window_depths = assign_depths(seg_depths, &windows);
+
+    // TODO Separate computation & printing so we can share this stuff with
+    // `window_depth_bed`!
     let name = gfa.get_path_name(&gfa.paths[path]);
     for i in 0..windows.len() {
         let start = windows[i].0;

--- a/flatgfa/src/ops/window_depth.rs
+++ b/flatgfa/src/ops/window_depth.rs
@@ -135,37 +135,42 @@ impl Emit for IntervalDepth<'_> {
     }
 }
 
+/// Compute the depth for a sequence of intervals along a single path.
+///
+/// Return one weighted depth value per interval. We require a path so we can
+/// avoid computing any average weights for segments not included within that
+/// path.
+fn interval_depth(gfa: &flatgfa::FlatGFA, path: Id<Path>, intervals: &FlatBED) -> Vec<f64> {
+    let depth = seg_depth(gfa).0;
+    let seg_depths = weighted_depths(gfa, &depth, path);
+    assign_depths(seg_depths, intervals)
+}
+
 /// Compute the depth for equally-sized windows along a given path.
 pub fn window_depth(
     gfa: &flatgfa::FlatGFA,
     path: Id<Path>,
     window_size: usize,
 ) -> (HeapBEDStore, Vec<f64>) {
-    let path_name = gfa.get_path_name(&gfa.paths[path]).to_owned();
-    let depth = seg_depth(gfa).0;
     let windows = make_windows(
-        path_name.as_ref(),
+        gfa.get_path_name(&gfa.paths[path]),
         path_length(gfa, path) as u64,
         window_size as u64,
     );
-    let seg_depths = weighted_depths(gfa, &depth, path);
-    let depths = assign_depths(seg_depths, &windows.as_ref());
+    let depths = interval_depth(gfa, path, &windows.as_ref());
     (windows, depths)
 }
 
-/// Compute the depth for arbitrary intervals and print a BED file.
+/// Compute the depth for arbitrary intervals from a FlatBED.
 ///
 /// The intervals must be (1) along a single path and (2) sorted in increasing
 /// order along that path.
-pub fn interval_depth(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) -> Vec<f64> {
+pub fn bed_depth(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) -> Vec<f64> {
     // We assume that this BED interval file contains only intervals from a
     // single path. (Relaxing this assumption without sacrificing performance is
     // interesting future work.)
     let path_name = intervals.get_name_of_entry(&intervals.entries.all()[0]);
     let path = gfa.find_path(path_name).expect("path not found in graph");
 
-    // TODO Share this stuff with `window_depth_bed`!
-    let depth = seg_depth(gfa).0;
-    let seg_depths = weighted_depths(gfa, &depth, path);
-    assign_depths(seg_depths, intervals)
+    interval_depth(gfa, path, intervals)
 }

--- a/flatgfa/src/ops/window_depth.rs
+++ b/flatgfa/src/ops/window_depth.rs
@@ -1,8 +1,10 @@
+use crate::emit::Emit;
 use crate::flatbed::FlatBED;
 use crate::flatgfa::{self, Path};
 use crate::ops::depth::{format_float, seg_depth};
 use crate::pool::Id;
 use crate::FlatGFA;
+use bstr::BString;
 
 struct SegmentDepth {
     depth: f64,
@@ -105,22 +107,38 @@ fn assign_depths(
     depths
 }
 
+/// The result of a window or arbitrary interval depth computation.
+///
+/// The result of `window_depth` or `interval_depth` is a list of offset
+/// intervals in a single path along with the average depths of those intervals.
+pub struct IntervalDepth {
+    path_name: BString,
+    intervals: Vec<(usize, usize)>,
+    depths: Vec<f64>,
+}
+
+impl Emit for IntervalDepth {
+    fn emit(self, f: &mut impl std::io::prelude::Write) -> std::io::Result<()> {
+        for (i, (start, end)) in self.intervals.into_iter().enumerate() {
+            let depth_str = format_float(self.depths[i], 4);
+            writeln!(f, "{}\t{start}\t{end}\t{depth_str}", self.path_name)?;
+        }
+        Ok(())
+    }
+}
+
 /// Compute the depth for equally-sized windows along a given path and print a
 /// BED file.
-pub fn window_depth_bed(gfa: &flatgfa::FlatGFA, path: Id<Path>, window_size: usize) {
-    // The actual depth computation.
+pub fn window_depth(gfa: &flatgfa::FlatGFA, path: Id<Path>, window_size: usize) -> IntervalDepth {
     let depth = seg_depth(gfa).0;
     let windows = make_windows(path_length(gfa, path), window_size);
     let seg_depths = weighted_depths(gfa, &depth, path);
     let window_depths = assign_depths(seg_depths, &windows);
 
-    // Print a BED table with these weights.
-    let name = gfa.get_path_name(&gfa.paths[path]);
-    for i in 0..windows.len() {
-        let start = windows[i].0;
-        let end = windows[i].1;
-        let depth_str = format_float(window_depths[i], 4);
-        println!("{name}\t{start}\t{end}\t{depth_str}");
+    IntervalDepth {
+        path_name: gfa.get_path_name(&gfa.paths[path]).to_owned(),
+        intervals: windows,
+        depths: window_depths,
     }
 }
 
@@ -128,7 +146,7 @@ pub fn window_depth_bed(gfa: &flatgfa::FlatGFA, path: Id<Path>, window_size: usi
 ///
 /// The intervals must be (1) along a single path and (2) sorted in increasing
 /// order along that path.
-pub fn interval_depth_bed(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) {
+pub fn interval_depth(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) -> IntervalDepth {
     // We assume that this BED interval file contains only intervals from a
     // single path. (Relaxing this assumption without sacrificing performance is
     // interesting future work.)
@@ -136,7 +154,7 @@ pub fn interval_depth_bed(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) {
     let path = gfa.find_path(path_name).expect("path not found in graph");
 
     // TODO Avoid this conversion cost!
-    let windows: Vec<_> = intervals
+    let intervals: Vec<_> = intervals
         .entries
         .all()
         .iter()
@@ -146,15 +164,11 @@ pub fn interval_depth_bed(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) {
     // TODO Share this stuff with `window_depth_bed`!
     let depth = seg_depth(gfa).0;
     let seg_depths = weighted_depths(gfa, &depth, path);
-    let window_depths = assign_depths(seg_depths, &windows);
+    let interval_depths = assign_depths(seg_depths, &intervals);
 
-    // TODO Separate computation & printing so we can share this stuff with
-    // `window_depth_bed`!
-    let name = gfa.get_path_name(&gfa.paths[path]);
-    for i in 0..windows.len() {
-        let start = windows[i].0;
-        let end = windows[i].1;
-        let depth_str = format_float(window_depths[i], 4);
-        println!("{name}\t{start}\t{end}\t{depth_str}");
+    IntervalDepth {
+        path_name: path_name.to_owned(),
+        intervals,
+        depths: interval_depths,
     }
 }

--- a/flatgfa/src/ops/window_depth.rs
+++ b/flatgfa/src/ops/window_depth.rs
@@ -1,27 +1,35 @@
 use crate::emit::Emit;
-use crate::flatbed::FlatBED;
+use crate::flatbed::{BEDEntry, FlatBED, HeapBEDStore};
 use crate::flatgfa::{self, Path};
 use crate::ops::depth::{format_float, seg_depth};
 use crate::pool::Id;
+use crate::pool::Store;
 use crate::FlatGFA;
-use bstr::BString;
+use bstr::BStr;
 
 struct SegmentDepth {
     depth: f64,
     range: (usize, usize),
 }
 
-/// Create "windows" from 0 through `len` in increments of `size`.
-pub fn make_windows(len: usize, size: usize) -> Vec<(usize, usize)> {
-    let num_windows = len.div_ceil(size);
-    let mut windows = Vec::with_capacity(num_windows);
-    let mut start = 0;
+/// Create a BED with "windows" from 0 through `len` in increments of `size`.
+///
+/// Every row in the resulting BED has the same `name`.
+pub fn make_windows(name: &BStr, len: u64, size: u64) -> HeapBEDStore {
+    let num_windows = len.div_ceil(size) as usize;
+    let mut store = HeapBEDStore {
+        name_data: Vec::with_capacity(name.len()).into(),
+        entries: Vec::with_capacity(num_windows).into(),
+    };
+    let name = store.name_data.add_slice(name.as_ref());
+
+    let mut start: u64 = 0;
     while start < len {
         let end = (start + size).min(len);
-        windows.push((start, end));
+        store.entries.add(BEDEntry { name, start, end });
         start = end;
     }
-    windows
+    store
 }
 
 /// Get the total length (in base pairs) of a single path.
@@ -72,18 +80,16 @@ fn overlap(a: (usize, usize), b: (usize, usize)) -> (usize, usize) {
 /// Given weighted segment depths from `weighted_depths`, assign that weight to
 /// each of the base-pair ranges in `windows`.
 #[allow(clippy::mut_range_bound)]
-fn assign_depths(
-    seg_depth: impl IntoIterator<Item = SegmentDepth>,
-    windows: &[(usize, usize)],
-) -> Vec<f64> {
-    let mut depths: Vec<f64> = vec![0.0; windows.len()];
+fn assign_depths(seg_depth: impl IntoIterator<Item = SegmentDepth>, windows: &FlatBED) -> Vec<f64> {
+    let mut depths: Vec<f64> = vec![0.0; windows.get_num_entries()];
 
     // Walk down the segments in the path.
     let mut cur_window_idx = 0;
     for seg in seg_depth {
         // Move through the windows that overlap with this segment.
-        while cur_window_idx < windows.len() {
-            let window = windows[cur_window_idx];
+        while cur_window_idx < windows.get_num_entries() {
+            let entry = windows.entries.all()[cur_window_idx];
+            let window = (entry.start as usize, entry.end as usize);
             let (start, end) = overlap(window, seg.range);
 
             // Is this window at least *partially* within the current segment?
@@ -111,64 +117,55 @@ fn assign_depths(
 ///
 /// The result of `window_depth` or `interval_depth` is a list of offset
 /// intervals in a single path along with the average depths of those intervals.
-pub struct IntervalDepth {
-    path_name: BString,
-    intervals: Vec<(usize, usize)>,
-    depths: Vec<f64>,
+pub struct IntervalDepth<'a> {
+    pub intervals: FlatBED<'a>,
+    pub depths: Vec<f64>,
 }
 
-impl Emit for IntervalDepth {
+impl Emit for IntervalDepth<'_> {
     fn emit(self, f: &mut impl std::io::prelude::Write) -> std::io::Result<()> {
-        for (i, (start, end)) in self.intervals.into_iter().enumerate() {
+        for (i, entry) in self.intervals.entries.all().iter().enumerate() {
             let depth_str = format_float(self.depths[i], 4);
-            writeln!(f, "{}\t{start}\t{end}\t{depth_str}", self.path_name)?;
+            let name = self.intervals.get_name_of_entry(entry);
+            let start = entry.start;
+            let end = entry.end;
+            writeln!(f, "{name}\t{start}\t{end}\t{depth_str}")?;
         }
         Ok(())
     }
 }
 
-/// Compute the depth for equally-sized windows along a given path and print a
-/// BED file.
-pub fn window_depth(gfa: &flatgfa::FlatGFA, path: Id<Path>, window_size: usize) -> IntervalDepth {
+/// Compute the depth for equally-sized windows along a given path.
+pub fn window_depth(
+    gfa: &flatgfa::FlatGFA,
+    path: Id<Path>,
+    window_size: usize,
+) -> (HeapBEDStore, Vec<f64>) {
+    let path_name = gfa.get_path_name(&gfa.paths[path]).to_owned();
     let depth = seg_depth(gfa).0;
-    let windows = make_windows(path_length(gfa, path), window_size);
+    let windows = make_windows(
+        path_name.as_ref(),
+        path_length(gfa, path) as u64,
+        window_size as u64,
+    );
     let seg_depths = weighted_depths(gfa, &depth, path);
-    let window_depths = assign_depths(seg_depths, &windows);
-
-    IntervalDepth {
-        path_name: gfa.get_path_name(&gfa.paths[path]).to_owned(),
-        intervals: windows,
-        depths: window_depths,
-    }
+    let depths = assign_depths(seg_depths, &windows.as_ref());
+    (windows, depths)
 }
 
 /// Compute the depth for arbitrary intervals and print a BED file.
 ///
 /// The intervals must be (1) along a single path and (2) sorted in increasing
 /// order along that path.
-pub fn interval_depth(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) -> IntervalDepth {
+pub fn interval_depth(gfa: &flatgfa::FlatGFA, intervals: &FlatBED) -> Vec<f64> {
     // We assume that this BED interval file contains only intervals from a
     // single path. (Relaxing this assumption without sacrificing performance is
     // interesting future work.)
     let path_name = intervals.get_name_of_entry(&intervals.entries.all()[0]);
     let path = gfa.find_path(path_name).expect("path not found in graph");
 
-    // TODO Avoid this conversion cost!
-    let intervals: Vec<_> = intervals
-        .entries
-        .all()
-        .iter()
-        .map(|entry| (entry.start as usize, entry.end as usize))
-        .collect();
-
     // TODO Share this stuff with `window_depth_bed`!
     let depth = seg_depth(gfa).0;
     let seg_depths = weighted_depths(gfa, &depth, path);
-    let interval_depths = assign_depths(seg_depths, &intervals);
-
-    IntervalDepth {
-        path_name: path_name.to_owned(),
-        intervals,
-        depths: interval_depths,
-    }
+    assign_depths(seg_depths, intervals)
 }

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -212,6 +212,12 @@ impl<T> Default for HeapStore<T> {
     }
 }
 
+impl<T> From<Vec<T>> for HeapStore<T> {
+    fn from(value: Vec<T>) -> Self {
+        Self(value)
+    }
+}
+
 /// A store that keeps its data in fixed locations in memory.
 ///
 /// This is a funkier kind of arena that uses memory that has already been pre-allocated


### PR DESCRIPTION
In #259, we added an end-to-end `fgfa window-depth` command that both calculates evenly-sized windows and then computes their average depth. The original script we're working from does this in two commands, though, so I was interested in implementing them separately too. What we needed was a drop-in replacement for `odgi depth -b something.bed`, which I have now added.

I refactored the stuff in `window_depth` a bit so that we could share almost all of the implementation across the "fixed-function" window version and the arbitrary-interval version.

I then added `odgi depth -b` to flash. Following the benchmarks in #259, we can now compare odgi and fgfa against a slightly adapted shell script. Here's that three-way comparison:

```
$ hyperfine -w1 -r3 \
    'sh odgi_wdepth.sh > odgi_result.bed' \
    'fgfa -i chr8.flatgfa window-depth "chm13#chr8" 5000 > fgfa_result.bed' \
    'flash flash_wdepth.sh > flash_result.bed'

Benchmark 1: sh odgi_wdepth.sh > odgi_result.bed
  Time (mean ± σ):     15.203 s ±  0.358 s    [User: 13.980 s, System: 3.043 s]
  Range (min … max):   14.810 s … 15.509 s    3 runs

Benchmark 2: fgfa -i chr8.flatgfa window-depth "chm13#chr8" 5000 > fgfa_result.bed
  Time (mean ± σ):     989.9 ms ±   3.6 ms    [User: 849.1 ms, System: 138.1 ms]
  Range (min … max):   987.3 ms … 994.1 ms    3 runs

Benchmark 3: flash flash_wdepth.sh > flash_result.bed
  Time (mean ± σ):      1.322 s ±  0.003 s    [User: 1.083 s, System: 0.234 s]
  Range (min … max):    1.318 s …  1.324 s    3 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  fgfa -i chr8.flatgfa window-depth "chm13#chr8" 5000 > fgfa_result.bed ran
    1.34 ± 0.01 times faster than flash flash_wdepth.sh > flash_result.bed
   15.36 ± 0.37 times faster than sh odgi_wdepth.sh > odgi_result.bed
```

As expected, flash pays some overhead w/r/t the all-in-one fgfa invocation in order to write that BED file and then parse it back, but it's not too much (1.34x ain't bad). The goal is to mostly eliminate this through optimizations.

---

As a reminder, here's the script for odgi:

```sh
odgi depth -i chr8.pan.og -r chm13#chr8 | \
    bedtools makewindows -b /dev/stdin -w 5000 > chm13.chr8.w5kbps.bed
odgi depth -i chr8.pan.og -b chm13.chr8.w5kbps.bed --threads 2 | \
    bedtools sort
```

Here's the flash script:

```sh
odgi depth -i chr8.flatgfa -r "chm13#chr8" | bedtools makewindows -b /dev/stdin -w 5000 > chm13.chr8.w5kbps.bed
odgi depth -i chr8.flatgfa -b chm13.chr8.w5kbps.bed --threads 2
```

Some notes on the shell syntax:

* I'm doing this without optimizations now, hence the hard-coded FlatGFA input file. With -O, you could use the `.og` input file and not pay for it.
* Our shell syntax parser sadly doesn't support escaped newlines (https://github.com/raphamorim/flash/issues/13).
* `--threads 2` doesn't do anything; it's silently ignored.
* We're skipping `bedtools sort`, which is a little unfair.