### PR TITLE
flash: Optimization to skip BED files

### DIFF
--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -153,6 +153,37 @@ path-depth(mmap-0) -> stdout
 ```
 
 
+Optimizations
+-------------
+
+The `-O` flag enables some optimizations in the intermediate representation.
+We've seen one (avoiding parsing when a pre-parsed file exists) above.
+Here are some other optimizations.
+
+### Eliminate Intermediate BED Files
+
+Some commands that produce BED files as text can also produce in-memory FlatBED resources, avoiding the need for a print/parse round trip.
+One optimization detects these round trips and removes them:
+
+```console
+$ flash -p -c 'bedtools makewindows -b in.bed -w 16 > intermediate.bed ; odgi depth -i g.gfa -b intermediate.bed'
+parse-bed("in.bed") -> bed-store-0
+make-windows(bed-store-0, size=16) -> "intermediate.bed"
+parse-gfa("g.gfa") -> gfa-store-0
+parse-bed("intermediate.bed") -> bed-store-1
+interval-depth(gfa-store-0, bed-store-1) -> stdout
+
+$ flash -p -O -c 'bedtools makewindows -b in.bed -w 16 > intermediate.bed ; odgi depth -i g.gfa -b intermediate.bed'
+parse-bed("in.bed") -> bed-store-0
+make-windows(bed-store-0, size=16) -> bed-store-1
+parse-gfa("g.gfa") -> gfa-store-0
+interval-depth(gfa-store-0, bed-store-1) -> stdout
+
+```
+
+The `intermediate.bed` file is eliminated.
+
+
 Complicated Example
 -------------------
 

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -4,6 +4,7 @@ The FlatGFA Fake Shell
 `flash` is a fake Unix shell that lets you run FlatGFA-oriented pipelines using shell-compatible syntax.
 You write a script that *appears* to invoke odgi but actually triggers built-in FlatGFA functionality.
 
+
 Demo
 ----
 
@@ -192,6 +193,13 @@ Here's a shell script that uses a pipeline to combine `odgi depth` and
 
 ```console
 $ flash windows.sh
+#path	start	end	mean.depth
+5	0	4	2
+5	4	8	2
+5	8	12	2
+5	12	13	2
+
+$ flash -O windows.sh
 #path	start	end	mean.depth
 5	0	4	2
 5	4	8	2

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -98,33 +98,27 @@ fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
     let store = env.bed_stores[input].take().unwrap();
     let in_bed = store.as_ref();
 
+    // Generate a series of windows for each input interval.
+    let all_windows = in_bed.entries.all().iter().map(|entry| Windows {
+        name: in_bed.get_name_of_entry(entry),
+        start: entry.start,
+        end: entry.end,
+        size: size.try_into().unwrap(),
+    });
+
+    // Output as either FlatBED or text.
     match output.kind {
         ResourceKind::BEDStore => {
-            // In-memory FlatBED output.
             let mut out = HeapBEDStore::default();
-            // TODO dedup with below
-            for entry in in_bed.entries.all() {
-                Windows {
-                    name: in_bed.get_name_of_entry(entry),
-                    start: entry.start,
-                    end: entry.end,
-                    size: size.try_into().unwrap(),
-                }
-                .emit_bed(&mut out);
+            for windows in all_windows {
+                windows.emit_bed(&mut out);
             }
             env.bed_stores[output] = Some(out);
         }
         _ => {
-            // Text output.
             let mut out = env.output(output);
-            for entry in in_bed.entries.all() {
-                out.emit(Windows {
-                    name: in_bed.get_name_of_entry(entry),
-                    start: entry.start,
-                    end: entry.end,
-                    size: size.try_into().unwrap(),
-                })
-                .unwrap();
+            for windows in all_windows {
+                out.emit(windows).unwrap();
             }
         }
     }

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -18,7 +18,7 @@ pub fn eval(env: &mut Env, instr: &Instr) {
 }
 
 fn node_depth(env: &mut Env, input: Resource, output: Resource) {
-    let mut out = env.output(output);
+    let mut out = env.bytes_output(output).expect("bytes output");
     let gfa = env.flatgfa(input);
     let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
     out.emit(ops::depth::SegDepth {
@@ -30,30 +30,37 @@ fn node_depth(env: &mut Env, input: Resource, output: Resource) {
 }
 
 fn path_depth(env: &mut Env, input: Resource, output: Resource, path: &Option<String>) {
-    let mut out = env.output(output);
+    let out = env.bytes_output(output);
     let gfa = env.flatgfa(input);
     if let Some(path_name) = &path {
         // TODO More elegantly handle missing paths.
-        let path_id = gfa
+        let path_id = env
+            .flatgfa(input)
             .find_path(path_name.as_bytes().into())
             .expect("no such path found");
         let (lengths, depths) = ops::depth::path_depth(&gfa, std::iter::once(path_id));
-        out.emit(ops::depth::PathDepth {
+        let depth = ops::depth::PathDepth {
             gfa: &gfa,
             depths,
             lengths,
             paths: std::iter::once(path_id),
-        })
-        .unwrap();
+        };
+        match output.kind {
+            ResourceKind::BEDStore => env.bed_stores[output] = Some(depth.as_bed()),
+            _ => out.expect("bytes output").emit(depth).unwrap(),
+        }
     } else {
         let (lengths, depths) = ops::depth::path_depth(&gfa, gfa.paths.ids());
-        out.emit(ops::depth::PathDepth {
+        let depth = ops::depth::PathDepth {
             gfa: &gfa,
             depths,
             lengths,
             paths: gfa.paths.ids(),
-        })
-        .unwrap();
+        };
+        match output.kind {
+            ResourceKind::BEDStore => env.bed_stores[output] = Some(depth.as_bed()),
+            _ => out.expect("bytes output").emit(depth).unwrap(),
+        }
     }
 }
 
@@ -64,7 +71,7 @@ fn exec(env: &mut Env, input: Resource, output: Resource, command: &String, args
 fn parse_gfa(env: &mut Env, input: Resource, output: Resource) {
     use flatgfa::parse::Parser;
 
-    let store = match env.input(input) {
+    let store = match env.bytes_input(input).expect("text input") {
         Input::File(file) => Parser::for_heap().parse_mem(file.as_ref()),
         Input::Stdin(stream) => Parser::for_heap().parse_stream(stream),
         Input::Pipe(stream) => Parser::for_heap().parse_stream(stream),
@@ -85,7 +92,7 @@ fn map_file(env: &mut Env, input: Resource, output: Resource) {
 fn parse_bed(env: &mut Env, input: Resource, output: Resource) {
     use flatgfa::flatbed::BEDParser;
 
-    let store = match env.input(input) {
+    let store = match env.bytes_input(input).expect("text input") {
         Input::File(file) => BEDParser::for_heap().parse_mem(file.as_ref()),
         Input::Stdin(stream) => BEDParser::for_heap().parse_stream(stream),
         Input::Pipe(stream) => BEDParser::for_heap().parse_stream(stream),
@@ -116,7 +123,7 @@ fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
             env.bed_stores[output] = Some(out);
         }
         _ => {
-            let mut out = env.output(output);
+            let mut out = env.bytes_output(output).expect("bytes output");
             for windows in all_windows {
                 out.emit(windows).unwrap();
             }
@@ -143,7 +150,7 @@ fn interval_depth(env: &mut Env, gfa_rsrc: Resource, bed_rsrc: Resource, output:
 
     let depths = ops::window_depth::bed_depth(&gfa, &bed_store.as_ref());
 
-    let mut out = env.output(output);
+    let mut out = env.bytes_output(output).expect("bytes output");
     out.write("#path\tstart\tend\tmean.depth\n").unwrap();
     out.emit(ops::window_depth::IntervalDepth {
         intervals: bed_store.as_ref(),

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -1,7 +1,7 @@
 use super::{Env, Input};
 use crate::ir::{Instr, Op, Resource, ResourceKind};
 use bstr::BStr;
-use flatgfa::{self, emit::Emit, memfile, ops};
+use flatgfa::{self, emit::Emit, flatbed::HeapBEDStore, memfile, ops};
 use std::io;
 
 /// Execute a single instruction.
@@ -115,18 +115,50 @@ impl<'a> Emit for WindowsBed<'a> {
     }
 }
 
+impl<'a> WindowsBed<'a> {
+    fn emit_bed(self, store: &mut HeapBEDStore) {
+        let mut pos = self.start;
+        while pos < self.end {
+            let end = (pos + self.size).min(self.end);
+            store.add_entry(self.name, pos, end); // TODO dedup name
+            pos = end;
+        }
+    }
+}
+
 fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
     let store = env.bed_stores[input].take().unwrap();
-    let bed = store.as_ref();
-    let mut out = env.output(output);
-    for entry in bed.entries.all() {
-        out.emit(WindowsBed {
-            name: bed.get_name_of_entry(entry),
-            start: entry.start,
-            end: entry.end,
-            size: size.try_into().unwrap(),
-        })
-        .unwrap();
+    let in_bed = store.as_ref();
+
+    match output.kind {
+        ResourceKind::BEDStore => {
+            // In-memory FlatBED output.
+            let mut out = HeapBEDStore::default();
+            // TODO dedup with below
+            for entry in in_bed.entries.all() {
+                WindowsBed {
+                    name: in_bed.get_name_of_entry(entry),
+                    start: entry.start,
+                    end: entry.end,
+                    size: size.try_into().unwrap(),
+                }
+                .emit_bed(&mut out);
+            }
+            env.bed_stores[output] = Some(out);
+        }
+        _ => {
+            // Text output.
+            let mut out = env.output(output);
+            for entry in in_bed.entries.all() {
+                out.emit(WindowsBed {
+                    name: in_bed.get_name_of_entry(entry),
+                    start: entry.start,
+                    end: entry.end,
+                    size: size.try_into().unwrap(),
+                })
+                .unwrap();
+            }
+        }
     }
 }
 

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -1,8 +1,6 @@
 use super::{Env, Input};
 use crate::ir::{Instr, Op, Resource, ResourceKind};
-use bstr::BStr;
-use flatgfa::{self, emit::Emit, flatbed::HeapBEDStore, memfile, ops};
-use std::io;
+use flatgfa::{self, flatbed::HeapBEDStore, memfile, ops, ops::window_depth::Windows};
 
 /// Execute a single instruction.
 pub fn eval(env: &mut Env, instr: &Instr) {
@@ -96,36 +94,6 @@ fn parse_bed(env: &mut Env, input: Resource, output: Resource) {
     env.bed_stores[output] = Some(store);
 }
 
-struct WindowsBed<'a> {
-    name: &'a BStr,
-    start: u64,
-    end: u64,
-    size: u64,
-}
-
-impl<'a> Emit for WindowsBed<'a> {
-    fn emit(self, f: &mut impl std::io::Write) -> io::Result<()> {
-        let mut pos = self.start;
-        while pos < self.end {
-            let end = (pos + self.size).min(self.end);
-            writeln!(f, "{}\t{}\t{}", self.name, pos, end)?;
-            pos = end;
-        }
-        Ok(())
-    }
-}
-
-impl<'a> WindowsBed<'a> {
-    fn emit_bed(self, store: &mut HeapBEDStore) {
-        let mut pos = self.start;
-        while pos < self.end {
-            let end = (pos + self.size).min(self.end);
-            store.add_entry(self.name, pos, end); // TODO dedup name
-            pos = end;
-        }
-    }
-}
-
 fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
     let store = env.bed_stores[input].take().unwrap();
     let in_bed = store.as_ref();
@@ -136,7 +104,7 @@ fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
             let mut out = HeapBEDStore::default();
             // TODO dedup with below
             for entry in in_bed.entries.all() {
-                WindowsBed {
+                Windows {
                     name: in_bed.get_name_of_entry(entry),
                     start: entry.start,
                     end: entry.end,
@@ -150,7 +118,7 @@ fn make_windows(env: &mut Env, input: Resource, output: Resource, size: usize) {
             // Text output.
             let mut out = env.output(output);
             for entry in in_bed.entries.all() {
-                out.emit(WindowsBed {
+                out.emit(Windows {
                     name: in_bed.get_name_of_entry(entry),
                     start: entry.start,
                     end: entry.end,

--- a/flatgfa-sh/src/eval/mod.rs
+++ b/flatgfa-sh/src/eval/mod.rs
@@ -69,25 +69,25 @@ impl Env {
         }
     }
 
-    fn input(&mut self, rsrc: Resource) -> Input {
+    fn bytes_input(&mut self, rsrc: Resource) -> Option<Input> {
         match rsrc.kind {
-            ResourceKind::Stdin => Input::Stdin(std::io::stdin().lock()),
-            ResourceKind::Stdout => panic!("cannot read from stdout"),
-            ResourceKind::File => Input::File(memfile::map_file(self.file_name(rsrc))),
-            ResourceKind::Pipe => Input::Pipe(BufReader::new(self.read_pipe(rsrc).unwrap())),
-            _ => panic!("non-bytes input"),
+            ResourceKind::Stdin => Some(Input::Stdin(std::io::stdin().lock())),
+            ResourceKind::File => Some(Input::File(memfile::map_file(self.file_name(rsrc)))),
+            ResourceKind::Pipe => Some(Input::Pipe(BufReader::new(self.read_pipe(rsrc).unwrap()))),
+            _ => None,
         }
     }
 
-    fn output(&mut self, rsrc: Resource) -> Output {
+    fn bytes_output(&mut self, rsrc: Resource) -> Option<Output> {
         match rsrc.kind {
-            ResourceKind::Stdin => panic!("cannot write to stdin"),
-            ResourceKind::Stdout => Output::Stdout(std::io::stdout().lock()),
-            ResourceKind::File => {
-                Output::File(BufWriter::new(File::create(self.file_name(rsrc)).unwrap()))
+            ResourceKind::Stdout => Some(Output::Stdout(std::io::stdout().lock())),
+            ResourceKind::File => Some(Output::File(BufWriter::new(
+                File::create(self.file_name(rsrc)).unwrap(),
+            ))),
+            ResourceKind::Pipe => {
+                Some(Output::Pipe(BufWriter::new(self.write_pipe(rsrc).unwrap())))
             }
-            ResourceKind::Pipe => Output::Pipe(BufWriter::new(self.write_pipe(rsrc).unwrap())),
-            _ => panic!("non-bytes output"),
+            _ => None,
         }
     }
 

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -2,7 +2,7 @@ use enum_map::{Enum, EnumMap};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Enum)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Enum)]
 pub enum ResourceKind {
     File,
     Stdin,
@@ -13,7 +13,7 @@ pub enum ResourceKind {
     BEDStore,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Resource {
     pub kind: ResourceKind,
     pub index: u16,

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -10,6 +10,7 @@ pub fn optimize(prog: Program) -> Program {
     // is available.
     opt_gfa_parse(&mut builder);
     opt_og_parse(&mut builder);
+    skip_bed_file(&mut builder);
 
     builder.build()
 }
@@ -121,4 +122,56 @@ fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> boo
     builder.replace_rsrc(old_gfa, new_gfa);
 
     true
+}
+
+fn find_bed_file_pair(builder: &mut Builder) -> Option<(usize, usize)> {
+    // Search for a `parse-bed` instruction.
+    let (parse_idx, parse_instr) = builder
+        .instrs
+        .iter()
+        .enumerate()
+        .find(|(_, instr)| matches!(instr.op, Op::ParseBED))?;
+
+    // Which instruction produces that file?
+    let bed_file = parse_instr.inputs[0];
+    debug_assert!(matches!(
+        bed_file.kind,
+        ResourceKind::File | ResourceKind::Pipe
+    ));
+    let (def_idx, def_instr) = builder
+        .instrs
+        .iter()
+        .enumerate()
+        .find(|(_, instr)| instr.output == bed_file)?;
+
+    // TODO Ensure there are no other uses of the file.
+
+    // We match if this is in an allowlist of operations that can either produce
+    // BED text files *or* in-memory FlatBED resources.
+    match def_instr.op {
+        Op::MakeWindows { size: _ } => Some((def_idx, parse_idx)),
+        _ => None,
+    }
+}
+
+/// Optimize BED file round trips.
+///
+/// Search for this pattern:
+///
+///     something -> "file.bed"
+///     parse-bed("file.bed") -> bed-store-0
+///
+/// And attempt to replace it with:
+///
+///     something -> bed-store 0
+fn skip_bed_file(builder: &mut Builder) {
+    let Some((def_idx, parse_idx)) = find_bed_file_pair(builder) else {
+        return;
+    };
+
+    // Make the defining instruction produce the parsed FlatBED resource directly.
+    builder.instrs[def_idx].output = builder.instrs[parse_idx].output;
+
+    // Delete the parse instruction.
+    builder.instrs.remove(parse_idx);
 }

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -71,19 +71,31 @@ fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
 /// relevant file exists, replace it with a `map-file` of an equivalent
 /// `.flatgfa` file.
 fn opt_gfa_parse(builder: &mut Builder) {
-    // Search for a `parse-gfa` instruction.
-    if let Some((parse_idx, parse_instr)) = builder
+    // Search for `parse-gfa` instructions that come from a file.
+    let parses: Vec<_> = builder
         .instrs
         .iter()
         .enumerate()
-        .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))
-    {
-        // Get the stem of the input `.gfa` file, if it's a file.
-        if parse_instr.inputs[0].kind != ResourceKind::File {
-            return;
-        }
+        .filter_map(|(idx, instr)| {
+            // Find `parse-gfa` instructions.
+            let Op::ParseGFA = instr.op else {
+                return None;
+            };
+
+            // ...where the input is a file.
+            if instr.inputs[0].kind != ResourceKind::File {
+                return None;
+            }
+
+            Some(idx)
+        })
+        .collect();
+
+    // Search for a `parse-gfa` instruction.
+    for parse_idx in parses {
+        // Get the stem of the input `.gfa` file.
         let stem = builder
-            .file_name(parse_instr.inputs[0])
+            .file_name(builder.instrs[parse_idx].inputs[0])
             .strip_suffix(".gfa")
             .expect("parse-gfa inputs must end in .gfa")
             .to_string();

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -21,48 +21,54 @@ pub fn optimize(prog: Program) -> Program {
 /// into a `gfa-parse` instruction, and (if found) replace that pair with a
 /// `map-file` of a similarly-named `.fgfa` file that exists on the filesystem.
 fn opt_og_parse(builder: &mut Builder) {
-    // Find an `odgi-view` -> `gfa-parse` pair.
-    let Some((view_idx, parse_idx)) = find_og_pair(&builder.instrs) else {
-        return;
-    };
-
-    // Get the stem of the input `.og` file to this pair.
-    let stem = builder
-        .file_name(builder.instrs[view_idx].inputs[0])
-        .strip_suffix(".og")
-        .expect("odgi-view inputs must end in .og")
-        .to_string();
-
-    // Try replacing this with a FlatGFA load.
-    if replace_with_flat(builder, &stem, parse_idx) {
-        // Remove the `odgi-view` too.
-        builder.instrs.remove(view_idx);
-        return;
-    }
-
-    // Otherwise, try replacing this with a direct text GFA parse.
-    let text_filename = format!("{stem}.gfa");
-    if fs::exists(&text_filename).unwrap() {
-        // Make the `parse-gfa` read from this file, and remove the `odgi-view`.
-        builder.instrs[parse_idx].inputs[0] = builder.file(text_filename);
-        builder.instrs.remove(view_idx);
-    }
-}
-
-fn find_og_pair(instrs: &[Instr]) -> Option<(usize, usize)> {
-    // Search for a `parse-gfa` instruction.
-    let (parse_idx, parse_instr) = instrs
+    // Search for def/use pairs of `odgi-view` and `parse-gfa` instructions.
+    let du = def_use(&builder.instrs);
+    let pairs: Vec<_> = builder
+        .instrs
         .iter()
         .enumerate()
-        .find(|(_, instr)| matches!(instr.op, Op::ParseGFA))?;
+        .filter_map(|(parse_idx, parse_instr)| {
+            // Start with a `parse-gfa` instruction.
+            let Op::ParseGFA = parse_instr.op else {
+                return None;
+            };
 
-    // Search for an `odgi-view` instruction that produces the GFA.
-    let gfa = parse_instr.inputs[0];
-    let view_idx = instrs
-        .iter()
-        .position(|instr| matches!(instr.op, Op::OdgiView) && instr.output == gfa)?;
+            // The definition must be an `odgi-view`.
+            let def_idx = du.defs[parse_idx][0]?;
+            let Op::OdgiView = builder.instrs[def_idx].op else {
+                return None;
+            };
 
-    Some((view_idx, parse_idx))
+            Some((def_idx, parse_idx))
+        })
+        .collect();
+
+    // Delete the `odgi-view` and rewire the result resource.
+    let mut to_drop = Vec::new();
+    for (view_idx, parse_idx) in pairs {
+        // Get the stem of the input `.og` file to this pair.
+        let stem = builder
+            .file_name(builder.instrs[view_idx].inputs[0])
+            .strip_suffix(".og")
+            .expect("odgi-view inputs must end in .og")
+            .to_string();
+
+        // Try replacing this with a FlatGFA load.
+        if replace_with_flat(builder, &stem, parse_idx) {
+            // Remove the `odgi-view` too.
+            to_drop.push(view_idx);
+            continue;
+        }
+
+        // Otherwise, try replacing this with a direct text GFA parse.
+        let text_filename = format!("{stem}.gfa");
+        if fs::exists(&text_filename).unwrap() {
+            // Make the `parse-gfa` read from this file, and remove the `odgi-view`.
+            builder.instrs[parse_idx].inputs[0] = builder.file(text_filename);
+            to_drop.push(view_idx);
+        }
+    }
+    remove_indices(&mut builder.instrs, &to_drop);
 }
 
 /// Optimize GFA file input to FlatGFA input.

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -17,9 +17,17 @@ pub fn optimize(prog: Program) -> Program {
 
 /// Try to replace odgi inputs with FlatGFA binary inputs.
 ///
-/// Search for an `odgi-view` instruction that reads an `.og` file and feeds
-/// into a `gfa-parse` instruction, and (if found) replace that pair with a
-/// `map-file` of a similarly-named `.fgfa` file that exists on the filesystem.
+/// Search for a pattern like this:
+///
+///     odgi-view("foo.og") -> pipe-0
+///     parse-gfa(pipe-0) -> gfa-0
+///
+/// And replace it with one of these options:
+///
+///     parse-gfa("foo.gfa") -> gfa-0   *or*
+///     map-file("foo.flatgfa") -> mmap-0
+///
+/// If either of the relevant files is available on the filesystem.
 fn opt_og_parse(builder: &mut Builder) {
     // Search for def/use pairs of `odgi-view` and `parse-gfa` instructions.
     let du = def_use(&builder.instrs);
@@ -73,9 +81,15 @@ fn opt_og_parse(builder: &mut Builder) {
 
 /// Optimize GFA file input to FlatGFA input.
 ///
-/// Search for a `parse-gfa` instruction for a `.gfa` file and, when the
-/// relevant file exists, replace it with a `map-file` of an equivalent
-/// `.flatgfa` file.
+/// Search for an instruction like this:
+///
+///     parse-gfa("foo.gfa") -> gfa-0
+///
+/// And replace it with:
+///
+///     map-file("foo.flatgfa") -> mmap-0
+///
+/// If the relevant FlatGFA file exists on the filesystem.
 fn opt_gfa_parse(builder: &mut Builder) {
     // Search for `parse-gfa` instructions that come from a file.
     let parses: Vec<_> = builder

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -235,7 +235,9 @@ fn remove_indices<T>(vec: &mut Vec<T>, indices: &[usize]) {
     let mut cur = 0;
     let mut i = 0;
     vec.retain(|_| {
-        if indices[cur] == i {
+        if cur >= indices.len() {
+            true
+        } else if indices[cur] == i {
             cur += 1;
             i += 1;
             false

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -213,12 +213,35 @@ fn skip_bed_files(builder: &mut Builder) {
         })
         .collect();
 
-    // TODO second+ iterations break because we will change indices :(
+    // Apply the optimization.
+    let mut to_drop = Vec::new();
     for (def_idx, parse_idx) in pairs {
         // Make the defining instruction produce the parsed FlatBED resource directly.
         builder.instrs[def_idx].output = builder.instrs[parse_idx].output;
 
         // Delete the parse instruction.
-        builder.instrs.remove(parse_idx);
+        to_drop.push(parse_idx);
     }
+    remove_indices(&mut builder.instrs, &to_drop);
+}
+
+/// Remove elements from a vector at the given indices.
+///
+/// The indices must be provided in sorted order.
+fn remove_indices<T>(vec: &mut Vec<T>, indices: &[usize]) {
+    if indices.is_empty() {
+        return;
+    }
+    let mut cur = 0;
+    let mut i = 0;
+    vec.retain(|_| {
+        if indices[cur] == i {
+            cur += 1;
+            i += 1;
+            false
+        } else {
+            i += 1;
+            true
+        }
+    });
 }

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -10,7 +10,7 @@ pub fn optimize(prog: Program) -> Program {
     // is available.
     opt_gfa_parse(&mut builder);
     opt_og_parse(&mut builder);
-    skip_bed_file(&mut builder);
+    skip_bed_files(&mut builder);
 
     builder.build()
 }
@@ -124,34 +124,38 @@ fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> boo
     true
 }
 
-fn find_bed_file_pair(builder: &mut Builder) -> Option<(usize, usize)> {
+fn find_bed_file_pairs(builder: &mut Builder) -> impl Iterator<Item = (usize, usize)> {
     // Search for a `parse-bed` instruction.
-    let (parse_idx, parse_instr) = builder
+    builder
         .instrs
         .iter()
         .enumerate()
-        .find(|(_, instr)| matches!(instr.op, Op::ParseBED))?;
+        .filter_map(|(parse_idx, parse_instr)| {
+            if let Op::ParseBED = parse_instr.op {
+                // Which instruction produces that file?
+                let bed_file = parse_instr.inputs[0];
+                debug_assert!(matches!(
+                    bed_file.kind,
+                    ResourceKind::File | ResourceKind::Pipe
+                ));
+                let (def_idx, def_instr) = builder
+                    .instrs
+                    .iter()
+                    .enumerate()
+                    .find(|(_, instr)| instr.output == bed_file)?;
 
-    // Which instruction produces that file?
-    let bed_file = parse_instr.inputs[0];
-    debug_assert!(matches!(
-        bed_file.kind,
-        ResourceKind::File | ResourceKind::Pipe
-    ));
-    let (def_idx, def_instr) = builder
-        .instrs
-        .iter()
-        .enumerate()
-        .find(|(_, instr)| instr.output == bed_file)?;
+                // TODO Ensure there are no other uses of the file.
 
-    // TODO Ensure there are no other uses of the file.
-
-    // We match if this is in an allowlist of operations that can either produce
-    // BED text files *or* in-memory FlatBED resources.
-    match def_instr.op {
-        Op::MakeWindows { size: _ } => Some((def_idx, parse_idx)),
-        _ => None,
-    }
+                // We match if this is in an allowlist of operations that can either produce
+                // BED text files *or* in-memory FlatBED resources.
+                match def_instr.op {
+                    Op::MakeWindows { size: _ } => Some((def_idx, parse_idx)),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        })
 }
 
 /// Optimize BED file round trips.
@@ -164,14 +168,14 @@ fn find_bed_file_pair(builder: &mut Builder) -> Option<(usize, usize)> {
 /// And attempt to replace it with:
 ///
 ///     something -> bed-store 0
-fn skip_bed_file(builder: &mut Builder) {
-    let Some((def_idx, parse_idx)) = find_bed_file_pair(builder) else {
-        return;
-    };
+fn skip_bed_files(builder: &mut Builder) {
+    let pairs: Vec<_> = find_bed_file_pairs(builder).collect();
+    // TODO second+ iterations break because we will change indices :(
+    for (def_idx, parse_idx) in pairs {
+        // Make the defining instruction produce the parsed FlatBED resource directly.
+        builder.instrs[def_idx].output = builder.instrs[parse_idx].output;
 
-    // Make the defining instruction produce the parsed FlatBED resource directly.
-    builder.instrs[def_idx].output = builder.instrs[parse_idx].output;
-
-    // Delete the parse instruction.
-    builder.instrs.remove(parse_idx);
+        // Delete the parse instruction.
+        builder.instrs.remove(parse_idx);
+    }
 }

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -30,7 +30,7 @@ pub fn optimize(prog: Program) -> Program {
 /// If either of the relevant files is available on the filesystem.
 fn opt_og_parse(builder: &mut Builder) {
     // Search for def/use pairs of `odgi-view` and `parse-gfa` instructions.
-    let du = def_use(&builder.instrs);
+    let du = DefUse::analyze(&builder.instrs);
     let pairs: Vec<_> = builder
         .instrs
         .iter()
@@ -125,6 +125,60 @@ fn opt_gfa_parse(builder: &mut Builder) {
     }
 }
 
+/// Optimize BED file round trips.
+///
+/// Search for this pattern:
+///
+///     something -> "file.bed"
+///     parse-bed("file.bed") -> bed-store-0
+///
+/// And attempt to replace it with:
+///
+///     something -> bed-store 0
+fn skip_bed_files(builder: &mut Builder) {
+    // Find def/use pairs consisting of something that produces a BED file and
+    // then a `parse-bed` instruction.
+    let du = DefUse::analyze(&builder.instrs);
+    let pairs: Vec<_> = builder
+        .instrs
+        .iter()
+        .enumerate()
+        .filter_map(|(parse_idx, parse_instr)| {
+            // Start with a `parse-bed` instruction.
+            let Op::ParseBED = parse_instr.op else {
+                return None;
+            };
+
+            // Find the instruction that produces this file. If there are no
+            // other uses of this file, we can optimize.
+            let def_idx = du.defs[parse_idx][0]?;
+            if du.uses[def_idx].len() != 1 {
+                return None;
+            }
+
+            // We match if this is in an allowlist of operations that
+            // can either produce BED text files *or* in-memory FlatBED
+            // resources.
+            let Op::MakeWindows { size: _ } = builder.instrs[def_idx].op else {
+                return None;
+            };
+
+            Some((def_idx, parse_idx))
+        })
+        .collect();
+
+    // Apply the optimization.
+    let mut to_drop = Vec::new();
+    for (def_idx, parse_idx) in pairs {
+        // Make the defining instruction produce the parsed FlatBED resource directly.
+        builder.instrs[def_idx].output = builder.instrs[parse_idx].output;
+
+        // Delete the parse instruction.
+        to_drop.push(parse_idx);
+    }
+    remove_indices(&mut builder.instrs, &to_drop);
+}
+
 /// Replace an instruction with a `map-file` to open a FlatGFA binary file.
 ///
 /// If the file `{stem}.flatgfa` exists, replace the instruction at `instr_idx`
@@ -174,93 +228,42 @@ struct DefUse {
     uses: Vec<SmallVec<[usize; 2]>>,
 }
 
-fn def_use(instrs: &[Instr]) -> DefUse {
-    let mut defs = Vec::with_capacity(instrs.len());
-    let mut uses = vec![SmallVec::new(); instrs.len()];
-    let mut last_def: HashMap<Resource, usize> = HashMap::new();
+impl DefUse {
+    fn analyze(instrs: &[Instr]) -> Self {
+        let mut defs = Vec::with_capacity(instrs.len());
+        let mut uses = vec![SmallVec::new(); instrs.len()];
+        let mut last_def: HashMap<Resource, usize> = HashMap::new();
 
-    for (idx, instr) in instrs.iter().enumerate() {
-        // Find the definition for each use.
-        defs.push(
-            instr
-                .inputs
-                .iter()
-                .map(|input| last_def.get(input).copied())
-                .collect(),
-        );
+        for (idx, instr) in instrs.iter().enumerate() {
+            // Find the definition for each use.
+            defs.push(
+                instr
+                    .inputs
+                    .iter()
+                    .map(|input| last_def.get(input).copied())
+                    .collect(),
+            );
 
-        // Attribute each use to its definition.
-        for input in &instr.inputs {
-            if let Some(&def_idx) = last_def.get(input) {
-                uses[def_idx].push(idx);
+            // Attribute each use to its definition.
+            for input in &instr.inputs {
+                if let Some(&def_idx) = last_def.get(input) {
+                    uses[def_idx].push(idx);
+                }
             }
+
+            // Record the definition.
+            last_def.insert(instr.output, idx);
         }
 
-        // Record the definition.
-        last_def.insert(instr.output, idx);
+        Self { defs, uses }
     }
-
-    DefUse { defs, uses }
-}
-
-/// Optimize BED file round trips.
-///
-/// Search for this pattern:
-///
-///     something -> "file.bed"
-///     parse-bed("file.bed") -> bed-store-0
-///
-/// And attempt to replace it with:
-///
-///     something -> bed-store 0
-fn skip_bed_files(builder: &mut Builder) {
-    // Find def/use pairs consisting of something that produces a BED file and
-    // then a `parse-bed` instruction.
-    let du = def_use(&builder.instrs);
-    let pairs: Vec<_> = builder
-        .instrs
-        .iter()
-        .enumerate()
-        .filter_map(|(parse_idx, parse_instr)| {
-            // Start with a `parse-bed` instruction.
-            let Op::ParseBED = parse_instr.op else {
-                return None;
-            };
-
-            // Find the instruction that produces this file. If there are no
-            // other uses of this file, we can optimize.
-            let def_idx = du.defs[parse_idx][0]?;
-            if du.uses[def_idx].len() != 1 {
-                return None;
-            }
-
-            // We match if this is in an allowlist of operations that
-            // can either produce BED text files *or* in-memory FlatBED
-            // resources.
-            let Op::MakeWindows { size: _ } = builder.instrs[def_idx].op else {
-                return None;
-            };
-
-            Some((def_idx, parse_idx))
-        })
-        .collect();
-
-    // Apply the optimization.
-    let mut to_drop = Vec::new();
-    for (def_idx, parse_idx) in pairs {
-        // Make the defining instruction produce the parsed FlatBED resource directly.
-        builder.instrs[def_idx].output = builder.instrs[parse_idx].output;
-
-        // Delete the parse instruction.
-        to_drop.push(parse_idx);
-    }
-    remove_indices(&mut builder.instrs, &to_drop);
 }
 
 /// Remove elements from a vector at the given indices.
 ///
 /// The indices must be provided in sorted order.
 fn remove_indices<T>(vec: &mut Vec<T>, indices: &[usize]) {
+    debug_assert!(indices.iter().is_sorted());
     if indices.is_empty() {
         return;
     }

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,6 +1,6 @@
-use crate::ir::{Builder, Instr, Op, Program, ResourceKind};
+use crate::ir::{Builder, Instr, Op, Program, Resource, ResourceKind};
 use smallvec::SmallVec;
-use std::fs;
+use std::{collections::HashMap, fs};
 
 /// Apply all our optimizations to a program.
 pub fn optimize(prog: Program) -> Program {
@@ -124,33 +124,73 @@ fn replace_with_flat(builder: &mut Builder, stem: &str, instr_idx: usize) -> boo
     true
 }
 
-fn find_bed_file_pairs(builder: &mut Builder) -> impl Iterator<Item = (usize, usize)> {
+#[derive(Debug)]
+struct DefUse {
+    /// The defining instruction for each use.
+    ///
+    /// For each instruction, this contains a vector that is the same length as
+    /// that instruction's `inputs`. Each entry in that vector references (via
+    /// index) the instruction that defined that input.
+    defs: Vec<SmallVec<[Option<usize>; 2]>>,
+
+    /// The uses of the resource defined by each instruction.
+    ///
+    /// Each instruction defines the resource that is its `output` resource.
+    /// For each instruction, this contains a vector referencing (via index) all
+    /// the instructions that use that defined resource. A use occurs when the
+    /// resource appears in an instruction's `inputs` before it is overwritten.
+    uses: Vec<SmallVec<[usize; 2]>>,
+}
+
+fn def_use(instrs: &[Instr]) -> DefUse {
+    let mut defs = Vec::with_capacity(instrs.len());
+    let mut uses = vec![SmallVec::new(); instrs.len()];
+    let mut last_def: HashMap<Resource, usize> = HashMap::new();
+
+    for (idx, instr) in instrs.iter().enumerate() {
+        // Find the definition for each use.
+        defs.push(
+            instr
+                .inputs
+                .iter()
+                .map(|input| last_def.get(input).copied())
+                .collect(),
+        );
+
+        // Attribute each use to its definition.
+        for input in &instr.inputs {
+            if let Some(&def_idx) = last_def.get(input) {
+                uses[def_idx].push(idx);
+            }
+        }
+
+        // Record the definition.
+        last_def.insert(instr.output, idx);
+    }
+
+    DefUse { defs, uses }
+}
+
+fn find_bed_file_pairs(instrs: &[Instr], du: &DefUse) -> impl Iterator<Item = (usize, usize)> {
     // Search for a `parse-bed` instruction.
-    builder
-        .instrs
+    instrs
         .iter()
         .enumerate()
-        .filter_map(|(parse_idx, parse_instr)| {
+        .filter_map(move |(parse_idx, parse_instr)| {
             if let Op::ParseBED = parse_instr.op {
-                // Which instruction produces that file?
-                let bed_file = parse_instr.inputs[0];
-                debug_assert!(matches!(
-                    bed_file.kind,
-                    ResourceKind::File | ResourceKind::Pipe
-                ));
-                let (def_idx, def_instr) = builder
-                    .instrs
-                    .iter()
-                    .enumerate()
-                    .find(|(_, instr)| instr.output == bed_file)?;
-
-                // TODO Ensure there are no other uses of the file.
-
-                // We match if this is in an allowlist of operations that can either produce
-                // BED text files *or* in-memory FlatBED resources.
-                match def_instr.op {
-                    Op::MakeWindows { size: _ } => Some((def_idx, parse_idx)),
-                    _ => None,
+                // Find the instruction that produces this file. If there are no
+                // other uses of this file, we can optimize.
+                let def_idx = du.defs[parse_idx][0]?;
+                if du.uses[def_idx].len() == 1 {
+                    // We match if this is in an allowlist of operations that
+                    // can either produce BED text files *or* in-memory FlatBED
+                    // resources.
+                    match instrs[def_idx].op {
+                        Op::MakeWindows { size: _ } => Some((def_idx, parse_idx)),
+                        _ => None,
+                    }
+                } else {
+                    None
                 }
             } else {
                 None
@@ -169,7 +209,8 @@ fn find_bed_file_pairs(builder: &mut Builder) -> impl Iterator<Item = (usize, us
 ///
 ///     something -> bed-store 0
 fn skip_bed_files(builder: &mut Builder) {
-    let pairs: Vec<_> = find_bed_file_pairs(builder).collect();
+    let du = def_use(&builder.instrs);
+    let pairs: Vec<_> = find_bed_file_pairs(&builder.instrs, &du).collect();
     // TODO second+ iterations break because we will change indices :(
     for (def_idx, parse_idx) in pairs {
         // Make the defining instruction produce the parsed FlatBED resource directly.

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -171,33 +171,6 @@ fn def_use(instrs: &[Instr]) -> DefUse {
     DefUse { defs, uses }
 }
 
-fn find_bed_file_pairs(instrs: &[Instr], du: &DefUse) -> impl Iterator<Item = (usize, usize)> {
-    // Search for a `parse-bed` instruction.
-    instrs
-        .iter()
-        .enumerate()
-        .filter_map(move |(parse_idx, parse_instr)| {
-            if let Op::ParseBED = parse_instr.op {
-                // Find the instruction that produces this file. If there are no
-                // other uses of this file, we can optimize.
-                let def_idx = du.defs[parse_idx][0]?;
-                if du.uses[def_idx].len() == 1 {
-                    // We match if this is in an allowlist of operations that
-                    // can either produce BED text files *or* in-memory FlatBED
-                    // resources.
-                    match instrs[def_idx].op {
-                        Op::MakeWindows { size: _ } => Some((def_idx, parse_idx)),
-                        _ => None,
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-}
-
 /// Optimize BED file round trips.
 ///
 /// Search for this pattern:
@@ -209,8 +182,37 @@ fn find_bed_file_pairs(instrs: &[Instr], du: &DefUse) -> impl Iterator<Item = (u
 ///
 ///     something -> bed-store 0
 fn skip_bed_files(builder: &mut Builder) {
+    // Find def/use pairs consisting of something that produces a BED file and
+    // then a `parse-bed` instruction.
     let du = def_use(&builder.instrs);
-    let pairs: Vec<_> = find_bed_file_pairs(&builder.instrs, &du).collect();
+    let pairs: Vec<_> = builder
+        .instrs
+        .iter()
+        .enumerate()
+        .filter_map(|(parse_idx, parse_instr)| {
+            // Start with a `parse-bed` instruction.
+            let Op::ParseBED = parse_instr.op else {
+                return None;
+            };
+
+            // Find the instruction that produces this file. If there are no
+            // other uses of this file, we can optimize.
+            let def_idx = du.defs[parse_idx][0]?;
+            if du.uses[def_idx].len() != 1 {
+                return None;
+            }
+
+            // We match if this is in an allowlist of operations that
+            // can either produce BED text files *or* in-memory FlatBED
+            // resources.
+            let Op::MakeWindows { size: _ } = builder.instrs[def_idx].op else {
+                return None;
+            };
+
+            Some((def_idx, parse_idx))
+        })
+        .collect();
+
     // TODO second+ iterations break because we will change indices :(
     for (def_idx, parse_idx) in pairs {
         // Make the defining instruction produce the parsed FlatBED resource directly.

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -159,9 +159,10 @@ fn skip_bed_files(builder: &mut Builder) {
             // We match if this is in an allowlist of operations that
             // can either produce BED text files *or* in-memory FlatBED
             // resources.
-            let Op::MakeWindows { size: _ } = builder.instrs[def_idx].op else {
-                return None;
-            };
+            match builder.instrs[def_idx].op {
+                Op::MakeWindows { size: _ } | Op::PathDepth { path: _ } => (),
+                _ => return None,
+            }
 
             Some((def_idx, parse_idx))
         })

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -1,4 +1,5 @@
 use crate::emit::Emit;
+use crate::flatbed::HeapBEDStore;
 use crate::flatgfa;
 use crate::pool::Id;
 use bit_vec::BitVec;
@@ -138,6 +139,30 @@ where
             )?;
         }
         Ok(())
+    }
+}
+
+impl<'a, I> PathDepth<'a, I>
+where
+    I: Iterator<Item = Id<flatgfa::Path>>,
+{
+    /// Emit the depth for each path as a BED table.
+    ///
+    /// This is currently quite weird because it throws away the actual depth
+    /// information and only emits the standard BED start/end positions. This
+    /// turns out to be what some workloads actually want, i.e., they don't
+    /// really use the depth. But for more general use cases, we should explore
+    /// letting FlatBED optionally represent more columns.
+    pub fn as_bed(self) -> HeapBEDStore {
+        let mut store = HeapBEDStore::default();
+        for (idx, id) in self.paths.enumerate() {
+            store.add_entry(
+                self.gfa.get_path_name(&self.gfa.paths[id]),
+                0,
+                self.lengths[idx] as u64,
+            );
+        }
+        store
     }
 }
 

--- a/flatgfa/src/ops/window_depth.rs
+++ b/flatgfa/src/ops/window_depth.rs
@@ -12,24 +12,57 @@ struct SegmentDepth {
     range: (usize, usize),
 }
 
-/// Create a BED with "windows" from 0 through `len` in increments of `size`.
+/// A sequence of equally-sized windows along a certain path.
 ///
-/// Every row in the resulting BED has the same `name`.
-pub fn make_windows(name: &BStr, len: u64, size: u64) -> HeapBEDStore {
-    let num_windows = len.div_ceil(size) as usize;
-    let mut store = HeapBEDStore {
-        name_data: Vec::with_capacity(name.len()).into(),
-        entries: Vec::with_capacity(num_windows).into(),
-    };
-    let name = store.name_data.add_slice(name.as_ref());
+/// The sequence of windows go from `start` through `end` in increments of
+/// `size`. This struct abstractly represents a sequence of windows. It allows
+/// emitting the sequence either as text or as an in-memory FlatBED store.
+pub struct Windows<'a> {
+    pub name: &'a BStr,
+    pub start: u64,
+    pub end: u64,
+    pub size: u64,
+}
 
-    let mut start: u64 = 0;
-    while start < len {
-        let end = (start + size).min(len);
-        store.entries.add(BEDEntry { name, start, end });
-        start = end;
+impl<'a> Emit for Windows<'a> {
+    fn emit(self, f: &mut impl std::io::Write) -> std::io::Result<()> {
+        let mut pos = self.start;
+        while pos < self.end {
+            let end = (pos + self.size).min(self.end);
+            writeln!(f, "{}\t{}\t{}", self.name, pos, end)?;
+            pos = end;
+        }
+        Ok(())
     }
-    store
+}
+
+impl<'a> Windows<'a> {
+    pub fn emit_bed(self, store: &mut HeapBEDStore) {
+        let name = store.name_data.add_slice(self.name.as_ref());
+        store.entries.reserve(self.len());
+
+        let mut start = self.start;
+        while start < self.end {
+            let end = (start + self.size).min(self.end);
+            store.entries.add(BEDEntry { name, start, end });
+            start = end;
+        }
+    }
+
+    pub fn as_bed(self) -> HeapBEDStore {
+        let mut store = HeapBEDStore::default();
+        self.emit_bed(&mut store);
+        store
+    }
+
+    /// The number of windows in the sequence.
+    pub fn len(&self) -> usize {
+        (self.end - self.start).div_ceil(self.size) as usize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Get the total length (in base pairs) of a single path.
@@ -152,11 +185,13 @@ pub fn window_depth(
     path: Id<Path>,
     window_size: usize,
 ) -> (HeapBEDStore, Vec<f64>) {
-    let windows = make_windows(
-        gfa.get_path_name(&gfa.paths[path]),
-        path_length(gfa, path) as u64,
-        window_size as u64,
-    );
+    let windows = Windows {
+        name: gfa.get_path_name(&gfa.paths[path]),
+        start: 0,
+        end: path_length(gfa, path) as u64,
+        size: window_size as u64,
+    }
+    .as_bed();
     let depths = interval_depth(gfa, path, &windows.as_ref());
     (windows, depths)
 }

--- a/flatgfa/src/pool.rs
+++ b/flatgfa/src/pool.rs
@@ -218,6 +218,12 @@ impl<T> From<Vec<T>> for HeapStore<T> {
     }
 }
 
+impl<T> HeapStore<T> {
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+}
+
 /// A store that keeps its data in fixed locations in memory.
 ///
 /// This is a funkier kind of arena that uses memory that has already been pre-allocated


### PR DESCRIPTION
In our target shell script, there are two text BED files generated and consumed. This adds an optimization that lets flash skip those files altogether and just exchange data in memory via a `FlatBED` object.

This required several changes:

* The `make-windows` instruction can now produce either text or FlatBED output, depending on which type of resource is assigned as its output.
* Same with the `path-depth` instruction.
* A new general def/use analysis makes it easier for optimizations to find chains of instructions to transform.
* Finally, the new optimization pass looks for a chain consisting of one of the above instructions and a `parse-bed`, removes the latter, and makes the former output a FlatBED resource.

In my tests so far, these optimizations actually have very little impact on the target workload, because all the time is spent in actual depth calculation. Which is fine! It's just cool to show that these optimizations can work, and I'm sure they'll matter more in situations with more I/O.