### PR TITLE
flash: Further optimize depth computations

### DIFF
--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -20,7 +20,7 @@ pub fn eval(env: &mut Env, instr: &Instr) {
 fn node_depth(env: &mut Env, input: Resource, output: Resource) {
     let mut out = env.bytes_output(output).expect("bytes output");
     let gfa = env.flatgfa(input);
-    let (depths, uniq_depths) = ops::depth::seg_depth(&gfa);
+    let (depths, uniq_depths) = ops::depth::seg_depth_with_uniq(&gfa);
     out.emit(ops::depth::SegDepth {
         gfa: &gfa,
         depths,

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -7,6 +7,7 @@ pub fn eval(env: &mut Env, instr: &Instr) {
     match &instr.op {
         Op::NodeDepth => node_depth(env, instr.inputs[0], instr.output),
         Op::PathDepth { path } => path_depth(env, instr.inputs[0], instr.output, path),
+        Op::PathLength { path } => path_length(env, instr.inputs[0], instr.output, path),
         Op::Exec { command, args } => exec(env, instr.inputs[0], instr.output, command, args),
         Op::ParseGFA => parse_gfa(env, instr.inputs[0], instr.output),
         Op::MapFile => map_file(env, instr.inputs[0], instr.output),
@@ -62,6 +63,23 @@ fn path_depth(env: &mut Env, input: Resource, output: Resource, path: &Option<St
             _ => out.expect("bytes output").emit(depth).unwrap(),
         }
     }
+}
+
+fn path_length(env: &mut Env, input: Resource, output: Resource, path_name: &str) {
+    let gfa = env.flatgfa(input);
+    let path = gfa.find_path(path_name.into()).expect("no such path found");
+
+    // Add up the total length in base pairs.
+    let mut len = 0;
+    for step in gfa.get_path_steps(&gfa.paths[path]) {
+        len += gfa.segs[step.segment()].len();
+    }
+
+    // Generate a (very short) BED table.
+    let mut store = HeapBEDStore::default();
+    store.add_entry(path_name.as_bytes(), 0, len as u64);
+
+    env.bed_stores[output] = Some(store);
 }
 
 fn exec(env: &mut Env, input: Resource, output: Resource, command: &String, args: &[String]) {

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -34,6 +34,9 @@ pub enum Op {
     PathDepth {
         path: Option<String>,
     },
+    PathLength {
+        path: String,
+    },
     Exec {
         command: String,
         args: SmallVec<[String; 4]>,

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -11,6 +11,7 @@ pub fn optimize(prog: Program) -> Program {
     opt_gfa_parse(&mut builder);
     opt_og_parse(&mut builder);
     skip_bed_files(&mut builder);
+    simplify_depth_to_length(&mut builder);
 
     builder.build()
 }
@@ -178,6 +179,56 @@ fn skip_bed_files(builder: &mut Builder) {
         to_drop.push(parse_idx);
     }
     remove_indices(&mut builder.instrs, &to_drop);
+}
+
+/// Simplify `path-depth` to `path-length` where possible.
+///
+/// Search for patterns like this:
+///
+///     path-depth(mmap-0, path="p") -> bed-store-0
+///     make-windows(bed-store-0, size=5) -> bed-store-1
+///
+/// And replace it with this:
+///
+///     path-length(mmap-0, path="p") -> bed-store-0
+///     make-windows(bed-store-0, size=5) -> bed-store-1
+///
+/// Beacuse the consuming instruction doesn't actually care about the depth (it
+/// just needs the path length) but there is no odgi surface syntax for just
+/// computing the length.
+fn simplify_depth_to_length(builder: &mut Builder) {
+    // Search for `path-depth` -> consumer pairs.
+    let du = DefUse::analyze(&builder.instrs);
+    let defs: Vec<_> = builder
+        .instrs
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, instr)| {
+            // Start with a `make-windows` instruction.
+            let Op::MakeWindows { size: _ } = instr.op else {
+                return None;
+            };
+
+            // Find the instruction that produces this BED. If there are no
+            // other uses of this file, we can optimize.
+            // TODO dedup
+            let def_idx = du.defs[idx][0]?;
+            if du.uses[def_idx].len() != 1 {
+                return None;
+            }
+
+            Some(def_idx)
+        })
+        .collect();
+
+    // Replace `path-depth` with `path-length`.
+    for def_idx in defs {
+        // The producer must be a `path-depth` instruction with a named path.
+        // TODO avoid clone
+        if let Op::PathDepth { path: Some(path) } = &builder.instrs[def_idx].op {
+            builder.instrs[def_idx].op = Op::PathLength { path: path.clone() };
+        }
+    }
 }
 
 /// Replace an instruction with a `map-file` to open a FlatGFA binary file.

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -37,6 +37,7 @@ impl Display for Wrapped<'_, ir::Instr> {
         let name = match &self.val.op {
             ir::Op::NodeDepth => "node-depth",
             ir::Op::PathDepth { path: _ } => "path-depth",
+            ir::Op::PathLength { path: _ } => "path-length",
             ir::Op::Exec {
                 command: _,
                 args: _,
@@ -54,6 +55,7 @@ impl Display for Wrapped<'_, ir::Instr> {
         }
         match &self.val.op {
             ir::Op::PathDepth { path: Some(path) } => write!(f, ", path={:?}", path)?,
+            ir::Op::PathLength { path } => write!(f, ", path={:?}", path)?,
             ir::Op::Exec { command, args } => {
                 write!(f, ", command={:?}, args={:?}", command, args)?
             }

--- a/flatgfa/src/cli/cmds.rs
+++ b/flatgfa/src/cli/cmds.rs
@@ -232,11 +232,11 @@ pub struct Depth {
 }
 
 pub fn depth(gfa: &flatgfa::FlatGFA, args: Depth) {
-    use crate::ops::depth::{path_depth, seg_depth, PathDepth, SegDepth};
+    use crate::ops::depth::{path_depth, seg_depth_with_uniq, PathDepth, SegDepth};
     use crate::ops::window_depth::{bed_depth, IntervalDepth};
     if args.seg_depth {
         // Segment depth table.
-        let (depths, uniq_depths) = seg_depth(gfa);
+        let (depths, uniq_depths) = seg_depth_with_uniq(gfa);
         SegDepth {
             gfa,
             depths,

--- a/flatgfa/src/ops/depth.rs
+++ b/flatgfa/src/ops/depth.rs
@@ -5,14 +5,14 @@ use crate::pool::Id;
 use bit_vec::BitVec;
 use std::io::Write;
 
-/// Compute the *depth* of each segment in the variation graph.
+/// Compute the *depth* and *unique depth* of each segment in the variation graph.
 ///
 /// The depth is defined to be the number of times that a path traverses a given
 /// segment. We return two values: the ordinary depth and the *unique* depth,
 /// which only counts each path that tarverses a given segment once.
 ///
 /// Both outputs are depth values indexed by segment ID.
-pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
+pub fn seg_depth_with_uniq(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     // Our output vectors: the ordinary and unique depths of each segment.
     let mut depths = vec![0; gfa.segs.len()];
     let mut uniq_depths = vec![0; gfa.segs.len()];
@@ -38,9 +38,26 @@ pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> (Vec<usize>, Vec<usize>) {
     (depths, uniq_depths)
 }
 
+/// Compute the (non-unique) depth of each segment in the graph.
+///
+/// Like `seg_depth_with_uniq`, but only computes the "ordinary" depth, which
+/// can be cheaper.
+pub fn seg_depth(gfa: &flatgfa::FlatGFA) -> Vec<usize> {
+    let mut depths = vec![0; gfa.segs.len()];
+
+    for path in gfa.paths.all().iter() {
+        for step in &gfa.steps[path.steps] {
+            let seg_id = step.segment().index();
+            depths[seg_id] += 1;
+        }
+    }
+
+    depths
+}
+
 /// A printable segment depth table.
 ///
-/// Formats the result of `seg_depth` in an odgi-style TSV.
+/// Formats the result of `seg_depth_with_uniq` in an odgi-style TSV.
 pub struct SegDepth<'a> {
     pub gfa: &'a flatgfa::FlatGFA<'a>,
     pub depths: Vec<usize>,

--- a/flatgfa/src/ops/window_depth.rs
+++ b/flatgfa/src/ops/window_depth.rs
@@ -174,7 +174,7 @@ impl Emit for IntervalDepth<'_> {
 /// avoid computing any average weights for segments not included within that
 /// path.
 fn interval_depth(gfa: &flatgfa::FlatGFA, path: Id<Path>, intervals: &FlatBED) -> Vec<f64> {
-    let depth = seg_depth(gfa).0;
+    let depth = seg_depth(gfa);
     let seg_depths = weighted_depths(gfa, &depth, path);
     assign_depths(seg_depths, intervals)
 }


### PR DESCRIPTION
This adds two new optimizations:

* When doing interval depth, avoid needlessly computing unique depth. That took us from roughly 1.3s to roughly 720ms.
* When using depth just to measure path length, add an optimization that skips the depth computation altogether. That took us from there to about 400ms.

Altogether, these optimizations are worth a speedup of about 3.2×.

Checking in on all our options for doing this one weird computation:

```
Benchmark 1: sh odgi_wdepth.sh > odgi_result.bed
  Time (mean ± σ):     15.008 s ±  0.119 s    [User: 13.973 s, System: 2.919 s]
  Range (min … max):   14.920 s … 15.144 s    3 runs

Benchmark 2: fgfa -i chr8.flatgfa window-depth "chm13#chr8" 5000 > fgfa_result.bed
  Time (mean ± σ):     972.5 ms ±   2.5 ms    [User: 844.5 ms, System: 125.5 ms]
  Range (min … max):   970.1 ms … 975.0 ms    3 runs

Benchmark 3: flash flash_wdepth.sh > flash_result.bed
  Time (mean ± σ):     710.0 ms ±   3.5 ms    [User: 502.4 ms, System: 206.2 ms]
  Range (min … max):   706.6 ms … 713.6 ms    3 runs

Benchmark 4: flash -O flash_wdepth.sh > flash_result.bed
  Time (mean ± σ):     394.0 ms ±   2.1 ms    [User: 271.7 ms, System: 120.6 ms]
  Range (min … max):   391.8 ms … 396.0 ms    3 runs

Summary
  flash -O flash_wdepth.sh > flash_result.bed ran
    1.80 ± 0.01 times faster than flash flash_wdepth.sh > flash_result.bed
    2.47 ± 0.01 times faster than fgfa -i chr8.flatgfa window-depth "chm13#chr8" 5000 > fgfa_result.bed
   38.09 ± 0.36 times faster than sh odgi_wdepth.sh > odgi_result.bed
```

So on the bottom line, we are now about 38× faster than odgi.