### PR TITLE
flash: Optimize away redundant file reads

### DIFF
--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -184,6 +184,45 @@ interval-depth(gfa-store-0, bed-store-1) -> stdout
 
 The `intermediate.bed` file is eliminated.
 
+### Deduplicate Redundant Reads
+
+If you have two commands that need the same input FlatGFA file, those get coalesced into one `map-file` instruction:
+
+```console
+$ flash -p -c 'odgi depth -i g.flatgfa -r foo ; odgi depth -i g.flatgfa -r bar'
+map-file("g.flatgfa") -> mmap-0
+path-depth(mmap-0, path="foo") -> stdout
+map-file("g.flatgfa") -> mmap-1
+path-depth(mmap-1, path="bar") -> stdout
+
+$ flash -p -O -c 'odgi depth -i g.flatgfa -r foo ; odgi depth -i g.flatgfa -r bar'
+map-file("g.flatgfa") -> mmap-0
+path-depth(mmap-0, path="foo") -> stdout
+path-depth(mmap-0, path="bar") -> stdout
+
+```
+
+### Reduce Depth to Length
+
+When feeding an `odgi depth` table into `bedtools makewindows`, we actually only need the path's *length*, not its depth.
+This optimization avoids computing the depth in that scenario:
+
+```console
+$ flash -p -c 'odgi depth -i g.gfa -r foo | bedtools makewindows -b /dev/stdin -w 4'
+parse-gfa("g.gfa") -> gfa-store-0
+path-depth(gfa-store-0, path="foo") -> pipe-0
+parse-bed(pipe-0) -> bed-store-0
+make-windows(bed-store-0, size=4) -> stdout
+
+$ flash -p -O -c 'odgi depth -i g.gfa -r foo | bedtools makewindows -b /dev/stdin -w 4'
+parse-gfa("g.gfa") -> gfa-store-0
+path-length(gfa-store-0, path="foo") -> bed-store-0
+make-windows(bed-store-0, size=4) -> stdout
+
+```
+
+Notice that `path-depth` has been replaced with `path-length`.
+
 
 Complicated Example
 -------------------

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,6 +1,7 @@
 use crate::ir::{Builder, Instr, Op, Program, Resource, ResourceKind};
 use smallvec::SmallVec;
-use std::{collections::HashMap, fs};
+use std::collections::hash_map::{Entry, HashMap};
+use std::fs;
 
 /// Apply all our optimizations to a program.
 pub fn optimize(prog: Program) -> Program {
@@ -12,6 +13,7 @@ pub fn optimize(prog: Program) -> Program {
     opt_og_parse(&mut builder);
     skip_bed_files(&mut builder);
     simplify_depth_to_length(&mut builder);
+    dedup_files(&mut builder);
 
     builder.build()
 }
@@ -229,6 +231,57 @@ fn simplify_depth_to_length(builder: &mut Builder) {
             builder.instrs[def_idx].op = Op::PathLength { path: path.clone() };
         }
     }
+}
+
+/// Deduplicate instructions that read the same file.
+///
+/// Search for multiple copies of instructions that read the same file:
+///
+///     map-file("foo.flatgfa") -> mmap-0
+///     ...
+///     map-file("foo.flatgfa") -> mmap-1
+///
+/// And replace them with a single copy. Works for `map-file` only for now, but
+/// could be extended to apply to `parse-gfa` and `parse-bed` when their input
+/// comes from a file.
+fn dedup_files(builder: &mut Builder) {
+    // Contains the files that have been read with `map-file` and not yet
+    // overwritten. We map each file to the resource read from it.
+    let mut seen_files = HashMap::new();
+
+    // The indices of instructions that read from a file that has already been
+    // read (without being overwritten).
+    let mut redundant_reads = Vec::new();
+
+    // Find redundant reads.
+    for (idx, instr) in builder.instrs.iter().enumerate() {
+        // Process file uses.
+        if let Op::MapFile = instr.op {
+            let input = instr.inputs[0];
+            debug_assert!(matches!(input.kind, ResourceKind::File));
+            if let Entry::Vacant(e) = seen_files.entry(input) {
+                e.insert(instr.output);
+            } else {
+                redundant_reads.push(idx);
+            }
+        }
+
+        // Process file definitions (i.e., overwrites).
+        if let ResourceKind::File = instr.output.kind {
+            seen_files.remove(&instr.output);
+        }
+    }
+
+    // Replace the outputs of the redundant reads.
+    for idx in &redundant_reads {
+        let file = builder.instrs[*idx].inputs[0];
+        let old_out = builder.instrs[*idx].output;
+        let new_out = *seen_files.get(&file).expect("original file not found");
+        builder.replace_rsrc(old_out, new_out);
+    }
+
+    // Remove the redundant read instructions.
+    remove_indices(&mut builder.instrs, &redundant_reads);
 }
 
 /// Replace an instruction with a `map-file` to open a FlatGFA binary file.


### PR DESCRIPTION
Because it comes up in our target workload (which opens the same GFA from multiple odgi commands), this attempts to optimize redundant reads of the same file to only do a single read. This doesn't matter much `map-file` which is presumably very fast, but it feels nice and could potentially actually matter in other situations.

In a little experiment, I am surprised to see that this might have actually saved a *little* bit of time:

* before: 395.4 ms ±   2.4 ms
* after:  387.1 ms ±   2.6 ms

I didn't expect anything at all, so even a tiny delta is worth celebrating, I guess. 🎉 

This is essentially a very restricted [CSE](https://en.wikipedia.org/wiki/Common_subexpression_elimination) optimization. We could generalize it much further if we run into cases where it would be helpful...