### PR TITLE
flash: Compression MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +570,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flatgfa"
 version = "0.1.0"
 dependencies = [
@@ -596,6 +621,7 @@ dependencies = [
  "brush-parser",
  "bstr",
  "enum-map",
+ "flate2",
  "flatgfa",
  "memmap",
  "pico-args",
@@ -903,6 +929,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1449,6 +1485,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"

--- a/flatgfa-sh/Cargo.toml
+++ b/flatgfa-sh/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2024"
 name = "flash"
 path = "src/main.rs"
 
+[features]
+default = ["compress"]
+compress = ["dep:flate2"]
+
 [dependencies]
 flatgfa = { path = "../flatgfa" }
 pico-args = "0.5"
@@ -16,6 +20,7 @@ bstr = { workspace = true }
 enum-map = "2"
 smallvec = "1"
 brush-parser = "0.4"
+flate2 = { version = "1", optional = true }
 
 [dev-dependencies]
 trycmd = "1.2.0"

--- a/flatgfa-sh/README.md
+++ b/flatgfa-sh/README.md
@@ -224,6 +224,54 @@ make-windows(bed-store-0, size=4) -> stdout
 Notice that `path-depth` has been replaced with `path-length`.
 
 
+Compression
+-----------
+
+Flash can help you read from compressed files.
+It can recognize the `gunzip` command:
+
+```
+$ flash -p -c 'gunzip < foo.gfa.gz | odgi depth'
+gzip-decompress("foo.gfa.gz") -> pipe-0
+parse-gfa(pipe-0) -> gfa-store-0
+path-depth(gfa-store-0) -> stdout
+
+```
+
+And it can also automatically decompress when it sees a `.gz` filename extension:
+
+```
+$ flash -p -c 'odgi depth -i foo.gfa.gz'
+gzip-decompress("foo.gfa.gz") -> pipe-0
+parse-gfa(pipe-0) -> gfa-store-0
+path-depth(gfa-store-0) -> stdout
+
+```
+
+Some instructions (actually, just `parse-gfa` for now) support directly reading from compressed files, without going through an OS pipe.
+There is an optimization the recognizes relevant uses of `gzip-decompress` and triggers this functionality:
+
+```
+$ flash -p -O -c 'odgi depth -i foo.gfa.gz'
+parse-gfa(gz "foo.gfa.gz") -> gfa-store-0
+path-depth(gfa-store-0) -> stdout
+
+```
+
+Notice the `gz` qualifier next to the filename in the first instruction.
+This means that the `parse-gfa` instruction will decompress the text on the fly while parsing.
+
+Here's an end-to-end test:
+
+```
+$ flash -O -c 'gzip < ../tests/k.gfa | gunzip | odgi depth'
+#path	start	end	mean.depth
+x	0	50	1.9
+y	0	50	1.9
+
+```
+
+
 Complicated Example
 -------------------
 

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -15,6 +15,7 @@ pub fn eval(env: &mut Env, instr: &Instr) {
         Op::MakeWindows { size } => make_windows(env, instr.inputs[0], instr.output, *size),
         Op::OdgiView => odgi_view(env, instr.inputs[0], instr.output),
         Op::IntervalDepth => interval_depth(env, instr.inputs[0], instr.inputs[1], instr.output),
+        Op::GzipDecompress => gzip_decompress(env, instr.inputs[0], instr.output),
     }
 }
 
@@ -175,4 +176,30 @@ fn interval_depth(env: &mut Env, gfa_rsrc: Resource, bed_rsrc: Resource, output:
         depths,
     })
     .unwrap();
+}
+
+/// Decompress a gzip file eagerly and produce the raw bytes.
+///
+/// This is a placeholder solution! It works by decompressing the whole thing
+/// into memory and then copying the decompressed data to the output resource.
+/// We want this work in a streaming style, never materializing the whole
+/// decompressed text.
+fn gzip_decompress(env: &mut Env, input: Resource, output: Resource) {
+    use flate2::bufread::GzDecoder;
+    use std::io::Read;
+
+    // Decompress the whole thing into memory.
+    let mut buf = Vec::new();
+    match env.bytes_input(input).expect("bytes input") {
+        Input::File(file) => GzDecoder::new(file.as_ref()).read_to_end(&mut buf),
+        Input::Stdin(stream) => GzDecoder::new(stream).read_to_end(&mut buf),
+        Input::Pipe(stream) => GzDecoder::new(stream).read_to_end(&mut buf),
+    }
+    .expect("decompression failed");
+
+    // Write the whole decompressed output immediately.
+    env.bytes_output(output)
+        .expect("bytes output")
+        .write_all(&buf)
+        .expect("error writing decompressed output");
 }

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -212,23 +212,20 @@ fn interval_depth(env: &mut Env, gfa_rsrc: Resource, bed_rsrc: Resource, output:
     .unwrap();
 }
 
-/// Decompress a gzip file and produce the raw bytes.
+#[cfg(feature = "compress")]
 fn gzip_decompress(env: &mut Env, input: Resource, output: Resource) {
-    #[cfg(feature = "compress")]
-    {
-        use flate2::bufread::GzDecoder;
+    use flate2::bufread::GzDecoder;
 
-        let mut out = env.bytes_output(output).expect("bytes output");
-        match env.bytes_input(input).expect("bytes input") {
-            Input::File(file) => out.copy(&mut GzDecoder::new(file.as_ref())),
-            Input::Stdin(stream) => out.copy(&mut GzDecoder::new(stream)),
-            Input::Pipe(stream) => out.copy(&mut GzDecoder::new(stream)),
-        }
-        .expect("decompression failed");
+    let mut out = env.bytes_output(output).expect("bytes output");
+    match env.bytes_input(input).expect("bytes input") {
+        Input::File(file) => out.copy(&mut GzDecoder::new(file.as_ref())),
+        Input::Stdin(stream) => out.copy(&mut GzDecoder::new(stream)),
+        Input::Pipe(stream) => out.copy(&mut GzDecoder::new(stream)),
     }
+    .expect("decompression failed");
+}
 
-    #[cfg(not(feature = "compress"))]
-    {
-        env.run_cmd("gzip", &["-d"], input, output)
-    }
+#[cfg(not(feature = "compress"))]
+fn gzip_decompress(env: &mut Env, input: Resource, output: Resource) {
+    env.run_cmd("gzip", &["-d"], input, output);
 }

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -1,6 +1,11 @@
 use super::{Env, Input};
-use crate::ir::{Instr, Op, Resource, ResourceKind};
-use flatgfa::{self, flatbed::HeapBEDStore, memfile, ops, ops::window_depth::Windows};
+use crate::ir::{Encoding, Instr, Op, Resource, ResourceKind};
+use flatgfa::{
+    self, HeapGFAStore,
+    flatbed::HeapBEDStore,
+    memfile,
+    ops::{self, window_depth::Windows},
+};
 
 /// Execute a single instruction.
 pub fn eval(env: &mut Env, instr: &Instr) {
@@ -88,12 +93,32 @@ fn exec(env: &mut Env, input: Resource, output: Resource, command: &String, args
 }
 
 fn parse_gfa(env: &mut Env, input: Resource, output: Resource) {
+    use flate2::bufread::GzDecoder;
     use flatgfa::parse::Parser;
+    use std::io::{BufRead, BufReader};
 
+    // Handle compressed or uncompressed input streams.
+    // TODO: This is currently worrisomely verbose, and it's only going to get
+    // worse if we try to apply this to other parsers.
+    fn parse_stream<R: BufRead>(stream: R, encoding: Encoding) -> HeapGFAStore {
+        use flatgfa::parse::Parser;
+        match encoding {
+            Encoding::None => Parser::for_heap().parse_stream(stream),
+            Encoding::Gzip => {
+                Parser::for_heap().parse_stream(BufReader::new(GzDecoder::new(stream)))
+            }
+        }
+    }
+
+    // For unencoded files on disk, we can use a (possibly faster) memchr-based
+    // parser. Otherwise, use the stream parser.
     let store = match env.bytes_input(input).expect("text input") {
-        Input::File(file) => Parser::for_heap().parse_mem(file.as_ref()),
-        Input::Stdin(stream) => Parser::for_heap().parse_stream(stream),
-        Input::Pipe(stream) => Parser::for_heap().parse_stream(stream),
+        Input::File(file) => match input.encoding {
+            Encoding::None => Parser::for_heap().parse_mem(file.as_ref()),
+            _ => parse_stream(file.as_ref(), input.encoding),
+        },
+        Input::Stdin(stream) => parse_stream(stream, input.encoding),
+        Input::Pipe(stream) => parse_stream(stream, input.encoding),
     };
 
     env.gfa_stores[output] = Some(store);
@@ -110,6 +135,11 @@ fn map_file(env: &mut Env, input: Resource, output: Resource) {
 
 fn parse_bed(env: &mut Env, input: Resource, output: Resource) {
     use flatgfa::flatbed::BEDParser;
+
+    // We do not yet support decompression.
+    // TODO: We need to centralize this logic, so instruction implementations
+    // like this one cannot easily "forget" to handle compressed streams.
+    assert!(matches!(input.encoding, Encoding::None));
 
     let store = match env.bytes_input(input).expect("text input") {
         Input::File(file) => BEDParser::for_heap().parse_mem(file.as_ref()),

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -155,10 +155,7 @@ fn odgi_view(env: &mut Env, input: Resource, output: Resource) {
     env.run_cmd(
         "odgi",
         &["view", "-g", "-i", &og_file],
-        Resource {
-            kind: ResourceKind::Stdin,
-            index: 0,
-        },
+        Resource::stdin(),
         output,
     )
 }

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -93,9 +93,8 @@ fn exec(env: &mut Env, input: Resource, output: Resource, command: &String, args
 }
 
 fn parse_gfa(env: &mut Env, input: Resource, output: Resource) {
-    use flate2::bufread::GzDecoder;
     use flatgfa::parse::Parser;
-    use std::io::{BufRead, BufReader};
+    use std::io::BufRead;
 
     // Handle compressed or uncompressed input streams.
     // TODO: This is currently worrisomely verbose, and it's only going to get
@@ -105,7 +104,15 @@ fn parse_gfa(env: &mut Env, input: Resource, output: Resource) {
         match encoding {
             Encoding::None => Parser::for_heap().parse_stream(stream),
             Encoding::Gzip => {
-                Parser::for_heap().parse_stream(BufReader::new(GzDecoder::new(stream)))
+                #[cfg(feature = "compress")]
+                {
+                    use flate2::bufread::GzDecoder;
+                    use std::io::BufReader;
+                    Parser::for_heap().parse_stream(BufReader::new(GzDecoder::new(stream)))
+                }
+
+                #[cfg(not(feature = "compress"))]
+                panic!("compression not supported")
             }
         }
     }
@@ -206,19 +213,22 @@ fn interval_depth(env: &mut Env, gfa_rsrc: Resource, bed_rsrc: Resource, output:
 }
 
 /// Decompress a gzip file and produce the raw bytes.
-///
-/// This is a generic implementation that works for any byte-stream resource
-/// types for the input and output, so it is appropriate when we actually want
-/// to do I/O. But when we want to consume the decompressed data internally,
-/// some other strategy would be more efficient.
 fn gzip_decompress(env: &mut Env, input: Resource, output: Resource) {
-    use flate2::bufread::GzDecoder;
+    #[cfg(feature = "compress")]
+    {
+        use flate2::bufread::GzDecoder;
 
-    let mut out = env.bytes_output(output).expect("bytes output");
-    match env.bytes_input(input).expect("bytes input") {
-        Input::File(file) => out.copy(&mut GzDecoder::new(file.as_ref())),
-        Input::Stdin(stream) => out.copy(&mut GzDecoder::new(stream)),
-        Input::Pipe(stream) => out.copy(&mut GzDecoder::new(stream)),
+        let mut out = env.bytes_output(output).expect("bytes output");
+        match env.bytes_input(input).expect("bytes input") {
+            Input::File(file) => out.copy(&mut GzDecoder::new(file.as_ref())),
+            Input::Stdin(stream) => out.copy(&mut GzDecoder::new(stream)),
+            Input::Pipe(stream) => out.copy(&mut GzDecoder::new(stream)),
+        }
+        .expect("decompression failed");
     }
-    .expect("decompression failed");
+
+    #[cfg(not(feature = "compress"))]
+    {
+        env.run_cmd("gzip", &["-d"], input, output)
+    }
 }

--- a/flatgfa-sh/src/eval/instr.rs
+++ b/flatgfa-sh/src/eval/instr.rs
@@ -178,28 +178,20 @@ fn interval_depth(env: &mut Env, gfa_rsrc: Resource, bed_rsrc: Resource, output:
     .unwrap();
 }
 
-/// Decompress a gzip file eagerly and produce the raw bytes.
+/// Decompress a gzip file and produce the raw bytes.
 ///
-/// This is a placeholder solution! It works by decompressing the whole thing
-/// into memory and then copying the decompressed data to the output resource.
-/// We want this work in a streaming style, never materializing the whole
-/// decompressed text.
+/// This is a generic implementation that works for any byte-stream resource
+/// types for the input and output, so it is appropriate when we actually want
+/// to do I/O. But when we want to consume the decompressed data internally,
+/// some other strategy would be more efficient.
 fn gzip_decompress(env: &mut Env, input: Resource, output: Resource) {
     use flate2::bufread::GzDecoder;
-    use std::io::Read;
 
-    // Decompress the whole thing into memory.
-    let mut buf = Vec::new();
+    let mut out = env.bytes_output(output).expect("bytes output");
     match env.bytes_input(input).expect("bytes input") {
-        Input::File(file) => GzDecoder::new(file.as_ref()).read_to_end(&mut buf),
-        Input::Stdin(stream) => GzDecoder::new(stream).read_to_end(&mut buf),
-        Input::Pipe(stream) => GzDecoder::new(stream).read_to_end(&mut buf),
+        Input::File(file) => out.copy(&mut GzDecoder::new(file.as_ref())),
+        Input::Stdin(stream) => out.copy(&mut GzDecoder::new(stream)),
+        Input::Pipe(stream) => out.copy(&mut GzDecoder::new(stream)),
     }
     .expect("decompression failed");
-
-    // Write the whole decompressed output immediately.
-    env.bytes_output(output)
-        .expect("bytes output")
-        .write_all(&buf)
-        .expect("error writing decompressed output");
 }

--- a/flatgfa-sh/src/eval/mod.rs
+++ b/flatgfa-sh/src/eval/mod.rs
@@ -211,6 +211,14 @@ impl Output {
             Self::Pipe(ref mut s) => write!(s, "{}", val),
         }
     }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        match *self {
+            Self::Stdout(ref mut s) => s.write_all(buf),
+            Self::File(ref mut s) => s.write_all(buf),
+            Self::Pipe(ref mut s) => s.write_all(buf),
+        }
+    }
 }
 
 pub fn run(prog: ir::Program) {

--- a/flatgfa-sh/src/eval/mod.rs
+++ b/flatgfa-sh/src/eval/mod.rs
@@ -8,7 +8,7 @@ use flatgfa::{self, emit::Emit, flatgfa::HeapGFAStore, memfile};
 use memmap::Mmap;
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter, Write};
+use std::io::{self, BufReader, BufWriter, PipeReader, PipeWriter, Read, Write};
 use std::ops::{Index, IndexMut};
 
 struct Env {
@@ -212,12 +212,13 @@ impl Output {
         }
     }
 
-    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+    fn copy<R: Read>(&mut self, reader: &mut R) -> std::io::Result<()> {
         match *self {
-            Self::Stdout(ref mut s) => s.write_all(buf),
-            Self::File(ref mut s) => s.write_all(buf),
-            Self::Pipe(ref mut s) => s.write_all(buf),
-        }
+            Self::Stdout(ref mut s) => io::copy(reader, s)?,
+            Self::File(ref mut s) => io::copy(reader, s)?,
+            Self::Pipe(ref mut s) => io::copy(reader, s)?,
+        };
+        Ok(())
     }
 }
 

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -2,6 +2,15 @@ use enum_map::{Enum, EnumMap};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 
+/// A value that instructions read or write.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct Resource {
+    pub kind: ResourceKind,
+    pub encoding: Encoding,
+    pub index: u16,
+}
+
+/// The type of resource. Each kind has a different index space.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Enum)]
 pub enum ResourceKind {
     File,
@@ -13,10 +22,14 @@ pub enum ResourceKind {
     BEDStore,
 }
 
+/// The data encoding to be used when reading or writing the resource.
+///
+/// This should only be non-`None` for byte-stream resources (File, Stdin,
+/// Stdout, Pipe, and Mmap).
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Resource {
-    pub kind: ResourceKind,
-    pub index: u16,
+pub enum Encoding {
+    None,
+    Gzip,
 }
 
 /// An instruction performs one imperative action.
@@ -59,9 +72,30 @@ pub struct Program {
     pub rsrc_counts: EnumMap<ResourceKind, u16>,
 }
 
+impl Resource {
+    /// Create a new resource (with no encoding).
+    pub fn new(kind: ResourceKind, index: u16) -> Self {
+        Resource {
+            kind,
+            index,
+            encoding: Encoding::None,
+        }
+    }
+
+    /// The (unencoded) standard input resource.
+    pub fn stdin() -> Self {
+        Self::new(ResourceKind::Stdin, 0)
+    }
+
+    /// The (unencoded) standard output resource.
+    pub fn stdout() -> Self {
+        Self::new(ResourceKind::Stdout, 0)
+    }
+}
+
 pub struct Builder {
     pub instrs: Vec<Instr>,
-    pub files: HashMap<String, Resource>,
+    pub files: HashMap<String, u16>,
     pub file_names: Vec<String>,
     pub rsrc_counts: EnumMap<ResourceKind, u16>,
 }
@@ -83,15 +117,7 @@ impl Builder {
             .file_names
             .iter()
             .enumerate()
-            .map(|(i, name)| {
-                (
-                    name.clone(),
-                    Resource {
-                        kind: ResourceKind::File,
-                        index: i.try_into().unwrap(),
-                    },
-                )
-            })
+            .map(|(i, name)| (name.clone(), i.try_into().unwrap()))
             .collect();
         Self {
             instrs: prog.instrs,
@@ -112,16 +138,13 @@ impl Builder {
 
     /// Add a file resource, or get an existing one if we've already added it.
     pub fn file(&mut self, name: String) -> Resource {
-        if let Some(&rsrc) = self.files.get(&name) {
-            rsrc
+        if let Some(&index) = self.files.get(&name) {
+            Resource::new(ResourceKind::File, index)
         } else {
-            let rsrc = Resource {
-                kind: ResourceKind::File,
-                index: self.files.len().try_into().unwrap(),
-            };
-            self.files.insert(name.clone(), rsrc);
+            let index: u16 = self.files.len().try_into().unwrap();
+            self.files.insert(name.clone(), index);
             self.file_names.push(name);
-            rsrc
+            Resource::new(ResourceKind::File, index)
         }
     }
 
@@ -134,23 +157,7 @@ impl Builder {
     pub fn rsrc(&mut self, kind: ResourceKind) -> Resource {
         let index = self.rsrc_counts[kind];
         self.rsrc_counts[kind] += 1;
-        Resource { kind, index }
-    }
-
-    /// Get the standard input resource.
-    pub fn stdin(&self) -> Resource {
-        Resource {
-            kind: ResourceKind::Stdin,
-            index: 0,
-        }
-    }
-
-    /// Get the standard output resource.
-    pub fn stdout(&self) -> Resource {
-        Resource {
-            kind: ResourceKind::Stdout,
-            index: 0,
-        }
+        Resource::new(kind, index)
     }
 
     /// Create an instruction to load a FlatGFA data structure as a resource.

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -91,6 +91,18 @@ impl Resource {
     pub fn stdout() -> Self {
         Self::new(ResourceKind::Stdout, 0)
     }
+
+    /// Get a version of the resource marked with a given encoding. The resource
+    /// must be a byte stream.
+    pub fn encoded(&self, encoding: Encoding) -> Self {
+        use ResourceKind::*;
+        assert!(matches!(self.kind, File | Mmap | Pipe | Stdin | Stdout));
+        Self {
+            kind: self.kind,
+            index: self.index,
+            encoding,
+        }
+    }
 }
 
 pub struct Builder {

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -158,7 +158,7 @@ impl Builder {
     /// Either parse GFA text, memory-map a FlatGFA binary file, or convert an
     /// odgi native file. If `input` is a byte stream, we treat it as GFA text.
     /// If it's a file, we use the filename to decide whether to treat it as GFA
-    /// text or FlatGFA binary.
+    /// text, compressed GFA text, FlatGFA binary, or an odgi graph.
     pub fn load_gfa(&mut self, input: Resource) -> Resource {
         match input.kind {
             ResourceKind::File if self.file_name(input).ends_with(".flatgfa") => {
@@ -175,6 +175,7 @@ impl Builder {
             }
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
                 // Parse as GFA text.
+                let input = self.maybe_decompress(input);
                 let output = self.rsrc(ResourceKind::GFAStore);
                 self.instr(&[input], output, Op::ParseGFA);
                 output
@@ -183,15 +184,33 @@ impl Builder {
         }
     }
 
-    /// Create an instruction to parse a BED file to a FlatBED resource.
+    /// Create an instruction to parse a (possibly compressed) text BED file to
+    /// a FlatBED resource.
     pub fn load_bed(&mut self, input: Resource) -> Resource {
         match input.kind {
             ResourceKind::Pipe | ResourceKind::Stdin | ResourceKind::File => {
+                let input = self.maybe_decompress(input);
                 let output = self.rsrc(ResourceKind::BEDStore);
                 self.instr(&[input], output, Op::ParseBED);
                 output
             }
             _ => panic!("cannot parse this resource as BED text"),
+        }
+    }
+
+    /// If the input is a gzip-compressed file, create an instruction to
+    /// decompress it. Otherwise, return it unchanged.
+    ///
+    /// This uses an OS pipe for the decompressed data, which is at least
+    /// general, but it's probably not the most efficient.
+    pub fn maybe_decompress(&mut self, input: Resource) -> Resource {
+        match input.kind {
+            ResourceKind::File if self.file_name(input).ends_with(".gz") => {
+                let pipe = self.rsrc(ResourceKind::Pipe);
+                self.instr(&[input], pipe, Op::GzipDecompress);
+                pipe
+            }
+            _ => input,
         }
     }
 

--- a/flatgfa-sh/src/ir.rs
+++ b/flatgfa-sh/src/ir.rs
@@ -49,6 +49,7 @@ pub enum Op {
     },
     OdgiView,
     IntervalDepth,
+    GzipDecompress,
 }
 
 #[derive(Debug)]

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -1,4 +1,4 @@
-use crate::ir::{Builder, Instr, Op, Program, Resource, ResourceKind};
+use crate::ir::{Builder, Encoding, Instr, Op, Program, Resource, ResourceKind};
 use smallvec::SmallVec;
 use std::collections::hash_map::{Entry, HashMap};
 use std::fs;
@@ -7,13 +7,12 @@ use std::fs;
 pub fn optimize(prog: Program) -> Program {
     let mut builder = Builder::rebuild(prog);
 
-    // Optimize `odgi-view` or `parse-gfa` into `map-file` when a FlatGFA file
-    // is available.
     opt_gfa_parse(&mut builder);
     opt_og_parse(&mut builder);
     skip_bed_files(&mut builder);
     simplify_depth_to_length(&mut builder);
     dedup_files(&mut builder);
+    opt_decompress(&mut builder);
 
     builder.build()
 }
@@ -137,7 +136,7 @@ fn opt_gfa_parse(builder: &mut Builder) {
 ///
 /// And attempt to replace it with:
 ///
-///     something -> bed-store 0
+///     something -> bed-store-0
 fn skip_bed_files(builder: &mut Builder) {
     // Find def/use pairs consisting of something that produces a BED file and
     // then a `parse-bed` instruction.
@@ -282,6 +281,63 @@ fn dedup_files(builder: &mut Builder) {
 
     // Remove the redundant read instructions.
     remove_indices(&mut builder.instrs, &redundant_reads);
+}
+
+/// Replace separate decompression instructions with decompressed stream access.
+///
+/// Search for this pattern:
+///
+///     gzip-decompress(foo) -> pipe-0
+///     parse-gfa(pipe-0) -> gfa-0
+///
+/// And replace it with this:
+///
+///     parse-gfa(gz foo) -> gfa-0
+///
+/// That is, for instructions that support on-the-fly decompression, give them
+/// direct access to the compressed file/stream and eliminate the separate
+/// decompression step and the intermediate pipe.
+fn opt_decompress(builder: &mut Builder) {
+    // Find `gzip-decompress` instructions where all uses support direct access
+    // to compressed streams.
+    let du = DefUse::analyze(&builder.instrs);
+    let decomp_defs: Vec<_> = builder
+        .instrs
+        .iter()
+        .enumerate()
+        .filter_map(|(decomp_idx, decomp_instr)| {
+            // Start with a `gzip-decompress` instruction.
+            let Op::GzipDecompress = decomp_instr.op else {
+                return None;
+            };
+
+            // Check that *all* the uses of this decompression support directly
+            // reading compressed streams. (This is somewhat restrictive. We may
+            // someday want to allow some instructions to fall back to explicit
+            // decompression.)
+            for use_idx in &du.uses[decomp_idx] {
+                // The only instruction that supports decompression so far is
+                // `parse-gfa`. We need to expand this.
+                let Op::ParseGFA = builder.instrs[*use_idx].op else {
+                    return None;
+                };
+            }
+
+            Some(decomp_idx)
+        })
+        .collect();
+
+    // Replace all uses of the explicitly decompressed data with direct, encoded
+    // uses of the stream.
+    for decomp_idx in &decomp_defs {
+        let compressed_rsrc = builder.instrs[*decomp_idx].inputs[0];
+        let decompressed_rsrc = builder.instrs[*decomp_idx].output;
+        let encoded_rsrc = compressed_rsrc.encoded(Encoding::Gzip);
+        builder.replace_rsrc(decompressed_rsrc, encoded_rsrc);
+    }
+
+    // Delete the decompression instructions.
+    remove_indices(&mut builder.instrs, &decomp_defs);
 }
 
 /// Replace an instruction with a `map-file` to open a FlatGFA binary file.

--- a/flatgfa-sh/src/opt.rs
+++ b/flatgfa-sh/src/opt.rs
@@ -12,6 +12,8 @@ pub fn optimize(prog: Program) -> Program {
     skip_bed_files(&mut builder);
     simplify_depth_to_length(&mut builder);
     dedup_files(&mut builder);
+
+    #[cfg(feature = "compress")]
     opt_decompress(&mut builder);
 
     builder.build()

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -105,6 +105,9 @@ fn cmd_to_ir(
             }
             _ => unimplemented!("unsupported bedtools subcommand"),
         }
+    } else if name == "gunzip" {
+        assert!(args.is_empty(), "no gunzip arguments are supported");
+        builder.instr(&[input], output, Op::GzipDecompress);
     } else {
         // Any non-odgi command is a "passthrough" shell command.
         builder.instr(

--- a/flatgfa-sh/src/parse.rs
+++ b/flatgfa-sh/src/parse.rs
@@ -173,11 +173,9 @@ fn item_to_ir(builder: &mut Builder, item: CompoundListItem, input: Resource, ou
 
 pub fn sh_to_ir(shell: Program) -> ir::Program {
     let mut builder = ir::Builder::new();
-    let stdin = builder.stdin();
-    let stdout = builder.stdout();
     for list in shell.complete_commands {
         for item in list.0 {
-            item_to_ir(&mut builder, item, stdin, stdout);
+            item_to_ir(&mut builder, item, Resource::stdin(), Resource::stdout());
         }
     }
     builder.build()

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -48,6 +48,7 @@ impl Display for Wrapped<'_, ir::Instr> {
             ir::Op::MakeWindows { size: _ } => "make-windows",
             ir::Op::OdgiView => "odgi-view",
             ir::Op::IntervalDepth => "interval-depth",
+            ir::Op::GzipDecompress => "gzip-decompress",
         };
         write!(f, "{}({}", name, self.wrap(&self.val.inputs[0]))?;
         for input in &self.val.inputs[1..] {

--- a/flatgfa-sh/src/pretty.rs
+++ b/flatgfa-sh/src/pretty.rs
@@ -70,6 +70,9 @@ impl Display for Wrapped<'_, ir::Instr> {
 impl Display for Wrapped<'_, ir::Resource> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let index = self.val.index;
+        if let ir::Encoding::Gzip = self.val.encoding {
+            write!(f, "gz ")?;
+        }
         match self.val.kind {
             ir::ResourceKind::File => write!(f, "\"{}\"", self.file_names[index as usize]),
             ir::ResourceKind::Stdin => write!(f, "stdin"),


### PR DESCRIPTION
This is a minimal implementation of the compression handling proposed in #272. It has these limitations:

* Decompression only (no compressed output yet).
* Gzip only (via `flate2`).
* We have infrastructure for "direct access" to compressed streams, but only `parse-gfa` supports that so far.

I have also attempted to keep everything behind a `compress` feature, so it's possible to build a much lighter-weight Flash that doesn't have built-in decompression support. Without built-in codecs, decompression still works; it just requires running a system-provided `gzip` executable as a subprocess.

There is a big combinatorial-explosion problem to be solved before we go any farther (i.e., before we support any other instructions beyond `parse-gfa`.) As you can see from the diff here, just making this one instruction compression-aware is quite verbose and complicated already; I do not relish doing the same thing to every other text-file-relevant instruction. We have to do _something_ to reduce the boilerplate.

Relatedly, this design does not yet do anything to help avoid mistakes where we forget to handle compression/decompression. We probably want to somehow force each instruction to either handle each encoding scheme or crash, but not silently ignore it and mishandle the compressed data.